### PR TITLE
Update to 1.11.0-beta.3

### DIFF
--- a/org.turbowarp.TurboWarp.yaml
+++ b/org.turbowarp.TurboWarp.yaml
@@ -22,13 +22,13 @@ modules:
         commands:
           - exec zypak-wrapper /app/turbowarp/turbowarp-desktop "$@"
       - type: archive
-        url: https://github.com/TurboWarp/desktop/releases/download/v1.10.1/TurboWarp-linux-x64-1.10.1.tar.gz
-        sha256: 0585ac92161057c15bc58a04d32b41fb7d7edd9b6b9c336860c16995ff0a642b
+        url: https://github.com/TurboWarp/desktop/releases/download/v1.11.0-beta.3/TurboWarp-linux-x64-1.11.0-beta.3.tar.gz
+        sha256: 82fcd9ef9bcb4412f9acb1e9e5a647aa6b9f704b9f6d148a781fac35971b7959
         dest: linux-unpacked
         only-arches: [x86_64]
       - type: archive
-        url: https://github.com/TurboWarp/desktop/releases/download/v1.10.1/TurboWarp-linux-arm64-1.10.1.tar.gz
-        sha256: 4b9d1c4d96ac3fd9c2152b23a09a45bad4e5717e0753eb74aefc4f38bf1d9cc0
+        url: https://github.com/TurboWarp/desktop/releases/download/v1.11.0-beta.3/TurboWarp-linux-arm64-1.11.0-beta.3.tar.gz
+        sha256: 1da05269cfccf84f2cd88f55a28ae9696d34ebef6be29f9cfb203b0dd52f5c4f
         dest: linux-unpacked
         only-arches: [aarch64]
     build-commands:


### PR DESCRIPTION
flatpak might be going from a week behind to a week ahead; I think this fixes the webgl errors we've been seeing

https://github.com/TurboWarp/desktop/issues/940

https://github.com/TurboWarp/desktop/issues/938