### PR TITLE
Add wayland socket by default

### DIFF
--- a/org.turbowarp.TurboWarp.yaml
+++ b/org.turbowarp.TurboWarp.yaml
@@ -13,6 +13,7 @@ separate-locales: false
 finish-args:
   - --share=ipc
   - --share=network
+  - --socket=wayland
   - --socket=x11
   - --socket=pulseaudio
   - --filesystem=home


### PR DESCRIPTION
Matches what other Electron apps like Slack, Joplin, Signal, Obsidian, Bitwarden do