### PR TITLE
Use webpack:prod script instead of manual NODE_ENV=production

### DIFF
--- a/org.turbowarp.TurboWarp.yaml
+++ b/org.turbowarp.TurboWarp.yaml
@@ -43,7 +43,7 @@ modules:
       - mv uncompressed-library-files/*.br dist-library-files
       - npm ci --offline
       - node scripts/prepare-extensions.js
-      - NODE_ENV=production npm run webpack:compile
+      - npm run webpack:prod
       - |
         . ./flatpak-node/electron-builder-arch-args.sh
         npx electron-builder $ELECTRON_BUILDER_ARCH_ARGS --linux --dir --publish never --config.extraMetadata.tw_dist="prod-flathub-$(uname -m)"


### PR DESCRIPTION
This should make no difference right now, but it should make sure that the flathub release always uses production mode in the future. Our other Linux automation scripts use webpack:prod