### PR TITLE
Re-add --filesystem=home

### DIFF
--- a/org.turbowarp.TurboWarp.yaml
+++ b/org.turbowarp.TurboWarp.yaml
@@ -12,6 +12,7 @@ finish-args:
   - --socket=x11
   - --socket=pulseaudio
   - --device=all
+  - --filesystem=home
 modules:
   - name: turbowarp
     buildsystem: simple


### PR DESCRIPTION
In 3def1830ac41f9660dd8062e8e5a2b85cb4cff1c we removed --filesystem=home because we fixed file:// parsing on argv. However, this broke being able to drag & drop costumes, sounds, sprites, extensions, etc. in as Electron does not support the file transfer portal.

These features are very convenient, enabled by default, and used in a lot of places throughout the app. Having it be broken by default is a bad experience.

Can't use a more specific --filesystem=... because we don't know where users will place their project files. Some people put them on the desktop; or in downloads; or in documents; or in a custom folder in their home directory.

Upstream bug: https://github.com/electron/electron/issues/30650
Related discussion: https://github.com/TurboWarp/desktop/issues/569