### PR TITLE
Gamepad workaround in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## Flatpak specific notes
 
-Gamepads will not work in the Flatpak version (we believe this has the same cause as https://github.com/flathub/org.chromium.Chromium/issues/40)<br>
+Gamepads will not work in the Flatpak version (we believe this has the same cause as https://github.com/flathub/org.chromium.Chromium/issues/40)
+
 However, there is a workaround by giving read-only access to `/run/udev` with Flatseal or by running this command:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 ## Flatpak specific notes
 
-Gamepads will not work in the Flatpak version (we believe this has the same cause as https://github.com/flathub/org.chromium.Chromium/issues/40)
+Gamepads will not work in the Flatpak version (we believe this has the same cause as https://github.com/flathub/org.chromium.Chromium/issues/40)<br>
+However, there is a workaround by giving read-only access to `/run/udev` with Flatseal or by running this command:
+
+```bash
+flatpak override org.turbowarp.TurboWarp --filesystem=/run/udev:ro
+```
 
 By default, drag and drop will only work with files in your downloads, pictures, music, or desktop folders. To allow other folders, run this command:
 


### PR DESCRIPTION
# Gamepad workaround
this hopefully lets users use a controller in TurboWarp if they run a command (in README)