### PR TITLE
Update to 1.7.0 and runtime 22.08

### DIFF
--- a/org.turbowarp.TurboWarp.yaml
+++ b/org.turbowarp.TurboWarp.yaml
@@ -1,9 +1,9 @@
 app-id: org.turbowarp.TurboWarp
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '21.08'
+base-version: '22.08'
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node14
 build-options:
@@ -23,7 +23,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/TurboWarp/desktop.git
-        commit: 700fb4cf27a61a4821ee20da8a13fd32ca3b5f26
+        commit: 2443c4b22db14e39ba898e413e43bfdf8c76e4d5
       - type: script
         dest-filename: run.sh
         commands:
@@ -44,6 +44,7 @@ modules:
       - brotli uncompressed/packager.html
       - mv uncompressed/packager.html.br static
       - npm ci --offline
+      - node scripts/prepare-extensions.js
       - |
         . ./flatpak-node/electron-builder-arch-args.sh
         npm run dist -- $ELECTRON_BUILDER_ARCH_ARGS --linux --dir

--- a/packager-sources.json
+++ b/packager-sources.json
@@ -1,8 +1,8 @@
 [
     {
         "type": "file",
-        "url": "https://github.com/TurboWarp/packager/releases/download/v1.3.0/turbowarp-packager-standalone-1.3.0.html",
-        "sha256": "fe8b27db8e2fbf8b78f93a52583b6bb540108003a1ca87f986671161fb48caf0",
+        "url": "https://github.com/TurboWarp/packager/releases/download/v1.6.0/turbowarp-packager-standalone-1.6.0.html",
+        "sha256": "a7dbb02163848ab6bac50863347d76d5bd836656072371842e97d83a1e99dbfe",
         "dest": "uncompressed",
         "dest-filename": "packager.html"
     }


### PR DESCRIPTION
https://github.com/TurboWarp/desktop/releases/tag/v1.7.0

Supercedes #2 - runtime 22.08 now supports node 14