### PR TITLE
Enable wayland if someone manually adds --socket=wayland

### DIFF
--- a/org.turbowarp.TurboWarp.yaml
+++ b/org.turbowarp.TurboWarp.yaml
@@ -17,10 +17,9 @@ modules:
   - name: turbowarp
     buildsystem: simple
     sources:
-      - type: script
-        dest-filename: run.sh
-        commands:
-          - exec zypak-wrapper /app/turbowarp/turbowarp-desktop "$@"
+      - type: file
+        dest-filename: turbowarp-desktop.sh
+        path: turbowarp-desktop.sh
       - type: archive
         url: https://github.com/TurboWarp/desktop/releases/download/v1.11.1/TurboWarp-linux-x64-1.11.1.tar.gz
         sha256: 53e9c3dd946d2a9ad79176243c7e087357538667892629c3926b9b5678bf4add
@@ -35,7 +34,7 @@ modules:
         path: org.turbowarp.TurboWarp.metainfo.xml
     build-commands:
       - cp -a linux-unpacked /app/turbowarp
-      - install -Dm755 run.sh /app/bin/turbowarp-desktop
+      - install -Dm755 turbowarp-desktop.sh /app/bin/turbowarp-desktop
       - install -Dm644 linux-unpacked/resources/icon.png /app/share/icons/hicolor/512x512/apps/org.turbowarp.TurboWarp.png
       - install -Dm644 linux-unpacked/linux-files/org.turbowarp.TurboWarp.desktop /app/share/applications/org.turbowarp.TurboWarp.desktop
       - desktop-file-edit --set-key=Exec --set-value="turbowarp-desktop %U" /app/share/applications/org.turbowarp.TurboWarp.desktop

--- a/turbowarp-desktop.sh
+++ b/turbowarp-desktop.sh
@@ -2,10 +2,12 @@
 
 # Enable Wayland if it is available
 # From https://github.com/flathub/com.slack.Slack/blob/62e3c2d2236f2e8375c2bdd9c4a89158a004774a/slack.sh
+FLAGS=""
 WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
 if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET}" || -e "${WAYLAND_DISPLAY}" ]]
 then
-    FLAGS="--enable-features=WaylandWindowDecorations --ozone-platform-hint=auto"
+    echo "org.turbowarp.TurboWarp: enabling wayland"
+    FLAGS="--ozone-platform-hint=auto"
 fi
 
 exec zypak-wrapper /app/turbowarp/turbowarp-desktop $FLAGS "$@"

--- a/turbowarp-desktop.sh
+++ b/turbowarp-desktop.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Enable Wayland if it is available
+# From https://github.com/flathub/com.slack.Slack/blob/62e3c2d2236f2e8375c2bdd9c4a89158a004774a/slack.sh
+WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
+if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET}" || -e "${WAYLAND_DISPLAY}" ]]
+then
+    FLAGS="--enable-features=WaylandWindowDecorations --ozone-platform-hint=auto"
+fi
+
+exec zypak-wrapper /app/turbowarp/turbowarp-desktop $FLAGS "$@"


### PR DESCRIPTION
I lack confidence to enable wayland by default, but for people that prefer wayland, let them use it by manually adding --socket=wayland permission

Slack & Discord flatpaks do the same