### PR TITLE
Update to 1.15.0

### DIFF
--- a/electron-sources.json
+++ b/electron-sources.json
@@ -1,20 +1,20 @@
 [
   {
     "type": "file",
-    "url": "https://github.com/electron/electron/releases/download/v36.4.0/electron-v36.4.0-linux-x64.zip",
-    "sha256": "d2ef32b2bff3fe2594774fca81abda8d617d5f6c0c40529e39900296309e4a3c",
+    "url": "https://github.com/electron/electron/releases/download/v38.3.0/electron-v38.3.0-linux-x64.zip",
+    "sha256": "ca8f7cd9cbd216e4cf96c32363237a9042829b357fbf9e93d9474249ad85c37d",
     "dest": "flatpak-electron",
-    "dest-filename": "electron-v36.4.0-linux-x64.zip",
+    "dest-filename": "electron-v38.3.0-linux-x64.zip",
     "only-arches": [
       "x86_64"
     ]
   },
   {
     "type": "file",
-    "url": "https://github.com/electron/electron/releases/download/v36.4.0/electron-v36.4.0-linux-arm64.zip",
-    "sha256": "27bf37e1cecc7683575140730cbcd4e1b0847bace2d5a705c69e6d1bcd1c0f4c",
+    "url": "https://github.com/electron/electron/releases/download/v38.3.0/electron-v38.3.0-linux-arm64.zip",
+    "sha256": "3b1b24b2c531a7361604905d9d33991903bb02ecf42c5accb01969359c01d0f4",
     "dest": "flatpak-electron",
-    "dest-filename": "electron-v36.4.0-linux-arm64.zip",
+    "dest-filename": "electron-v38.3.0-linux-arm64.zip",
     "only-arches": [
       "aarch64"
     ]

--- a/extensions-sources.json
+++ b/extensions-sources.json
@@ -1,0 +1,65 @@
+[
+  {
+    "type": "file",
+    "url": "https://cdn.jsdelivr.net/npm/@mediapipe/face_detection@0.4.1646425229/face_detection.js",
+    "sha256": "464efd192f197f1000ab60bedde235f349b8ee2967e1443cc3a29cebf42cbce2",
+    "dest": "node_modules/@turbowarp/extensions/cached-extension-dependencies",
+    "dest-filename": "464efd192f197f1000ab60bedde235f349b8ee2967e1443cc3a29cebf42cbce2"
+  },
+  {
+    "type": "file",
+    "url": "https://cdn.jsdelivr.net/npm/@mediapipe/face_detection@0.4.1646425229/face_detection_short.binarypb",
+    "sha256": "771c6b632d5ba58a41d3160abfd80185a1d18081f52bcefc5baec9f3d10aa8d9",
+    "dest": "node_modules/@turbowarp/extensions/cached-extension-dependencies",
+    "dest-filename": "771c6b632d5ba58a41d3160abfd80185a1d18081f52bcefc5baec9f3d10aa8d9"
+  },
+  {
+    "type": "file",
+    "url": "https://cdn.jsdelivr.net/npm/@mediapipe/face_detection@0.4.1646425229/face_detection_short_range.tflite",
+    "sha256": "3bc182eb9f33925d9e58b5c8d59308a760f4adea8f282370e428c51212c26633",
+    "dest": "node_modules/@turbowarp/extensions/cached-extension-dependencies",
+    "dest-filename": "3bc182eb9f33925d9e58b5c8d59308a760f4adea8f282370e428c51212c26633"
+  },
+  {
+    "type": "file",
+    "url": "https://cdn.jsdelivr.net/npm/@mediapipe/face_detection@0.4.1646425229/face_detection_solution_simd_wasm_bin.js",
+    "sha256": "ac6721ba5e4ddba4b145116e5012a0e2536c95cd814230e7095fbda78c4e46b7",
+    "dest": "node_modules/@turbowarp/extensions/cached-extension-dependencies",
+    "dest-filename": "ac6721ba5e4ddba4b145116e5012a0e2536c95cd814230e7095fbda78c4e46b7"
+  },
+  {
+    "type": "file",
+    "url": "https://cdn.jsdelivr.net/npm/@mediapipe/face_detection@0.4.1646425229/face_detection_solution_simd_wasm_bin.wasm",
+    "sha256": "ed927313be5ead0002008a7bc18177ecd342c60fd75795e4611fb44e19c4745b",
+    "dest": "node_modules/@turbowarp/extensions/cached-extension-dependencies",
+    "dest-filename": "ed927313be5ead0002008a7bc18177ecd342c60fd75795e4611fb44e19c4745b"
+  },
+  {
+    "type": "file",
+    "url": "https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-webgl@4.22.0/dist/tf-backend-webgl.min.js",
+    "sha256": "b41fcbb4aee7721af0cc77ecfede60b44ad4ed6d5782a8392b84f774f4359a45",
+    "dest": "node_modules/@turbowarp/extensions/cached-extension-dependencies",
+    "dest-filename": "b41fcbb4aee7721af0cc77ecfede60b44ad4ed6d5782a8392b84f774f4359a45"
+  },
+  {
+    "type": "file",
+    "url": "https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-core@4.22.0/dist/tf-core.min.js",
+    "sha256": "0924438788ff7da57b14d0f7c45a05d81611a5a4b52653da6d065e86d348757c",
+    "dest": "node_modules/@turbowarp/extensions/cached-extension-dependencies",
+    "dest-filename": "0924438788ff7da57b14d0f7c45a05d81611a5a4b52653da6d065e86d348757c"
+  },
+  {
+    "type": "file",
+    "url": "https://cdn.jsdelivr.net/npm/@turbowarp/tensorflow-models-face-detection@1.0.3-tw1/dist/face-detection.min.js",
+    "sha256": "3faf18f98df4270e0a945f2ad67d5ab6f43d6e625e0b3f2c3bcfcd1e6330ab57",
+    "dest": "node_modules/@turbowarp/extensions/cached-extension-dependencies",
+    "dest-filename": "3faf18f98df4270e0a945f2ad67d5ab6f43d6e625e0b3f2c3bcfcd1e6330ab57"
+  },
+  {
+    "type": "file",
+    "url": "https://cdn.jsdelivr.net/npm/lz-string@1.5.0/libs/lz-string.min.js",
+    "sha256": "95f4d1cbf099f57161b664bc048426ec3df92637801a4c79116e83315aa787e7",
+    "dest": "node_modules/@turbowarp/extensions/cached-extension-dependencies",
+    "dest-filename": "95f4d1cbf099f57161b664bc048426ec3df92637801a4c79116e83315aa787e7"
+  }
+]

--- a/node-sources.json
+++ b/node-sources.json
@@ -1,17 +1,10 @@
 [
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-    "sha512": "df4899b403e0cfe2d3218a1e8afa98a3ce777f4da305849de6e1a71a9905574337c4eb7d68def77ab920600999538df1e157ea7272f15bd2a98374792c2e1863",
+    "url": "https://registry.npmjs.org/@babel/cli/-/cli-7.28.0.tgz",
+    "sha512": "098ad91bb15a82d13c45e28305f22dc67ac405fda486ad9e4cc9cfbaa3bc515374c33869d5e317d707dd6bc6f56b7da5d9aa982f045120e18da2f9bc155ce633",
     "dest": "flatpak-node/npm",
-    "dest-filename": "remapping-df4899b403e0cfe2d3218a1e8afa98a3ce777f4da305849de6e1a71a9905574337c4eb7d68def77ab920600999538df1e157ea7272f15bd2a98374792c2e1863"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/@babel/cli/-/cli-7.27.2.tgz",
-    "sha512": "71f77b0e71a5847e8e232b8f4928f7bdc7c87676d7ba4840c8a63c35a66b15a742ee95f22fd98e2f95a08dca6d88424b8b99378fc698bcb2150b37b3ad64da88",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "cli-71f77b0e71a5847e8e232b8f4928f7bdc7c87676d7ba4840c8a63c35a66b15a742ee95f22fd98e2f95a08dca6d88424b8b99378fc698bcb2150b37b3ad64da88"
+    "dest-filename": "cli-098ad91bb15a82d13c45e28305f22dc67ac405fda486ad9e4cc9cfbaa3bc515374c33869d5e317d707dd6bc6f56b7da5d9aa982f045120e18da2f9bc155ce633"
   },
   {
     "type": "file",
@@ -71,17 +64,17 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.5.tgz",
-    "sha512": "2a2440a7f56825a5a492d7bce13bd477daa375b640762ab2bccc6b1a5d4deafcc5a202a668b8283372f5920b4b89ca761cfe5f0494bc26b64a2d521919524056",
+    "url": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
+    "sha512": "eb45fbaa4825beb6a9f269f5961d9e6f15dd658b5472977b82c9b2f642da049e22fd6758f0fa9349dc7203caab6a292a2902b90b529104a5eace7ad56a9c8d6b",
     "dest": "flatpak-node/npm",
-    "dest-filename": "compat-data-2a2440a7f56825a5a492d7bce13bd477daa375b640762ab2bccc6b1a5d4deafcc5a202a668b8283372f5920b4b89ca761cfe5f0494bc26b64a2d521919524056"
+    "dest-filename": "compat-data-eb45fbaa4825beb6a9f269f5961d9e6f15dd658b5472977b82c9b2f642da049e22fd6758f0fa9349dc7203caab6a292a2902b90b529104a5eace7ad56a9c8d6b"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
-    "sha512": "6d7631ad716e6de61dbc1d0d843fcd041dd08ba699795db418e595238eedd9d91e7021289de47834f55c6fb69ba570c4bde8e0ad47c5b46eaf1bfcf100a9a0fa",
+    "url": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+    "sha512": "d8108e3fb4cdf0cfa05438fbfe1b7786c68efc1fe7e680db880cb2be746534eb3ebb5a3e2563584d0ae6a6e369d7f5aada0705ac8d352405bea5a10a0ccc7f08",
     "dest": "flatpak-node/npm",
-    "dest-filename": "core-6d7631ad716e6de61dbc1d0d843fcd041dd08ba699795db418e595238eedd9d91e7021289de47834f55c6fb69ba570c4bde8e0ad47c5b46eaf1bfcf100a9a0fa"
+    "dest-filename": "core-d8108e3fb4cdf0cfa05438fbfe1b7786c68efc1fe7e680db880cb2be746534eb3ebb5a3e2563584d0ae6a6e369d7f5aada0705ac8d352405bea5a10a0ccc7f08"
   },
   {
     "type": "file",
@@ -92,10 +85,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
-    "sha512": "646840dfb9747bf836b350a7cdd8b1d0edda2d89bae9e17c6ae7e256d78e827c3182744ff06a32323ed55ac8169d06d5297ca07bb86aac58762b64d033ab751f",
+    "url": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+    "sha512": "de54a9c4682f9e66739e60640919d54443d4149bf6c2bbfd880a050ef00325cd32a6674ec5d52d70b78180127acc4d0f31e4ca9f1790cf2934c5306ae04a7bcf",
     "dest": "flatpak-node/npm",
-    "dest-filename": "generator-646840dfb9747bf836b350a7cdd8b1d0edda2d89bae9e17c6ae7e256d78e827c3182744ff06a32323ed55ac8169d06d5297ca07bb86aac58762b64d033ab751f"
+    "dest-filename": "generator-de54a9c4682f9e66739e60640919d54443d4149bf6c2bbfd880a050ef00325cd32a6674ec5d52d70b78180127acc4d0f31e4ca9f1790cf2934c5306ae04a7bcf"
   },
   {
     "type": "file",
@@ -127,10 +120,17 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.4.tgz",
-    "sha512": "8e58df475ac69d75cd5a79908362b7f9bbe1931079d51977d9045a393bb0c23be21ab1f321b49cf3ec7d0a9ada0ed6d3ee67f28d739b50b3f8c3f69dba737003",
+    "url": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
+    "sha512": "b899c615c3ec5902bc7ef8e018fe4b654659b18188a0f7918d21793c6c2b7a5620abb435e7f16df4d185a75ce0970808bfffd6d2e1b805ebd1b92251cb29593e",
     "dest": "flatpak-node/npm",
-    "dest-filename": "helper-define-polyfill-provider-8e58df475ac69d75cd5a79908362b7f9bbe1931079d51977d9045a393bb0c23be21ab1f321b49cf3ec7d0a9ada0ed6d3ee67f28d739b50b3f8c3f69dba737003"
+    "dest-filename": "helper-define-polyfill-provider-b899c615c3ec5902bc7ef8e018fe4b654659b18188a0f7918d21793c6c2b7a5620abb435e7f16df4d185a75ce0970808bfffd6d2e1b805ebd1b92251cb29593e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+    "sha512": "f96e9c21291715ad635ec0c475803c1de7af413fc550b871cd1f7da71a6196d65c55aba0a6ce774c709e89603c4a0bb1c694a9de028f8ae61f496a2990b43887",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "helper-globals-f96e9c21291715ad635ec0c475803c1de7af413fc550b871cd1f7da71a6196d65c55aba0a6ce774c709e89603c4a0bb1c694a9de028f8ae61f496a2990b43887"
   },
   {
     "type": "file",
@@ -148,10 +148,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-    "sha512": "7523af630bf22ec58178847239e1d7a79bcf8f9975234d75af9d85335fabd6308446ff9a157624e3086041c7181066312b61f7640200f27b8f910d07694a37aa",
+    "url": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+    "sha512": "832b5751bb3c936b174bd3e7429b73e68d109e92cbe754b001220e458e97681285f3c9ec393d19c3db332ea9521900cfff84e58c1003e72f7ca765357ea91db3",
     "dest": "flatpak-node/npm",
-    "dest-filename": "helper-module-transforms-7523af630bf22ec58178847239e1d7a79bcf8f9975234d75af9d85335fabd6308446ff9a157624e3086041c7181066312b61f7640200f27b8f910d07694a37aa"
+    "dest-filename": "helper-module-transforms-832b5751bb3c936b174bd3e7429b73e68d109e92cbe754b001220e458e97681285f3c9ec393d19c3db332ea9521900cfff84e58c1003e72f7ca765357ea91db3"
   },
   {
     "type": "file",
@@ -218,17 +218,17 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-    "sha512": "9ae13c4edf0cdb6eb7f07537d40dc281f494722c33d5f8404dfa156a2d3968f5c6a2bfff09d58309b9e5635caf04fa34ee78ee54e08d1824a9fc64edd76948ba",
+    "url": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+    "sha512": "1c5379f4c9905c61d5c9869d28b56e998b00f5d045ba7fe5758c62a448f3038d7dea3a4b65df148c41012e46c492f7d8ade0ea2616716005853edadf84da63e3",
     "dest": "flatpak-node/npm",
-    "dest-filename": "helpers-9ae13c4edf0cdb6eb7f07537d40dc281f494722c33d5f8404dfa156a2d3968f5c6a2bfff09d58309b9e5635caf04fa34ee78ee54e08d1824a9fc64edd76948ba"
+    "dest-filename": "helpers-1c5379f4c9905c61d5c9869d28b56e998b00f5d045ba7fe5758c62a448f3038d7dea3a4b65df148c41012e46c492f7d8ade0ea2616716005853edadf84da63e3"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
-    "sha512": "3ac41dd7be52c569069736e7cbc2772bc4e79c30f437796b214b41f76c70c91a7369e9c6661c43bf137f260534d14dc20d9363f6d3ee0c9e47d164b836ddef2a",
+    "url": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+    "sha512": "c996c1a9e33a4e4a4ff5dbbf236a5466726c44c186bceb88ae18f30b50301f05beea17b89a78ba069fe6f228e7d223ae66e3c8d817e40a8491ba7a728e7ad02a",
     "dest": "flatpak-node/npm",
-    "dest-filename": "parser-3ac41dd7be52c569069736e7cbc2772bc4e79c30f437796b214b41f76c70c91a7369e9c6661c43bf137f260534d14dc20d9363f6d3ee0c9e47d164b836ddef2a"
+    "dest-filename": "parser-c996c1a9e33a4e4a4ff5dbbf236a5466726c44c186bceb88ae18f30b50301f05beea17b89a78ba069fe6f228e7d223ae66e3c8d817e40a8491ba7a728e7ad02a"
   },
   {
     "type": "file",
@@ -309,10 +309,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.27.1.tgz",
-    "sha512": "7924fd46bc25a5aa090431d285cf834b6486e004d38b631835be0ec5891fde7fbb79be3d2d6a674be1d2a557d6e31f76eea430824f00da118d55a6a3004c3410",
+    "url": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz",
+    "sha512": "04439dbd7e3e33beb989c34f65e89dc800c8bd0d66d609ae9d7b9f5f1bd1112cbf8cd3727e8bc8a94c84ecc5601818d692d0a8265cef140d53a363b8ca620edd",
     "dest": "flatpak-node/npm",
-    "dest-filename": "plugin-transform-async-generator-functions-7924fd46bc25a5aa090431d285cf834b6486e004d38b631835be0ec5891fde7fbb79be3d2d6a674be1d2a557d6e31f76eea430824f00da118d55a6a3004c3410"
+    "dest-filename": "plugin-transform-async-generator-functions-04439dbd7e3e33beb989c34f65e89dc800c8bd0d66d609ae9d7b9f5f1bd1112cbf8cd3727e8bc8a94c84ecc5601818d692d0a8265cef140d53a363b8ca620edd"
   },
   {
     "type": "file",
@@ -330,10 +330,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.5.tgz",
-    "sha512": "245eae136b3aedfd32d9165c9b692901411b0f9d2f1fad93c9655e6f1c070256d274ce3d56a3f3f2de1ad6e223a78348388678c732df8d8e5e9adfd10b20bb4d",
+    "url": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.0.tgz",
+    "sha512": "80a2a7c23a5dc79b0447fc25d1637479f50117317fe7a6193b4449ad260fe029635e73f7d41c98edfa25f3d033a267652cdcc8dfa02f3939981ec9d94c292af1",
     "dest": "flatpak-node/npm",
-    "dest-filename": "plugin-transform-block-scoping-245eae136b3aedfd32d9165c9b692901411b0f9d2f1fad93c9655e6f1c070256d274ce3d56a3f3f2de1ad6e223a78348388678c732df8d8e5e9adfd10b20bb4d"
+    "dest-filename": "plugin-transform-block-scoping-80a2a7c23a5dc79b0447fc25d1637479f50117317fe7a6193b4449ad260fe029635e73f7d41c98edfa25f3d033a267652cdcc8dfa02f3939981ec9d94c292af1"
   },
   {
     "type": "file",
@@ -351,10 +351,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.27.1.tgz",
-    "sha512": "ee22e17c502e6e6a5e25efd6a364d5b83af2921ff39565cbccf35d2f426a9ff5eef11dd043c87d7dff0542821264eb30ef8fc716a148ecd5fadc737b40520728",
+    "url": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.0.tgz",
+    "sha512": "22333522824dc3bd80645963df70aef17d2ad972bfe806950b78d0bbe7204399538560f96a39ee5009a5f3476a4663a198f9131fcb80c27a4cbbd46f8f42d344",
     "dest": "flatpak-node/npm",
-    "dest-filename": "plugin-transform-classes-ee22e17c502e6e6a5e25efd6a364d5b83af2921ff39565cbccf35d2f426a9ff5eef11dd043c87d7dff0542821264eb30ef8fc716a148ecd5fadc737b40520728"
+    "dest-filename": "plugin-transform-classes-22333522824dc3bd80645963df70aef17d2ad972bfe806950b78d0bbe7204399538560f96a39ee5009a5f3476a4663a198f9131fcb80c27a4cbbd46f8f42d344"
   },
   {
     "type": "file",
@@ -365,10 +365,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.27.3.tgz",
-    "sha512": "b3826ba24f3626989a229aed6369c7b189ab4e12afbf0807c2381ded432262165a3746ac75734baf4cbe3634df900ed2c901398b615bede6b050e6662efcaa38",
+    "url": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.0.tgz",
+    "sha512": "bf59eb48c06229ca1d86cc89e067fe67453fc9ac2624304e4e9101de6710639dabf512323e7786c804bfc8ceac78fffc23e9962377a538cb53e5d07c18956cf8",
     "dest": "flatpak-node/npm",
-    "dest-filename": "plugin-transform-destructuring-b3826ba24f3626989a229aed6369c7b189ab4e12afbf0807c2381ded432262165a3746ac75734baf4cbe3634df900ed2c901398b615bede6b050e6662efcaa38"
+    "dest-filename": "plugin-transform-destructuring-bf59eb48c06229ca1d86cc89e067fe67453fc9ac2624304e4e9101de6710639dabf512323e7786c804bfc8ceac78fffc23e9962377a538cb53e5d07c18956cf8"
   },
   {
     "type": "file",
@@ -397,6 +397,13 @@
     "sha512": "307ce45907049a3cf3556f63daaf0b1a3c065a91b69a3c1a681d01350c2cb771488eab20f02b7f988665bd23c9bdf8bdcb6002f268bf92dc5b1552fda59d48e0",
     "dest": "flatpak-node/npm",
     "dest-filename": "plugin-transform-dynamic-import-307ce45907049a3cf3556f63daaf0b1a3c065a91b69a3c1a681d01350c2cb771488eab20f02b7f988665bd23c9bdf8bdcb6002f268bf92dc5b1552fda59d48e0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.0.tgz",
+    "sha512": "2bc9e151c9f77fa881f8fde0c02bff9e8ece77339941c29c856e8ddfcf55e8f0fc35458a647ce774e77db0f0d56cca01b1b9a332a941e0bf5f9be7c414d565c1",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "plugin-transform-explicit-resource-management-2bc9e151c9f77fa881f8fde0c02bff9e8ece77339941c29c856e8ddfcf55e8f0fc35458a647ce774e77db0f0d56cca01b1b9a332a941e0bf5f9be7c414d565c1"
   },
   {
     "type": "file",
@@ -512,10 +519,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.27.3.tgz",
-    "sha512": "ed966dce717d8389762422260a8e4b34a1470797979cddfd94bb4b6394e0f95911d23c0eb7b4c172231c92e89020e216ecbe6d9103828776d519879780cc79d9",
+    "url": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.0.tgz",
+    "sha512": "f553468a45f1ceee5e0a2423744e08667f2c6fdabb5ec9391172c304a5188357bf4ef7bcff4e7e28912d7311b1020098e6dfc1a4a40cf8910bff24f8b6f82250",
     "dest": "flatpak-node/npm",
-    "dest-filename": "plugin-transform-object-rest-spread-ed966dce717d8389762422260a8e4b34a1470797979cddfd94bb4b6394e0f95911d23c0eb7b4c172231c92e89020e216ecbe6d9103828776d519879780cc79d9"
+    "dest-filename": "plugin-transform-object-rest-spread-f553468a45f1ceee5e0a2423744e08667f2c6fdabb5ec9391172c304a5188357bf4ef7bcff4e7e28912d7311b1020098e6dfc1a4a40cf8910bff24f8b6f82250"
   },
   {
     "type": "file",
@@ -540,10 +547,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.1.tgz",
-    "sha512": "d35f0a464efa1d629e679978a138f6ccfa5287e35b19db74b2de52eb1d2981ae8782b8c13896f6e263031e8ac5a2938e77a60790b80e67ecda0a36463cee1a2a",
+    "url": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+    "sha512": "a819184d809befa451c5433a09c640e4a46ef0ae1233c6a3cd579481574c54ef4d37db88fc669598183f58a2491a7368915f5263c17134e556197ceacd489d06",
     "dest": "flatpak-node/npm",
-    "dest-filename": "plugin-transform-parameters-d35f0a464efa1d629e679978a138f6ccfa5287e35b19db74b2de52eb1d2981ae8782b8c13896f6e263031e8ac5a2938e77a60790b80e67ecda0a36463cee1a2a"
+    "dest-filename": "plugin-transform-parameters-a819184d809befa451c5433a09c640e4a46ef0ae1233c6a3cd579481574c54ef4d37db88fc669598183f58a2491a7368915f5263c17134e556197ceacd489d06"
   },
   {
     "type": "file",
@@ -568,10 +575,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.27.1.tgz",
-    "sha512": "a7df95977cae1cf9a48ab46b834db55e23fe1044e63cc4132ebe80ca38fce512cd11b6f71326bfe15234bc0773406f521009762e7b7b7f2e656723338d8a1941",
+    "url": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.28.0.tgz",
+    "sha512": "0fa12e8dcdb33312a37dae19c65e061ccb2684a299f55a5ca8872124bbf04f169df7358862e970608b41a2fa433a834b212a5c6525e80c9e606866d0503a9588",
     "dest": "flatpak-node/npm",
-    "dest-filename": "plugin-transform-react-display-name-a7df95977cae1cf9a48ab46b834db55e23fe1044e63cc4132ebe80ca38fce512cd11b6f71326bfe15234bc0773406f521009762e7b7b7f2e656723338d8a1941"
+    "dest-filename": "plugin-transform-react-display-name-0fa12e8dcdb33312a37dae19c65e061ccb2684a299f55a5ca8872124bbf04f169df7358862e970608b41a2fa433a834b212a5c6525e80c9e606866d0503a9588"
   },
   {
     "type": "file",
@@ -596,10 +603,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.5.tgz",
-    "sha512": "ba107cc877ab7dedcc5a7b8b02111b790e1a7d5a2abfc050b0faab4efedefe367dcb4d2424bea5f5afdfe0e59a2b1a2d9a3cdec1f1325c4d6f80325e9e4436fd",
+    "url": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.1.tgz",
+    "sha512": "3f442257fb5a69ade45e92d8fac5e56b9cde73813ee2de00a9cf6080795f67b6b6729f3fc7f1afd3c8dfc04b67f609e760832f1f1e9aa0e67c5c92fc794ef50e",
     "dest": "flatpak-node/npm",
-    "dest-filename": "plugin-transform-regenerator-ba107cc877ab7dedcc5a7b8b02111b790e1a7d5a2abfc050b0faab4efedefe367dcb4d2424bea5f5afdfe0e59a2b1a2d9a3cdec1f1325c4d6f80325e9e4436fd"
+    "dest-filename": "plugin-transform-regenerator-3f442257fb5a69ade45e92d8fac5e56b9cde73813ee2de00a9cf6080795f67b6b6729f3fc7f1afd3c8dfc04b67f609e760832f1f1e9aa0e67c5c92fc794ef50e"
   },
   {
     "type": "file",
@@ -680,10 +687,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.27.2.tgz",
-    "sha512": "31ae334ae6129463519422cef840332e70a624adaf76cb60bfe9fb6943fefc8299ace7d61ce25575226dbae6fc4731d38f76a10f7ee4e4e2895afcdfd7a4d0c9",
+    "url": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.0.tgz",
+    "sha512": "5666b17863b0b83ab32e5e495242113355f642edae286c471105a1f9cbef6e5ec9b894602862527ec105fdb51ac4584997f5c0cb105eeeaeea4ae4db285b82ca",
     "dest": "flatpak-node/npm",
-    "dest-filename": "preset-env-31ae334ae6129463519422cef840332e70a624adaf76cb60bfe9fb6943fefc8299ace7d61ce25575226dbae6fc4731d38f76a10f7ee4e4e2895afcdfd7a4d0c9"
+    "dest-filename": "preset-env-5666b17863b0b83ab32e5e495242113355f642edae286c471105a1f9cbef6e5ec9b894602862527ec105fdb51ac4584997f5c0cb105eeeaeea4ae4db285b82ca"
   },
   {
     "type": "file",
@@ -715,17 +722,17 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
-    "sha512": "a0d72ed906c7aadb3d06d396268b0e5496a95a30434b1182a45be290d4794c60d80d07f7270a48a0ccc82abbdfa2d8bdddc2df3c9106e2d1fd48f55ec821a074",
+    "url": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+    "sha512": "604cee6e83f6aaf41abc072381035582cbc7203bfa669c17bdcbe39b2c923f60c832e0724bfea2a14e46f6962b58733a4f66037dcef181af6237360eb35d8215",
     "dest": "flatpak-node/npm",
-    "dest-filename": "traverse-a0d72ed906c7aadb3d06d396268b0e5496a95a30434b1182a45be290d4794c60d80d07f7270a48a0ccc82abbdfa2d8bdddc2df3c9106e2d1fd48f55ec821a074"
+    "dest-filename": "traverse-604cee6e83f6aaf41abc072381035582cbc7203bfa669c17bdcbe39b2c923f60c832e0724bfea2a14e46f6962b58733a4f66037dcef181af6237360eb35d8215"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
-    "sha512": "113c87124d951c7be5f5bf6364fe481cf6af1d8939ec485a9e5451b9a7bd5c2a5bfe3e5b0c26cf3cc3817c25a19e5ffb103273d2310c0a2fd185c70213caf5f9",
+    "url": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+    "sha512": "6e416a90b861de9301510424a558160d6abf96acdcdbaefc794c8395306146a8421c582e61818cd047e06bbb589384e8806ff7c7410497aebf390f9619b581fd",
     "dest": "flatpak-node/npm",
-    "dest-filename": "types-113c87124d951c7be5f5bf6364fe481cf6af1d8939ec485a9e5451b9a7bd5c2a5bfe3e5b0c26cf3cc3817c25a19e5ffb103273d2310c0a2fd185c70213caf5f9"
+    "dest-filename": "types-6e416a90b861de9301510424a558160d6abf96acdcdbaefc794c8395306146a8421c582e61818cd047e06bbb589384e8806ff7c7410497aebf390f9619b581fd"
   },
   {
     "type": "file",
@@ -743,10 +750,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@electron/asar/-/asar-3.2.18.tgz",
-    "sha512": "d97caf31edcddcdaecf1c577f482842d11d36145852ab9aaa9263553e18c95cd23bea8c8567a3184d7761f826895642771b262d430af6f94cdc59b88d9f1235a",
+    "url": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
+    "sha512": "8b8feb34f452f38b74bd245ad87a2b7ab1915d6c85e2f4e17c77acc347667161e9f9cb292bbe3751a9c0d2cb80e50e72f24cd8db2e982abbdb2149faf4108088",
     "dest": "flatpak-node/npm",
-    "dest-filename": "asar-d97caf31edcddcdaecf1c577f482842d11d36145852ab9aaa9263553e18c95cd23bea8c8567a3184d7761f826895642771b262d430af6f94cdc59b88d9f1235a"
+    "dest-filename": "asar-8b8feb34f452f38b74bd245ad87a2b7ab1915d6c85e2f4e17c77acc347667161e9f9cb292bbe3751a9c0d2cb80e50e72f24cd8db2e982abbdb2149faf4108088"
   },
   {
     "type": "file",
@@ -757,10 +764,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
-    "sha512": "cf1d0422aefc5a563f9416f5b97973899983648e2e6dc09720c278b868d7cd95b49d2d7d4e348f7973c08f3cd398a425254666d126e66613ca3fbb6e4354ac13",
+    "url": "https://registry.npmjs.org/@electron/fuses/-/fuses-2.0.0.tgz",
+    "sha512": "9726f5ccadd81de5948dacfbca22b41a7c523ddbb001228cca20db0ad6e7deca4fe8412df945ad92d82059e846d22705ad7024dc6c2f709e270ab24ed0df4885",
     "dest": "flatpak-node/npm",
-    "dest-filename": "fuses-cf1d0422aefc5a563f9416f5b97973899983648e2e6dc09720c278b868d7cd95b49d2d7d4e348f7973c08f3cd398a425254666d126e66613ca3fbb6e4354ac13"
+    "dest-filename": "fuses-9726f5ccadd81de5948dacfbca22b41a7c523ddbb001228cca20db0ad6e7deca4fe8412df945ad92d82059e846d22705ad7024dc6c2f709e270ab24ed0df4885"
   },
   {
     "type": "file",
@@ -792,27 +799,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-    "sha512": "26dd2f1f233e8e6501aa88c1ec4d4d21869db74bc8d10c63c5dd9312b5bde300f3f84d8b026e6f28c5d7c20e996414c73ee5250e0407297be318175f705d590d",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "brace-expansion-26dd2f1f233e8e6501aa88c1ec4d4d21869db74bc8d10c63c5dd9312b5bde300f3f84d8b026e6f28c5d7c20e996414c73ee5250e0407297be318175f705d590d"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-    "sha512": "afc869123890118945d9053475fddd4be9f1c5222b797412d6a461309334439343751dfce82ee36fb1f0c2877c1608ae7b1fa4d0616381fb75f32bf19b95e809",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "glob-afc869123890118945d9053475fddd4be9f1c5222b797412d6a461309334439343751dfce82ee36fb1f0c2877c1608ae7b1fa4d0616381fb75f32bf19b95e809"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-    "sha512": "94ac15ff56eba46ea6054147b5becd526b400426f65996669b6c0d88e0398406fc55d092e01dddb4c5b2bdca1589c730016fc23844635cbb74ccfd735d4376ea",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "minimatch-94ac15ff56eba46ea6054147b5becd526b400426f65996669b6c0d88e0398406fc55d092e01dddb4c5b2bdca1589c730016fc23844635cbb74ccfd735d4376ea"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
     "sha512": "8cd4fc9f01f57fd5f91842135da43c205fca76c92f2243857c1d82bf0ba6b2f79589dce949cfa6be185331d0064981773be36ae3d949ef2facb0e0d15eed3af8",
     "dest": "flatpak-node/npm",
@@ -820,17 +806,17 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.1.tgz",
-    "sha512": "0407ef89444c1e999bd586f9d186c2c67398d307f068b5c7e4a278fbcd334b48149330d7dde736de7693944a8ab0df8fc189fe6b5702cccec127859c777b06cf",
+    "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+    "sha512": "85c8376667a94b7d3fec1485a91be8a370ce310bbb223ab13b99c20edfb333d5d68dbdf75a0ef388d4fe42fa9bb9cdfe816a733b4d89b9b5729361b866fa3539",
     "dest": "flatpak-node/npm",
-    "dest-filename": "osx-sign-0407ef89444c1e999bd586f9d186c2c67398d307f068b5c7e4a278fbcd334b48149330d7dde736de7693944a8ab0df8fc189fe6b5702cccec127859c777b06cf"
+    "dest-filename": "fs-extra-85c8376667a94b7d3fec1485a91be8a370ce310bbb223ab13b99c20edfb333d5d68dbdf75a0ef388d4fe42fa9bb9cdfe816a733b4d89b9b5729361b866fa3539"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-    "sha512": "a115c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d",
+    "url": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
+    "sha512": "299f26857bd6bf6ac812031b599e32df76c31f250a3179f1e0cd2c4f23cd2bfbdc07cd4899d798f4681dab2d1259b3038266eac90fa98607a387a57747642e4a",
     "dest": "flatpak-node/npm",
-    "dest-filename": "fs-extra-a115c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d"
+    "dest-filename": "osx-sign-299f26857bd6bf6ac812031b599e32df76c31f250a3179f1e0cd2c4f23cd2bfbdc07cd4899d798f4681dab2d1259b3038266eac90fa98607a387a57747642e4a"
   },
   {
     "type": "file",
@@ -841,24 +827,31 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.7.0.tgz",
-    "sha512": "556fbe08d4a56703183fb3325c46eb2a3a73130841e640cd6f31ad88f123c18cacab24c217e61b349db5d038f70235ac19257888413036498937dc8666656f9b",
+    "url": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.1.tgz",
+    "sha512": "88c1976fa21bec7fd0deff81299268113805f60e8a30d6556ec3b86fb0e6a606f9a9316ac854f3a96f45dd33921ddc9bbf6bca60acd24bd3a264bf9d7096fed5",
     "dest": "flatpak-node/npm",
-    "dest-filename": "rebuild-556fbe08d4a56703183fb3325c46eb2a3a73130841e640cd6f31ad88f123c18cacab24c217e61b349db5d038f70235ac19257888413036498937dc8666656f9b"
+    "dest-filename": "rebuild-88c1976fa21bec7fd0deff81299268113805f60e8a30d6556ec3b86fb0e6a606f9a9316ac854f3a96f45dd33921ddc9bbf6bca60acd24bd3a264bf9d7096fed5"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.1.tgz",
-    "sha512": "7caa6ff6483848f9adfa163b49506721850b13d40997c2f7b027dc06c9ea6c9c3007001e4cba2427d4d1b7dcbb6cad09033216db2efc4d5563be74049acff2c8",
+    "url": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
+    "sha512": "5a7f6c3d8215151165e479b030990044209feeba8afc4bab91f43fac9675e261cfde26138d94883925689c40278567805f0b70ef339e90646573ac93b59d2dfa",
     "dest": "flatpak-node/npm",
-    "dest-filename": "universal-7caa6ff6483848f9adfa163b49506721850b13d40997c2f7b027dc06c9ea6c9c3007001e4cba2427d4d1b7dcbb6cad09033216db2efc4d5563be74049acff2c8"
+    "dest-filename": "universal-5a7f6c3d8215151165e479b030990044209feeba8afc4bab91f43fac9675e261cfde26138d94883925689c40278567805f0b70ef339e90646573ac93b59d2dfa"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-    "sha512": "6785da08be9d5031df3ff8d3db98c928c9adc6fbb06e4ac3d6f352305968f6534b6367391476124201cf459523001dba4e90c4a16f4708e82996b75b68f57f7b",
+    "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+    "sha512": "26dd2f1f233e8e6501aa88c1ec4d4d21869db74bc8d10c63c5dd9312b5bde300f3f84d8b026e6f28c5d7c20e996414c73ee5250e0407297be318175f705d590d",
     "dest": "flatpak-node/npm",
-    "dest-filename": "fs-extra-6785da08be9d5031df3ff8d3db98c928c9adc6fbb06e4ac3d6f352305968f6534b6367391476124201cf459523001dba4e90c4a16f4708e82996b75b68f57f7b"
+    "dest-filename": "brace-expansion-26dd2f1f233e8e6501aa88c1ec4d4d21869db74bc8d10c63c5dd9312b5bde300f3f84d8b026e6f28c5d7c20e996414c73ee5250e0407297be318175f705d590d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
+    "sha512": "5ebf45eb3eaea7a5acf8d8f330265ce965e0d9815196b2cff4d4033b7550ad6adf8a88dd852e7a4f3b9e4fcf337b4b817424f0108850de9b6798a79618501ed0",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "fs-extra-5ebf45eb3eaea7a5acf8d8f330265ce965e0d9815196b2cff4d4033b7550ad6adf8a88dd852e7a4f3b9e4fcf337b4b817424f0108850de9b6798a79618501ed0"
   },
   {
     "type": "file",
@@ -869,10 +862,115 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
-    "sha512": "75f65ea31eba02f74fb5bda50fc3ac208421d764e9d063424540df04720a1a96e6a2966da36fc0f274a96182e879d3c81e9aa479b959fe4f0e5741b2ecf62ec9",
+    "url": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+    "sha512": "96b4cfaa0bdf150b51fde63faa4233a7df0e19d349bb49b98e2deafe7248f2fdd25e444a1275a23b13266ef712a00233bff7068aebd1cb9ee4e2cb8a41201dc0",
     "dest": "flatpak-node/npm",
-    "dest-filename": "windows-sign-75f65ea31eba02f74fb5bda50fc3ac208421d764e9d063424540df04720a1a96e6a2966da36fc0f274a96182e879d3c81e9aa479b959fe4f0e5741b2ecf62ec9"
+    "dest-filename": "invariant-96b4cfaa0bdf150b51fde63faa4233a7df0e19d349bb49b98e2deafe7248f2fdd25e444a1275a23b13266ef712a00233bff7068aebd1cb9ee4e2cb8a41201dc0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+    "sha512": "6b25451ddb59fa1b2ad6dd83cb6e300a619719ee2af46bb7b2684b6002c9aebe3bdd91f6eccb2748bf8b2949629a9e01589a8c0cc2e63e9c7f43d47738094be2",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "eslint-utils-6b25451ddb59fa1b2ad6dd83cb6e300a619719ee2af46bb7b2684b6002c9aebe3bdd91f6eccb2748bf8b2949629a9e01589a8c0cc2e63e9c7f43d47738094be2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+    "sha512": "c2973e2d77a2ca28acc4f944914cd4eacbf24b57eb20edcc8318f57ddcbb3e6f1883382e6b1d8ddc56bf0ff6a0d56a9b3a9add23eb98eb031497cfdad86fa26a",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "eslint-visitor-keys-c2973e2d77a2ca28acc4f944914cd4eacbf24b57eb20edcc8318f57ddcbb3e6f1883382e6b1d8ddc56bf0ff6a0d56a9b3a9add23eb98eb031497cfdad86fa26a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+    "sha512": "0826420c9b9db81f4e524164636220a69359322da5050803daacf05e41226b5e9c81eda98a363f6978bde8224caae0cc9f79c97653d5d40e4aac9117c1f2cdcd",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "regexpp-0826420c9b9db81f4e524164636220a69359322da5050803daacf05e41226b5e9c81eda98a363f6978bde8224caae0cc9f79c97653d5d40e4aac9117c1f2cdcd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+    "sha512": "6b0d6035ac96a5d23f8d2615833379a4bd1c7f3534d864f7341a5e4ff0d76f1d7fd71ed92b114f77d6f0af3ca0c7faa2c08422275b30ff30fca98fe446f9461c",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "config-array-6b0d6035ac96a5d23f8d2615833379a4bd1c7f3534d864f7341a5e4ff0d76f1d7fd71ed92b114f77d6f0af3ca0c7faa2c08422275b30ff30fca98fe446f9461c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.1.tgz",
+    "sha512": "72c640ce4361b20c1bd08fd4015ebf4461536e26a43c27f466b1a6ac8c50a58bc6674d0f8539129f228da25a61808be69c9786c3aadc1951177d3cd49c5b84bf",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "config-helpers-72c640ce4361b20c1bd08fd4015ebf4461536e26a43c27f466b1a6ac8c50a58bc6674d0f8539129f228da25a61808be69c9786c3aadc1951177d3cd49c5b84bf"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
+    "sha512": "9e60bcfeda2dc286c8885706903cdadc620a7c0c35fa12e2615ae1dc8d67228990f0f12be5cc60df88e792619ac2e97f7a9e76c0644073278308db562923a3e1",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "core-9e60bcfeda2dc286c8885706903cdadc620a7c0c35fa12e2615ae1dc8d67228990f0f12be5cc60df88e792619ac2e97f7a9e76c0644073278308db562923a3e1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+    "sha512": "82d175f3a097848975a78a49346670f1873a465b21a1e3d1bc4d17f75a0f19bdef67ca4cdea392f56f4d18f6adf4bce268157b5eb2561b294d41790672733721",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "eslintrc-82d175f3a097848975a78a49346670f1873a465b21a1e3d1bc4d17f75a0f19bdef67ca4cdea392f56f4d18f6adf4bce268157b5eb2561b294d41790672733721"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+    "sha512": "359c896ab05f2fb9d6c08abe1432fa669ff21c485e3cc3679c9d32dea7e2782ae636f61cb7cbafb62578d54be549ee9aa407e4d1f63515b5b1f8dc1f9a9bed4e",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "acorn-359c896ab05f2fb9d6c08abe1432fa669ff21c485e3cc3679c9d32dea7e2782ae636f61cb7cbafb62578d54be549ee9aa407e4d1f63515b5b1f8dc1f9a9bed4e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+    "sha512": "8fa3c0436b94afbf4f6610633f90b97e197c7b7f459919ce8ec0f99469d6ac553c8b61bbefab412bbfa73fc2ae4144d3c80654c1f42a5c082b547e4c6c7f4261",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "espree-8fa3c0436b94afbf4f6610633f90b97e197c7b7f459919ce8ec0f99469d6ac553c8b61bbefab412bbfa73fc2ae4144d3c80654c1f42a5c082b547e4c6c7f4261"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@eslint/js/-/js-9.38.0.tgz",
+    "sha512": "519d55a45bd77fd274e981bdc5005d9f353e92d868aece8a8e130097a7f8807e2eb07ca1df5ad47f60cb1889d3f111582117985cd4b27603d8d15d8bb96825ec",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "js-519d55a45bd77fd274e981bdc5005d9f353e92d868aece8a8e130097a7f8807e2eb07ca1df5ad47f60cb1889d3f111582117985cd4b27603d8d15d8bb96825ec"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+    "sha512": "56d00e6b299655f65c9996e9e84da6ca6a43207bf28d7b3fd762ea5988d5c3aaa3adf17e54af9fc86df7902873de79caf92539fcd7873aaad31074bcb173b738",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "object-schema-56d00e6b299655f65c9996e9e84da6ca6a43207bf28d7b3fd762ea5988d5c3aaa3adf17e54af9fc86df7902873de79caf92539fcd7873aaad31074bcb173b738"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.0.tgz",
+    "sha512": "b01e6ec9eabe770096c8f8b7d41da0425565a3e8f96eb3e55b1e32641ac4691a3f9e174313c5e47b582c1a0b6205d6814f1b9391c78b56e56dfe9725adab1bd0",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "plugin-kit-b01e6ec9eabe770096c8f8b7d41da0425565a3e8f96eb3e55b1e32641ac4691a3f9e174313c5e47b582c1a0b6205d6814f1b9391c78b56e56dfe9725adab1bd0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+    "sha512": "f9b4f6b87e04e4b184ee1fe7ddebdc4bfb109495c2a48a7aca6f0e589e5e57afbaec3b2a97f2da693eea24102ddabcdfa1aff94011818710e2c7574cb7691029",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "levn-f9b4f6b87e04e4b184ee1fe7ddebdc4bfb109495c2a48a7aca6f0e589e5e57afbaec3b2a97f2da693eea24102ddabcdfa1aff94011818710e2c7574cb7691029"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+    "sha512": "be47033eb459a354192db9f944b18fa60fd698843ae6aa165a170629ffdbe5ea659246ab5f49bdcfca6909ab789a53aa52c5a9c8db9880edd5472ad81d2cd7e6",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "prelude-ls-be47033eb459a354192db9f944b18fa60fd698843ae6aa165a170629ffdbe5ea659246ab5f49bdcfca6909ab789a53aa52c5a9c8db9880edd5472ad81d2cd7e6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+    "sha512": "5e5794a1cf6ec065ea8d6c176944d9026ccc705679f39f10036befc7552be7121c8b15c83fef0b9c50e0469954df4bacead7aa765b2415fbbe69ee0aefd3a87b",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "type-check-5e5794a1cf6ec065ea8d6c176944d9026ccc705679f39f10036befc7552be7121c8b15c83fef0b9c50e0469954df4bacead7aa765b2415fbbe69ee0aefd3a87b"
   },
   {
     "type": "file",
@@ -880,6 +978,34 @@
     "sha512": "9364f2d49715a238c9170ae0fd384a8b6ba327b5cd2d868518d07f6d64fdc0647ea123091cc6b9c3e094abaa7fa55aca78d36003ba42a847234a71d5a2a25017",
     "dest": "flatpak-node/npm",
     "dest-filename": "promisify-9364f2d49715a238c9170ae0fd384a8b6ba327b5cd2d868518d07f6d64fdc0647ea123091cc6b9c3e094abaa7fa55aca78d36003ba42a847234a71d5a2a25017"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+    "sha512": "e43c90e3ed49114cde8de2b524620272275ec9f51b1a2c604bd8cd81ec799ea916f9c63b59987106282689e379427c3d668b123550bd2902b26fe194686c8a50",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "core-e43c90e3ed49114cde8de2b524620272275ec9f51b1a2c604bd8cd81ec799ea916f9c63b59987106282689e379427c3d668b123550bd2902b26fe194686c8a50"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+    "sha512": "ff3531fb23ac22b1b8638dc4876a5e0de282c6546dfe0113e9a1df68aa6eab6ebba977580c55625477cc68bcb28193a79749065b114882c072f1016e4cb51711",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "node-ff3531fb23ac22b1b8638dc4876a5e0de282c6546dfe0113e9a1df68aa6eab6ebba977580c55625477cc68bcb28193a79749065b114882c072f1016e4cb51711"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+    "sha512": "6f1bde57857cbf961be277054d3deb3d281904ea429237cad32e28555549c08b8354144c0d7acfc9744bf7cf22e5aa7d9bd6e7c8412359f9b95a4066b5f7cb7c",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "module-importer-6f1bde57857cbf961be277054d3deb3d281904ea429237cad32e28555549c08b8354144c0d7acfc9744bf7cf22e5aa7d9bd6e7c8412359f9b95a4066b5f7cb7c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+    "sha512": "6d5d13828f4ae217cf09e93e68c027f35469a452afdb248341e328499baf4c04b2c0d4e7549080ac2644d855aaa6f21ab4abbb54c44b5a547511acef5610f285",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "retry-6d5d13828f4ae217cf09e93e68c027f35469a452afdb248341e328499baf4c04b2c0d4e7549080ac2644d855aaa6f21ab4abbb54c44b5a547511acef5610f285"
   },
   {
     "type": "file",
@@ -904,17 +1030,17 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-    "sha512": "ec7497e1041be02b297222e9545c3245eefd3b7c6c2190c32c4476d6411143bd6868fa1d17c8cbef6e408093050186e8a08aa8949a112ee33cd52a5e524a64bc",
+    "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+    "sha512": "06add2992a721476968cf93c21ff7273ab2f33c739e9d079040b56e106f0e631d3c305d77132e844c9290c9a7a54bd17ce559a0874d7ae415444c6260f4b0baa",
     "dest": "flatpak-node/npm",
-    "dest-filename": "ansi-regex-ec7497e1041be02b297222e9545c3245eefd3b7c6c2190c32c4476d6411143bd6868fa1d17c8cbef6e408093050186e8a08aa8949a112ee33cd52a5e524a64bc"
+    "dest-filename": "ansi-regex-06add2992a721476968cf93c21ff7273ab2f33c739e9d079040b56e106f0e631d3c305d77132e844c9290c9a7a54bd17ce559a0874d7ae415444c6260f4b0baa"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-    "sha512": "6cdefdf2015f417faf8b0dd1ef2ac6591aa7acdda84641245238e5e09367e04f06c716e3b46dc56eb108218de5f3f86bc14c0878266f8b842e3933f8304ad5ba",
+    "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+    "sha512": "e038fa336f0907ea001fc9059132d4a3e6b68f038592ea9bdf2b9c53408035c45151bc52d1c3f49d96021a371cdc1357c1122c5159831a0cdac267bbcef247be",
     "dest": "flatpak-node/npm",
-    "dest-filename": "ansi-styles-6cdefdf2015f417faf8b0dd1ef2ac6591aa7acdda84641245238e5e09367e04f06c716e3b46dc56eb108218de5f3f86bc14c0878266f8b842e3933f8304ad5ba"
+    "dest-filename": "ansi-styles-e038fa336f0907ea001fc9059132d4a3e6b68f038592ea9bdf2b9c53408035c45151bc52d1c3f49d96021a371cdc1357c1122c5159831a0cdac267bbcef247be"
   },
   {
     "type": "file",
@@ -932,10 +1058,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-    "sha512": "8aae9e55523ae274104d162ad8ab44836776b94ecb125853270b07e18cc81d9b21c658199acff021ce15a03413946fc8bd522b04a1b4e82ad99e9d2abfb86471",
+    "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+    "sha512": "826046b25a68409b609cc02f395a86669133f5dca82930b3cb69dfcff9fc68816137f8c213fac299cc5a6c1ea338e1d5fb458d9f294ec5ac4140f4af71692584",
     "dest": "flatpak-node/npm",
-    "dest-filename": "strip-ansi-8aae9e55523ae274104d162ad8ab44836776b94ecb125853270b07e18cc81d9b21c658199acff021ce15a03413946fc8bd522b04a1b4e82ad99e9d2abfb86471"
+    "dest-filename": "strip-ansi-826046b25a68409b609cc02f395a86669133f5dca82930b3cb69dfcff9fc68816137f8c213fac299cc5a6c1ea338e1d5fb458d9f294ec5ac4140f4af71692584"
   },
   {
     "type": "file",
@@ -946,10 +1072,31 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-    "sha512": "8a601b04691bf9e6d0cb12a0cefe47bb69e644ec680ce5c787cd1ebf17685cd3abbc09d5c7bce29b37353a8e61f5195f578bcf5da13688ce693856ef3820a558",
+    "url": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+    "sha512": "c209bd1219768e97aa3f7cf0ffb9a8de4447169e4c10386a01dc32d5f4c69070309e418e56c829bd084bf01e67d6a95bd358d5de7fdb23465f669e65580d64e3",
     "dest": "flatpak-node/npm",
-    "dest-filename": "gen-mapping-8a601b04691bf9e6d0cb12a0cefe47bb69e644ec680ce5c787cd1ebf17685cd3abbc09d5c7bce29b37353a8e61f5195f578bcf5da13688ce693856ef3820a558"
+    "dest-filename": "fs-minipass-c209bd1219768e97aa3f7cf0ffb9a8de4447169e4c10386a01dc32d5f4c69070309e418e56c829bd084bf01e67d6a95bd358d5de7fdb23465f669e65580d64e3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+    "sha512": "a8e3b34b57014d6605e011fc7d578f0c138ef62a6d327194119c0d73f70c5a74d5da754b67b56835610f1e461ccd9034a5da00edd97a7bb14beb9f675fd4b66b",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "minipass-a8e3b34b57014d6605e011fc7d578f0c138ef62a6d327194119c0d73f70c5a74d5da754b67b56835610f1e461ccd9034a5da00edd97a7bb14beb9f675fd4b66b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+    "sha512": "da492dffb9e227a32010fc45d1b61d43a7ad65a03e7d0bc370b29c921cb5c8840ecdaa0a8c10634a3eb7fda2d58d8137aa146de5dbccfae5327c283a50a0816c",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "gen-mapping-da492dffb9e227a32010fc45d1b61d43a7ad65a03e7d0bc370b29c921cb5c8840ecdaa0a8c10634a3eb7fda2d58d8137aa146de5dbccfae5327c283a50a0816c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+    "sha512": "2c8f6effe95a606e03b354c3292256d983eb22571560ec22d9f502eb1078de5b9e0a383157895f7ce0990ad605887e9334e5feb50297c7ded3e082876e1c8711",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "remapping-2c8f6effe95a606e03b354c3292256d983eb22571560ec22d9f502eb1078de5b9e0a383157895f7ce0990ad605887e9334e5feb50297c7ded3e082876e1c8711"
   },
   {
     "type": "file",
@@ -960,31 +1107,24 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-    "sha512": "47c80b45365eca9d37ca6ccfffa2e297fdbcb46786133871d6ada4ef4dca19644023555dbcf217746ef4549736a40330dcd03a24a2f986116ed6c257d0c9e7fc",
+    "url": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+    "sha512": "64ca7557c64570f1b97485a740baf7352235322094ed4113752fc0d06f15fd7587bc9bf766c16abad267d58e513e600f5fa177062137f7b3aabde53ff4d0ae20",
     "dest": "flatpak-node/npm",
-    "dest-filename": "set-array-47c80b45365eca9d37ca6ccfffa2e297fdbcb46786133871d6ada4ef4dca19644023555dbcf217746ef4549736a40330dcd03a24a2f986116ed6c257d0c9e7fc"
+    "dest-filename": "source-map-64ca7557c64570f1b97485a740baf7352235322094ed4113752fc0d06f15fd7587bc9bf766c16abad267d58e513e600f5fa177062137f7b3aabde53ff4d0ae20"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-    "sha512": "d5925365e6e0aa594eefdb9ed9b9b7ac81ae77f6ce7b4a4fe418d2442471c58904652f124d5ef337ce1405b898bbb8f2f9e08a4a7548520a16584fedb7eb2131",
+    "url": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+    "sha512": "71843ddf5d20aeac6e7966e5f96b885086a251a0dc8fb58eab97d58449633558117ce52163d7f2db34ef7e8a96b2779b87c4a5ef45527056c80af2672ca0743a",
     "dest": "flatpak-node/npm",
-    "dest-filename": "source-map-d5925365e6e0aa594eefdb9ed9b9b7ac81ae77f6ce7b4a4fe418d2442471c58904652f124d5ef337ce1405b898bbb8f2f9e08a4a7548520a16584fedb7eb2131"
+    "dest-filename": "sourcemap-codec-71843ddf5d20aeac6e7966e5f96b885086a251a0dc8fb58eab97d58449633558117ce52163d7f2db34ef7e8a96b2779b87c4a5ef45527056c80af2672ca0743a"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-    "sha512": "82fdd945a2125377e33c080db2b88146a19640beaab85c74e1830f5bfcc3f1730bb14df69a10826df6cee8a6452e3bd8a4267ccf20c482ab207fe3f03da33b19",
+    "url": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+    "sha512": "190ecdc391b6953bbf06d1d329f5e1287a24d9619eb5de1761c54a1b1d344a3024f06330809337cebeb339188f1ae384fbfbe473dd0ab53a2c492bda0a329bd9",
     "dest": "flatpak-node/npm",
-    "dest-filename": "sourcemap-codec-82fdd945a2125377e33c080db2b88146a19640beaab85c74e1830f5bfcc3f1730bb14df69a10826df6cee8a6452e3bd8a4267ccf20c482ab207fe3f03da33b19"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-    "sha512": "bcd93a684c326c6b5ac169b2fcfcf09c60ce8c290b5920f6c2abe3186020380c02196c926177d8a31b74d082644c5fbc2dbe7b0f039bdc06b4a3d080a5ea6261",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "trace-mapping-bcd93a684c326c6b5ac169b2fcfcf09c60ce8c290b5920f6c2abe3186020380c02196c926177d8a31b74d082644c5fbc2dbe7b0f039bdc06b4a3d080a5ea6261"
+    "dest-filename": "trace-mapping-190ecdc391b6953bbf06d1d329f5e1287a24d9619eb5de1761c54a1b1d344a3024f06330809337cebeb339188f1ae384fbfbe473dd0ab53a2c492bda0a329bd9"
   },
   {
     "type": "file",
@@ -1037,6 +1177,20 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
+    "sha512": "4bbf4d74480341dfcd1826b2e930a85735d28fbe2c9116482897292630b994eab7e12673c88e8caad8a25a88955a856b4dc1a335e0b88a96e1d552079697c5e5",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "agent-4bbf4d74480341dfcd1826b2e930a85735d28fbe2c9116482897292630b994eab7e12673c88e8caad8a25a88955a856b4dc1a335e0b88a96e1d552079697c5e5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+    "sha512": "24d03365c5eb0ade365462ee633d337c0cc37c0bc9596e807d8943050c835790c2948da6e6c0262be3883bbb39f577ec46c587a74da3009ad169d3d1193b7a49",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "lru-cache-24d03365c5eb0ade365462ee633d337c0cc37c0bc9596e807d8943050c835790c2948da6e6c0262be3883bbb39f577ec46c587a74da3009ad169d3d1193b7a49"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
     "sha512": "f0a1b9443d0654fe32744cd19ff23804d0eec43b6a55b39d9bcebbe53e3d3881bf34685a2b4a633d7ed970396f2986c0fae96f54adf3b5f705e2e05d3b1b896d",
     "dest": "flatpak-node/npm",
@@ -1072,13 +1226,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-    "sha512": "5c2b8a14fe4f4b9e609cc56edddb72f0a3dab4ba94a32fd96330f3006090f093450a42d7ce623bbcd1c247e5e96d968c5902bfbd0b9bafb3e462af20e3bd09fc",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "once-5c2b8a14fe4f4b9e609cc56edddb72f0a3dab4ba94a32fd96330f3006090f093450a42d7ce623bbcd1c247e5e96d968c5902bfbd0b9bafb3e462af20e3bd09fc"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/@transifex/api/-/api-4.3.0.tgz",
     "sha512": "442a6a02ac5996b1c3a3badf6a6f2d2d2a13d36c2f17c2d078d442d15646e481ab1fec2ff86e9f07c3d62cb1ebbd4b9aa8ee970b090c998949fd7f54f532d31f",
     "dest": "flatpak-node/npm",
@@ -1086,10 +1233,17 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/core-js/-/core-js-3.43.0.tgz",
-    "sha512": "37ac046d34d9498398dab6009fce42baf5969022ba43078c9fbff836bdf0fa00c1781864ff1e0425e63a14fa384330e8259c554eff14ec232f81693aa4e1c7a8",
+    "url": "https://registry.npmjs.org/core-js/-/core-js-3.45.0.tgz",
+    "sha512": "7362992fd94fe038e4377864fda9f8a569f96f965e7e14499c0738da7e8b275f644a76de45b750644e5d49e1362c1a25d4ec090f75f5050bc54c0b1af1179e0c",
     "dest": "flatpak-node/npm",
-    "dest-filename": "core-js-37ac046d34d9498398dab6009fce42baf5969022ba43078c9fbff836bdf0fa00c1781864ff1e0425e63a14fa384330e8259c554eff14ec232f81693aa4e1c7a8"
+    "dest-filename": "core-js-7362992fd94fe038e4377864fda9f8a569f96f965e7e14499c0738da7e8b275f644a76de45b750644e5d49e1362c1a25d4ec090f75f5050bc54c0b1af1179e0c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@turbowarp/ancient-hull.js/-/ancient-hull.js-0.2.13.tgz",
+    "sha512": "969543af5f2a46338b59c3edc3d1fe9e516163b85b7604252d4d5bea725f127da9318467384b7315765ba6b1b9260994088cc6c7f1fd58f6a36e48d176f502f9",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "ancient-hull.js-969543af5f2a46338b59c3edc3d1fe9e516163b85b7604252d4d5bea725f127da9318467384b7315765ba6b1b9260994088cc6c7f1fd58f6a36e48d176f502f9"
   },
   {
     "type": "file",
@@ -1107,10 +1261,31 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-    "sha512": "3d802d8536b69b654ac6ebd20f70cf0bf1b2f94fac380d4b02e4fc9a4991bafc3e34009269e5c443e34771517bace365eaa71ac55dd4b9e9b06b093eefe4892f",
+    "url": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+    "sha512": "7561f31dad96a845c8fced44f4e8eba1c313289976992ac4a258752289abbfa53e26e3706875ec5f1f5b2eee601bb05458520dd2c90840943f2f5ac87b1e17eb",
     "dest": "flatpak-node/npm",
-    "dest-filename": "accepts-3d802d8536b69b654ac6ebd20f70cf0bf1b2f94fac380d4b02e4fc9a4991bafc3e34009269e5c443e34771517bace365eaa71ac55dd4b9e9b06b093eefe4892f"
+    "dest-filename": "estree-7561f31dad96a845c8fced44f4e8eba1c313289976992ac4a258752289abbfa53e26e3706875ec5f1f5b2eee601bb05458520dd2c90840943f2f5ac87b1e17eb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+    "sha512": "e7e7cff0ff0c14d0be0326420f1ac1da991914f1b3a90594ce949ebae54bbe6f1531ca2b3586af06aa057312bc6d0cf842c6e7e2850411e9b8c032df732b061c",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "json-schema-e7e7cff0ff0c14d0be0326420f1ac1da991914f1b3a90594ce949ebae54bbe6f1531ca2b3586af06aa057312bc6d0cf842c6e7e2850411e9b8c032df732b061c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+    "sha512": "e5cbe0e82b4ac1f81d995a98d562225ca7374356e446a18b8bed96ffa6a8fba63b82efd10b046e021184ce1e41e0a96ccd2b932e0658baa16aa396c89a334a9e",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "accepts-e5cbe0e82b4ac1f81d995a98d562225ca7374356e446a18b8bed96ffa6a8fba63b82efd10b046e021184ce1e41e0a96ccd2b932e0658baa16aa396c89a334a9e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+    "sha512": "aeaf6cf893617f4202863b435f196527b838d68664e52957b69d0b1f0c80e5c7a3c27eef2a62a9e293eb8ba60478fbf63d4eb9b00b1e81b5ed2229e60c50d781",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "acorn-jsx-aeaf6cf893617f4202863b435f196527b838d68664e52957b69d0b1f0c80e5c7a3c27eef2a62a9e293eb8ba60478fbf63d4eb9b00b1e81b5ed2229e60c50d781"
   },
   {
     "type": "file",
@@ -1118,6 +1293,13 @@
     "sha512": "4c6c39c958b8b1a6a3b12120cf6e60ace6c61c451a0eb9e2c2f036ab0482d3ad0a7ea18f760961bcf300da53c8a31b373d0208b63da26a0df97ce35c42a81469",
     "dest": "flatpak-node/npm",
     "dest-filename": "adm-zip-4c6c39c958b8b1a6a3b12120cf6e60ace6c61c451a0eb9e2c2f036ab0482d3ad0a7ea18f760961bcf300da53c8a31b373d0208b63da26a0df97ce35c42a81469"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+    "sha512": "8f77d52e0bd3a39dbb6a7c98c893864d825b1bebe79d062f1349b99a691cd532be9f1029a6408b3082f4699e1d6e55423681928619be933138654ca4068320e2",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "ajv-8f77d52e0bd3a39dbb6a7c98c893864d825b1bebe79d062f1349b99a691cd532be9f1029a6408b3082f4699e1d6e55423681928619be933138654ca4068320e2"
   },
   {
     "type": "file",
@@ -1135,17 +1317,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-    "sha512": "3c254042cc167a6bba51dc6c0c5157ffe815798a8a0287770f75159bdd631f0ca782e3b002f60f871f2736533ef8da9170ae82c71a5469f8e684874a88789baa",
+    "url": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+    "sha512": "86d0940e5c72c822cc81a337c578340b42d6db1a9fb90ea9d39a42108b17bb243e6b592860a4ee04ccd13709b26df2e0bc90cc774af52d39f8f84d138ba0b600",
     "dest": "flatpak-node/npm",
-    "dest-filename": "array-flatten-3c254042cc167a6bba51dc6c0c5157ffe815798a8a0287770f75159bdd631f0ca782e3b002f60f871f2736533ef8da9170ae82c71a5469f8e684874a88789baa"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-    "sha512": "6da359caa69a2e1c8b54a9bf0e5bdd5b4e7531280ee9bf1e55f21ece5f44e4fa96c458332e6ff0427b445b8ccecad55bbab0c4af426500b12974e170bc4acbb2",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "async-6da359caa69a2e1c8b54a9bf0e5bdd5b4e7531280ee9bf1e55f21ece5f44e4fa96c458332e6ff0427b445b8ccecad55bbab0c4af426500b12974e170bc4acbb2"
+    "dest-filename": "async-86d0940e5c72c822cc81a337c578340b42d6db1a9fb90ea9d39a42108b17bb243e6b592860a4ee04ccd13709b26df2e0bc90cc774af52d39f8f84d138ba0b600"
   },
   {
     "type": "file",
@@ -1156,31 +1331,17 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-    "sha512": "eeb0310728d432a437fdb1c9cbb0fa3865efc7f30c73822a067fd7d1f70cd5051c008b6966b0446215867a6fadcd71fdd1cf86d35ca931c60904ef58df4db4de",
+    "url": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+    "sha512": "d36aaf01ac6ff2da7b7c16bf9b0d606bdf0e1a6f9e09bab324e2a846def4b0b99f1048be8f20585530c67c22ff934ebfe04324ff3d358027bb1e8087fdfd8b4e",
     "dest": "flatpak-node/npm",
-    "dest-filename": "body-parser-eeb0310728d432a437fdb1c9cbb0fa3865efc7f30c73822a067fd7d1f70cd5051c008b6966b0446215867a6fadcd71fdd1cf86d35ca931c60904ef58df4db4de"
+    "dest-filename": "body-parser-d36aaf01ac6ff2da7b7c16bf9b0d606bdf0e1a6f9e09bab324e2a846def4b0b99f1048be8f20585530c67c22ff934ebfe04324ff3d358027bb1e8087fdfd8b4e"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-    "sha512": "6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730",
+    "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+    "sha512": "f53f548d6debd145b973543b193c25969b57c21bd8984cc587331f67d1fb1505adfae65e3e364f8c13ff5b5644c99d6dc065a89b9ff9e9317894f72a8e70c772",
     "dest": "flatpak-node/npm",
-    "dest-filename": "debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-    "sha512": "4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-    "sha512": "882b8f1c3160ac75fb1f6bc423fe71a73d3bcd21c1d344e9ba0aa1998b5598c3bae75f260ae44ca0e60595d101974835f3bb9fa3375a1e058a71815beb5a8688",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "brace-expansion-882b8f1c3160ac75fb1f6bc423fe71a73d3bcd21c1d344e9ba0aa1998b5598c3bae75f260ae44ca0e60595d101974835f3bb9fa3375a1e058a71815beb5a8688"
+    "dest-filename": "brace-expansion-f53f548d6debd145b973543b193c25969b57c21bd8984cc587331f67d1fb1505adfae65e3e364f8c13ff5b5644c99d6dc065a89b9ff9e9317894f72a8e70c772"
   },
   {
     "type": "file",
@@ -1202,6 +1363,13 @@
     "sha512": "fb2b3df7b53dea9a382b1fc0069042aa103d12ec49690583420ef6f791f8841a61bf72198346e804abb0629b78617a7a319e4099942753fb72313951a5a49e8e",
     "dest": "flatpak-node/npm",
     "dest-filename": "call-bound-fb2b3df7b53dea9a382b1fc0069042aa103d12ec49690583420ef6f791f8841a61bf72198346e804abb0629b78617a7a319e4099942753fb72313951a5a49e8e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+    "sha512": "3fc06302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "callsites-3fc06302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69"
   },
   {
     "type": "file",
@@ -1240,10 +1408,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-    "sha512": "16f7994cdb86c34e1cc6502259bce2eb34c02ff9617a16966d3b6096e261e3f13de43a8cc139a16b7299375680580f1c148847ccc654bcb7af930e51aa4fad49",
+    "url": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+    "sha512": "02ef6744bf15354badfd74b36d0037f3e33bf1dccfe03f9eaa0de07c91cc2071d86b76e0d3aef18f52b13145a3f9550b6e264ca302a780515b29ccd4acd2759a",
     "dest": "flatpak-node/npm",
-    "dest-filename": "content-disposition-16f7994cdb86c34e1cc6502259bce2eb34c02ff9617a16966d3b6096e261e3f13de43a8cc139a16b7299375680580f1c148847ccc654bcb7af930e51aa4fad49"
+    "dest-filename": "content-disposition-02ef6744bf15354badfd74b36d0037f3e33bf1dccfe03f9eaa0de07c91cc2071d86b76e0d3aef18f52b13145a3f9550b6e264ca302a780515b29ccd4acd2759a"
   },
   {
     "type": "file",
@@ -1261,10 +1429,31 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-    "sha512": "4000f395a1dcf22715f08eef6da257270a1df47598a7cb82a9fd716b839f36ed53ec9571408ad480e5ad1dd343b4f8b2c2615b892d76563a2d2172eb28cde8ad",
+    "url": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+    "sha512": "0fbeae53bdee9525eb0f5517178284d93331555c21b270a07c0c9383d93c3fa2866639572ab38b7b874940a2370718b9c237ac6681572561253560633d931b86",
     "dest": "flatpak-node/npm",
-    "dest-filename": "cookie-signature-4000f395a1dcf22715f08eef6da257270a1df47598a7cb82a9fd716b839f36ed53ec9571408ad480e5ad1dd343b4f8b2c2615b892d76563a2d2172eb28cde8ad"
+    "dest-filename": "cookie-signature-0fbeae53bdee9525eb0f5517178284d93331555c21b270a07c0c9383d93c3fa2866639572ab38b7b874940a2370718b9c237ac6681572561253560633d931b86"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+    "sha512": "b95d903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "cross-spawn-b95d903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+    "sha512": "446c305a7c10be455f6af295b76d8518bc3ec5849dcc04709b4aeee83853540dee994e6165cdbc57790ee2cb6062bcab4e52e9baf808f468a28e5b408cd6dca8",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "debug-446c305a7c10be455f6af295b76d8518bc3ec5849dcc04709b4aeee83853540dee994e6165cdbc57790ee2cb6062bcab4e52e9baf808f468a28e5b408cd6dca8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+    "sha512": "a083f392c993838fccae289a6063bea245c34fbced9ffc37129b6fffe81221d31d2ac268d2ee027d834524fcbee1228cb82a86c36c319c0f9444c837b7c6bf6d",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "deep-is-a083f392c993838fccae289a6063bea245c34fbced9ffc37129b6fffe81221d31d2ac268d2ee027d834524fcbee1228cb82a86c36c319c0f9444c837b7c6bf6d"
   },
   {
     "type": "file",
@@ -1272,13 +1461,6 @@
     "sha512": "83b9c7e8fe9dc838a8268800006a6b1a90ad5489898693e4feba02cdd6f77c887ad7fb3f9cfb1f47aa27c8cc2408047f3a50b7c810b49444af52840402cb08af",
     "dest": "flatpak-node/npm",
     "dest-filename": "depd-83b9c7e8fe9dc838a8268800006a6b1a90ad5489898693e4feba02cdd6f77c887ad7fb3f9cfb1f47aa27c8cc2408047f3a50b7c810b49444af52840402cb08af"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-    "sha512": "dac246253697208691d70e22252368374867318ec6a5cfe7f03e2a482270f10a855977fb72e0209c41f1069c1e69570f7af0b69772a98d80b1dcdca941081a26",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "destroy-dac246253697208691d70e22252368374867318ec6a5cfe7f03e2a482270f10a855977fb72e0209c41f1069c1e69570f7af0b69772a98d80b1dcdca941081a26"
   },
   {
     "type": "file",
@@ -1345,6 +1527,69 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+    "sha512": "4eda5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "escape-string-regexp-4eda5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
+    "sha512": "b7968f3a99ad25c65ccf9509c98d866efa4396c2b913c26a46aa0ab5f88a13770d878dfb288a9f26bdc0dc029fe64eb834fc7a7741b7767a3a5c3634e4fa8fb7",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "eslint-b7968f3a99ad25c65ccf9509c98d866efa4396c2b913c26a46aa0ab5f88a13770d878dfb288a9f26bdc0dc029fe64eb834fc7a7741b7767a3a5c3634e4fa8fb7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+    "sha512": "b0d5ce7ca0a7ef8aedf1120228cbc94bb5ca57f5e4f6403b0f226bf262629374bb0b0832dea964926c92dae401de388983a54d75977fa43049bb49ef1b63654e",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "eslint-scope-b0d5ce7ca0a7ef8aedf1120228cbc94bb5ca57f5e4f6403b0f226bf262629374bb0b0832dea964926c92dae401de388983a54d75977fa43049bb49ef1b63654e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+    "sha512": "521764e6c7ea71e7bff47feb08e262918cfaee8d1ad93c3684644f386d98d51d9d83b6eb45ed6e1b4c9a3500c7bbe4cefee40f17fe5e09aa6f612987523b7b25",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "eslint-visitor-keys-521764e6c7ea71e7bff47feb08e262918cfaee8d1ad93c3684644f386d98d51d9d83b6eb45ed6e1b4c9a3500c7bbe4cefee40f17fe5e09aa6f612987523b7b25"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+    "sha512": "a2bb99685923a2b4e9177da40d2239ffbe558b019e6608a7186cb636839283743d6e7c259e60e6e072e7925d111379fe9e30d7474dfb698d7ec79f19ff315dc1",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "espree-a2bb99685923a2b4e9177da40d2239ffbe558b019e6608a7186cb636839283743d6e7c259e60e6e072e7925d111379fe9e30d7474dfb698d7ec79f19ff315dc1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+    "sha512": "71af69c3d7e898570a3ef14b5e104a50af7466f1a26e218ebd124d6e396363bb3bbaaff960ee013b3718b49a84c5dc7df6b17a6807274711e67141dccfab10b2",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "esquery-71af69c3d7e898570a3ef14b5e104a50af7466f1a26e218ebd124d6e396363bb3bbaaff960ee013b3718b49a84c5dc7df6b17a6807274711e67141dccfab10b2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+    "sha512": "2a67ca2f76fa1be457bcff0dd6faf74ead642ffa021609f63585c4b6a3fcfcbde929aa540381bc70555aa05dd2537db7083e17ca947f7df8a81e692d8bafd36a",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "esrecurse-2a67ca2f76fa1be457bcff0dd6faf74ead642ffa021609f63585c4b6a3fcfcbde929aa540381bc70555aa05dd2537db7083e17ca947f7df8a81e692d8bafd36a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+    "sha512": "30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "estraverse-30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+    "sha512": "915b1ca97938382a7af126747648042958baffc8a3df4d0a0564c9ab7d8ffdd61e5934b02b8d56c93c5a94dd5e46603967d514fcb5fd0fb1564a657d480631ea",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "esutils-915b1ca97938382a7af126747648042958baffc8a3df4d0a0564c9ab7d8ffdd61e5934b02b8d56c93c5a94dd5e46603967d514fcb5fd0fb1564a657d480631ea"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
     "sha512": "6882f9171ee66b055adf4d1a976067104e2236fa35a844f12eb3c8fe8d392fbcfa828edf0b0d49e844266cae05989d804bb920545fca1195ae7c17dd0a531c3e",
     "dest": "flatpak-node/npm",
@@ -1352,10 +1597,38 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-    "sha512": "dbc1ea80c6409a28750b3b7d9f2eeaafa7a4daa75d17815c95b333c21091101e8e15f1fead7027b8d0b0a35ff016faed6e0b100dbe2449b5fd75ef6515bad79c",
+    "url": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+    "sha512": "0d3f5c939608454fbc198cf3539913dde1c603988bfb565dd04bad3a64c4f43b64f93beecdddb754153e79cec73cd493c5760ee7980f57f86ae294812438c5a4",
     "dest": "flatpak-node/npm",
-    "dest-filename": "express-dbc1ea80c6409a28750b3b7d9f2eeaafa7a4daa75d17815c95b333c21091101e8e15f1fead7027b8d0b0a35ff016faed6e0b100dbe2449b5fd75ef6515bad79c"
+    "dest-filename": "express-0d3f5c939608454fbc198cf3539913dde1c603988bfb565dd04bad3a64c4f43b64f93beecdddb754153e79cec73cd493c5760ee7980f57f86ae294812438c5a4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+    "sha512": "7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "fast-deep-equal-7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+    "sha512": "96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "fast-json-stable-stringify-96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+    "sha512": "0c25eee887e1a9c92ced364a6371f1a77cbaaa9858e522599ab58c0eb29c11148e5d641d32153d220fcf62bcf2c3fba5f63388ca1d0de0cd2d6c2e61a1d83c77",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "fast-levenshtein-0c25eee887e1a9c92ced364a6371f1a77cbaaa9858e522599ab58c0eb29c11148e5d641d32153d220fcf62bcf2c3fba5f63388ca1d0de0cd2d6c2e61a1d83c77"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+    "sha512": "5d74d4c02be2b1ae6869c34644ff527cdb5804d00c8be44fc011666e564417b37bb301d8412ebf65f93b491c31e03e63dc21f6d7560d45ca350c430d55f6429d",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "file-entry-cache-5d74d4c02be2b1ae6869c34644ff527cdb5804d00c8be44fc011666e564417b37bb301d8412ebf65f93b491c31e03e63dc21f6d7560d45ca350c430d55f6429d"
   },
   {
     "type": "file",
@@ -1366,17 +1639,38 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-    "sha512": "5e7008bd0f1e33e902e9a50bc7ac2e422c15b27cec8bd7775b1cd5dc5a564c6035f45eb6d64c1d6ec01c14a5e02941d95accbe998ea22f5b074f1584142cad0c",
+    "url": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+    "sha512": "94ac15ff56eba46ea6054147b5becd526b400426f65996669b6c0d88e0398406fc55d092e01dddb4c5b2bdca1589c730016fc23844635cbb74ccfd735d4376ea",
     "dest": "flatpak-node/npm",
-    "dest-filename": "brace-expansion-5e7008bd0f1e33e902e9a50bc7ac2e422c15b27cec8bd7775b1cd5dc5a564c6035f45eb6d64c1d6ec01c14a5e02941d95accbe998ea22f5b074f1584142cad0c"
+    "dest-filename": "minimatch-94ac15ff56eba46ea6054147b5becd526b400426f65996669b6c0d88e0398406fc55d092e01dddb4c5b2bdca1589c730016fc23844635cbb74ccfd735d4376ea"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-    "sha512": "e8137db6b1fb6e9deabe7ad1cb3b01cfe837959c533594db54ed84575092d1621c0db6b0615758bc67e5304ffd40fd21d296250830424e361af67673303a72c5",
+    "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+    "sha512": "fedf3c4f2ddde495906d662068e1820987d7470575f9b7b4d96a986252fa87494489400c3ccf28f2a2863b4d58224387ce46b6ba9d3cc2f8180f4983888faadd",
     "dest": "flatpak-node/npm",
-    "dest-filename": "finalhandler-e8137db6b1fb6e9deabe7ad1cb3b01cfe837959c533594db54ed84575092d1621c0db6b0615758bc67e5304ffd40fd21d296250830424e361af67673303a72c5"
+    "dest-filename": "finalhandler-fedf3c4f2ddde495906d662068e1820987d7470575f9b7b4d96a986252fa87494489400c3ccf28f2a2863b4d58224387ce46b6ba9d3cc2f8180f4983888faadd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+    "sha512": "efcfcf5d3d7094b2c3813cc3b3bb23abd873cf4bd70fece7fbbc32a447b87d74310a6766a9f1ac10f4319a2092408dda8c557dd5b552b2f36dac94625ba9c69e",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "find-up-efcfcf5d3d7094b2c3813cc3b3bb23abd873cf4bd70fece7fbbc32a447b87d74310a6766a9f1ac10f4319a2092408dda8c557dd5b552b2f36dac94625ba9c69e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+    "sha512": "7fb71c14f2b7497147a71d795081b2449fc525072db8a674cd5b8dddfac1a381e72b771acbd5445b447ac8f6051c2d0082a86e90fcca8eadb6b790e6032a86cb",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "flat-cache-7fb71c14f2b7497147a71d795081b2449fc525072db8a674cd5b8dddfac1a381e72b771acbd5445b447ac8f6051c2d0082a86e90fcca8eadb6b790e6032a86cb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+    "sha512": "197fb2b30e0f042cf43f3a2c1c37a964600d12e14230bae7453884cbd31c1a39a409063046ae00fd7efce86fdf8ccffe3a3b16494d59ad8e6ac8045998efeec2",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "flatted-197fb2b30e0f042cf43f3a2c1c37a964600d12e14230bae7453884cbd31c1a39a409063046ae00fd7efce86fdf8ccffe3a3b16494d59ad8e6ac8045998efeec2"
   },
   {
     "type": "file",
@@ -1387,10 +1681,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-    "sha512": "cc9da6418335f2b1053ae75e57819285318843b45bcc0ee8cdb53d23f5c1a66ee4aa0332c209b294cc171f16499a45686249daf5dda95575573dd6133fd7a3f1",
+    "url": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+    "sha512": "471fd6c9c67ad0739aa8b2808ba70744a288ef3c566c9df53219ed9adc0ca1a4de17b5c51fd861069f2f21368c89d7e58d143a7985822a46932beca45491cfd8",
     "dest": "flatpak-node/npm",
-    "dest-filename": "fresh-cc9da6418335f2b1053ae75e57819285318843b45bcc0ee8cdb53d23f5c1a66ee4aa0332c209b294cc171f16499a45686249daf5dda95575573dd6133fd7a3f1"
+    "dest-filename": "fresh-471fd6c9c67ad0739aa8b2808ba70744a288ef3c566c9df53219ed9adc0ca1a4de17b5c51fd861069f2f21368c89d7e58d143a7985822a46932beca45491cfd8"
   },
   {
     "type": "file",
@@ -1412,6 +1706,20 @@
     "sha512": "b1349f063a17069f3d26f20a21e7eac3b53608279bb1cef892263a6b0886a202ada1219b823604fc6ffe97db05dcc5853cd73d21ca0e0b83837ca1dfc459a9d2",
     "dest": "flatpak-node/npm",
     "dest-filename": "get-proto-b1349f063a17069f3d26f20a21e7eac3b53608279bb1cef892263a6b0886a202ada1219b823604fc6ffe97db05dcc5853cd73d21ca0e0b83837ca1dfc459a9d2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+    "sha512": "5f1c08f043a1550816a7a8832feddbd2bf3a7f877a017eb3494e791df078c9d084b972d773915c61e3aefa79c67ed4b84c48eeff5d6bb782893d33206df9afe0",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "glob-parent-5f1c08f043a1550816a7a8832feddbd2bf3a7f877a017eb3494e791df078c9d084b972d773915c61e3aefa79c67ed4b84c48eeff5d6bb782893d33206df9afe0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+    "sha512": "a1a846bee3064253f0fe2bc86018d54ab5807d62c17a4bb9b693c4d9f38f2e2f961df7c859bba1dad0a38724214c13cc7f913d8c3107e053a64d8818c1b2b0b5",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "globals-a1a846bee3064253f0fe2bc86018d54ab5807d62c17a4bb9b693c4d9f38f2e2f961df7c859bba1dad0a38724214c13cc7f913d8c3107e053a64d8818c1b2b0b5"
   },
   {
     "type": "file",
@@ -1450,10 +1758,24 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-    "sha512": "bf73179d901cbe7cb091350466898801cb657bb4575de79d391df5c3097b565ca85cee108bd6abbd27a73505a77b54dc4708422f51f02c8db56c4a9da63f3fac",
+    "url": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+    "sha512": "470340f59ffb3eb2b4eab60b23314c95a17e97bde2c29ceca9120581b30b6d370b0fa70e6a8f364da59e7cf5d0bc1d9f382e008ee612127752ecdfe64c26e475",
     "dest": "flatpak-node/npm",
-    "dest-filename": "iconv-lite-bf73179d901cbe7cb091350466898801cb657bb4575de79d391df5c3097b565ca85cee108bd6abbd27a73505a77b54dc4708422f51f02c8db56c4a9da63f3fac"
+    "dest-filename": "statuses-470340f59ffb3eb2b4eab60b23314c95a17e97bde2c29ceca9120581b30b6d370b0fa70e6a8f364da59e7cf5d0bc1d9f382e008ee612127752ecdfe64c26e475"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+    "sha512": "e1f0a4efdc2c84c773329dab1f4eaa5ab244e22a25a8b842507f8e8ae22053ef91074fbde0d9432fcd5ab4eec65f9e6e50ab9ea34b711cdb6f13223a0fb59d33",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "iconv-lite-e1f0a4efdc2c84c773329dab1f4eaa5ab244e22a25a8b842507f8e8ae22053ef91074fbde0d9432fcd5ab4eec65f9e6e50ab9ea34b711cdb6f13223a0fb59d33"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+    "sha512": "86c053354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "ignore-86c053354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa"
   },
   {
     "type": "file",
@@ -1461,6 +1783,20 @@
     "sha512": "211a972a5697c2048c00cb6937365ad5901ef26f926b5efbd03864f15912b0ff4b4be8870fad9977c1502acf1f6cf89a80113b073a055f6ddcc459f0b21a55eb",
     "dest": "flatpak-node/npm",
     "dest-filename": "image-size-211a972a5697c2048c00cb6937365ad5901ef26f926b5efbd03864f15912b0ff4b4be8870fad9977c1502acf1f6cf89a80113b073a055f6ddcc459f0b21a55eb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+    "sha512": "4d1dca7eb4d94d82cf07a8d48dfc7a305f56716ac72fdb2ee5339b2b866462005d58a3ce1684a8408744b93b91f36a66b711f6b29586f61e9eb707ebd692c1a9",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "import-fresh-4d1dca7eb4d94d82cf07a8d48dfc7a305f56716ac72fdb2ee5339b2b866462005d58a3ce1684a8408744b93b91f36a66b711f6b29586f61e9eb707ebd692c1a9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+    "sha512": "2665cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "imurmurhash-2665cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c"
   },
   {
     "type": "file",
@@ -1478,10 +1814,73 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
-    "sha512": "6438b768ff9f1bf2dc87207350cf34e158dd767c1f49fb1d798930b7c35c6ca46fa38ac592386ce39ea22c59f79366545af35ee22e3c5800836f36bc7e1ab6fb",
+    "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+    "sha512": "49b29b00d90deb4dd58b88c466fe3d2de549327e321b0b1bcd9c28ac4a32122badb0dde725875b3b7eb37e1189e90103a4e6481640ed9eae494719af9778eca1",
     "dest": "flatpak-node/npm",
-    "dest-filename": "jake-6438b768ff9f1bf2dc87207350cf34e158dd767c1f49fb1d798930b7c35c6ca46fa38ac592386ce39ea22c59f79366545af35ee22e3c5800836f36bc7e1ab6fb"
+    "dest-filename": "is-extglob-49b29b00d90deb4dd58b88c466fe3d2de549327e321b0b1bcd9c28ac4a32122badb0dde725875b3b7eb37e1189e90103a4e6481640ed9eae494719af9778eca1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+    "sha512": "c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "is-glob-c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+    "sha512": "86fa6823a928ae124c9de8f6f3975283a9eed7e7babb1b3bcc6dc16009b96f2a83b2024d5b0c7333acfa8998808104784c9df42660533b0a99530dd69721f701",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "is-promise-86fa6823a928ae124c9de8f6f3975283a9eed7e7babb1b3bcc6dc16009b96f2a83b2024d5b0c7333acfa8998808104784c9df42660533b0a99530dd69721f701"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+    "sha512": "447c4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "isexe-447c4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+    "sha512": "c291d8ce1c625502fe215d3904b1365e7df8cd6d52db6de1be3b6a934fa0b0faf077ff0934b5c981964cfe23c5b18735c72a6117ee8ce84bdd13913d3011a40c",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "jake-c291d8ce1c625502fe215d3904b1365e7df8cd6d52db6de1be3b6a934fa0b0faf077ff0934b5c981964cfe23c5b18735c72a6117ee8ce84bdd13913d3011a40c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+    "sha512": "c29c59b3d368c596891122462194f20c4698a65d0529203e141f5a262c9e98a84cc24c5083ade1e13d4a2605061e94ea3c33517269982ee82b46326506d5af44",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "js-yaml-c29c59b3d368c596891122462194f20c4698a65d0529203e141f5a262c9e98a84cc24c5083ade1e13d4a2605061e94ea3c33517269982ee82b46326506d5af44"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+    "sha512": "e1b57905f4769aa7d04c99be579b4f3dd7fe669ba1888bd3b8007983c91cad7399a534ff430c15456072c17d68cebea512e3dd6c7c70689966f46ea6236b1f49",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "json-buffer-e1b57905f4769aa7d04c99be579b4f3dd7fe669ba1888bd3b8007983c91cad7399a534ff430c15456072c17d68cebea512e3dd6c7c70689966f46ea6236b1f49"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+    "sha512": "c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "json-schema-traverse-c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+    "sha512": "05d6e8cbe97bb40dce196e858f21475a43f92ee0728f54e4df72e3caad1ac72cdd93dfff2528b6bb77cfd504a677528dc2ae9538a606940bbcec28ac562afa3f",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "json-stable-stringify-without-jsonify-05d6e8cbe97bb40dce196e858f21475a43f92ee0728f54e4df72e3caad1ac72cdd93dfff2528b6bb77cfd504a677528dc2ae9538a606940bbcec28ac562afa3f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+    "sha512": "a3154790747f1097f608d5e75b144b5ba9a0ec9c82094706d03b441a62f672d528d4f3538a7d4f52297eafffb8af93295600bf7e7d648ecc7b9a34ae8caa88a7",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "keyv-a3154790747f1097f608d5e75b144b5ba9a0ec9c82094706d03b441a62f672d528d4f3538a7d4f52297eafffb8af93295600bf7e7d648ecc7b9a34ae8caa88a7"
   },
   {
     "type": "file",
@@ -1489,6 +1888,20 @@
     "sha512": "e5a1c26f341100371d3fe013aa70ee86127f31122a0e4657e69ca3147451cac4bcbd9e406ea184a0521bea96073d9f8bfce0b62dcfb14fcb875554790802bfc1",
     "dest": "flatpak-node/npm",
     "dest-filename": "linkify-it-e5a1c26f341100371d3fe013aa70ee86127f31122a0e4657e69ca3147451cac4bcbd9e406ea184a0521bea96073d9f8bfce0b62dcfb14fcb875554790802bfc1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+    "sha512": "88f64ae9e6236f146edee078fd667712c10830914ca80a28a65dd1fb3baad148dc026fcc3ba282c1e0e03df3f77a54f3b6828fdcab67547c539f63470520d553",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "locate-path-88f64ae9e6236f146edee078fd667712c10830914ca80a28a65dd1fb3baad148dc026fcc3ba282c1e0e03df3f77a54f3b6828fdcab67547c539f63470520d553"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+    "sha512": "d0aa63a97455beb6320ac5f5b3047f5d32b4bdae9542440ce8c368ecfa96efb0728c086801103c11facfd4de3e2a52a3f184b46540ad453fd852e872603ba321",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "lodash.merge-d0aa63a97455beb6320ac5f5b3047f5d32b4bdae9542440ce8c368ecfa96efb0728c086801103c11facfd4de3e2a52a3f184b46540ad453fd852e872603ba321"
   },
   {
     "type": "file",
@@ -1513,45 +1926,31 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-    "sha512": "76afaa7a543d6a41e970e97f8145514f15483a4009d70477400bdbe11b158d2f285681630c64dcebbf702589949a49d41791f030b3a06f93be6b72b17d66a93d",
+    "url": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+    "sha512": "6a2b27ac33f818d7b4e9470a1675796df30d3c1530e23b0b19a5b059f9c7defd361a706e5d7d8c0959f945bad6a348f7a5ccd48a561b96aedf43b370dade572b",
     "dest": "flatpak-node/npm",
-    "dest-filename": "media-typer-76afaa7a543d6a41e970e97f8145514f15483a4009d70477400bdbe11b158d2f285681630c64dcebbf702589949a49d41791f030b3a06f93be6b72b17d66a93d"
+    "dest-filename": "media-typer-6a2b27ac33f818d7b4e9470a1675796df30d3c1530e23b0b19a5b059f9c7defd361a706e5d7d8c0959f945bad6a348f7a5ccd48a561b96aedf43b370dade572b"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-    "sha512": "81a36f012ed367cf7bfeb55a6749ccb40cb13728bfa5d6e36c0c14a4542937bd06aa755f3a25e979450c291066cd769243c0dd4d7e3fd26b3adabd8afa113a99",
+    "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+    "sha512": "4a7937d785796b214b869ddf914444b9be96b6305f3dd08f6352e7f3ff26ba7b8bba2621b000600555aca33006f8c58c6d512f71d7296e2f51ef0c36da5f50de",
     "dest": "flatpak-node/npm",
-    "dest-filename": "merge-descriptors-81a36f012ed367cf7bfeb55a6749ccb40cb13728bfa5d6e36c0c14a4542937bd06aa755f3a25e979450c291066cd769243c0dd4d7e3fd26b3adabd8afa113a99"
+    "dest-filename": "merge-descriptors-4a7937d785796b214b869ddf914444b9be96b6305f3dd08f6352e7f3ff26ba7b8bba2621b000600555aca33006f8c58c6d512f71d7296e2f51ef0c36da5f50de"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-    "sha512": "89c9401de36a366ebccc5b676747bed4bdb250876fccda1ab8a53858103756f1ffbcf162785eea7d197051953e0c0f4ff5b3d7212f74ba5c68528087db7b15db",
+    "url": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+    "sha512": "694e4426e20dd960de982700a76bc505fa7f9b810085626750d492c348b1b3bfe45db77a3e0eb8126c0990d745841f1a5add6c1f60935eb2f1a3f880195de83d",
     "dest": "flatpak-node/npm",
-    "dest-filename": "methods-89c9401de36a366ebccc5b676747bed4bdb250876fccda1ab8a53858103756f1ffbcf162785eea7d197051953e0c0f4ff5b3d7212f74ba5c68528087db7b15db"
+    "dest-filename": "mime-db-694e4426e20dd960de982700a76bc505fa7f9b810085626750d492c348b1b3bfe45db77a3e0eb8126c0990d745841f1a5add6c1f60935eb2f1a3f880195de83d"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-    "sha512": "c74567f2ca48fb0b89d4ee92ee09db69083c3f187834d1dbeca4883661162a23c4e1128ea65be28e7f8d92662699180febc99cef48f611b793151b2bb306907a",
+    "url": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+    "sha512": "c51738a04853e9e681a54d5717b023a4e143fb14265cd0793952b0a78b6a0ae0691cb4bf65b043adcd3b9984c3a95320e8f7f15238cda7ce4ee8277667fe4758",
     "dest": "flatpak-node/npm",
-    "dest-filename": "mime-c74567f2ca48fb0b89d4ee92ee09db69083c3f187834d1dbeca4883661162a23c4e1128ea65be28e7f8d92662699180febc99cef48f611b793151b2bb306907a"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-    "sha512": "b0f538b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "mime-db-b0f538b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-    "sha512": "64363e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "mime-types-64363e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b"
+    "dest-filename": "mime-types-c51738a04853e9e681a54d5717b023a4e143fb14265cd0793952b0a78b6a0ae0691cb4bf65b043adcd3b9984c3a95320e8f7f15238cda7ce4ee8277667fe4758"
   },
   {
     "type": "file",
@@ -1562,10 +1961,17 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-    "sha512": "f8452ca863cbb0cfa3ff37428598ec9d7e758385eb1c53885f07e70953c695093f9398226a470ab2ec4239b051bba0d29bda29c3f3bab2559b25d82140ce1b06",
+    "url": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+    "sha512": "396343f1e8b756d342f61ed5eb4a9f7f7495a1b1ebf7de824f0831b9b832418129836f7487d2746eec8408d3497b19059b9b0e6a38791b5d7a45803573c64c4b",
     "dest": "flatpak-node/npm",
-    "dest-filename": "negotiator-f8452ca863cbb0cfa3ff37428598ec9d7e758385eb1c53885f07e70953c695093f9398226a470ab2ec4239b051bba0d29bda29c3f3bab2559b25d82140ce1b06"
+    "dest-filename": "natural-compare-396343f1e8b756d342f61ed5eb4a9f7f7495a1b1ebf7de824f0831b9b832418129836f7487d2746eec8408d3497b19059b9b0e6a38791b5d7a45803573c64c4b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+    "sha512": "f0e7ecfc051087c31a11cae5ab9c4e5f4090f72a53179765efc9a394c35f38ad3c7f3a604c741140f07170f944b48c34c91a70b3e668ff7afee5645bcbbbb71a",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "negotiator-f0e7ecfc051087c31a11cae5ab9c4e5f4090f72a53179765efc9a394c35f38ad3c7f3a604c741140f07170f944b48c34c91a70b3e668ff7afee5645bcbbbb71a"
   },
   {
     "type": "file",
@@ -1583,6 +1989,41 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+    "sha512": "94d689808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "once-94d689808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+    "sha512": "e88a50ee6294c5171934b20e6d1d21cfb971b1aa5248860d649c173c6785d264d5a862852178f50d070ca13db64b744e70bc98febcf43d669667d6b25a669df6",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "optionator-e88a50ee6294c5171934b20e6d1d21cfb971b1aa5248860d649c173c6785d264d5a862852178f50d070ca13db64b744e70bc98febcf43d669667d6b25a669df6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+    "sha512": "4d839a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "p-limit-4d839a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+    "sha512": "2da363b51594058fbecc1e6713f37071aa0cca548f93e4be647341d53cdd6cc24c9f2e9dca7a401aded7fed97f418ab74c8784ea7c47a696e8d8b1b29ab1b93f",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "p-locate-2da363b51594058fbecc1e6713f37071aa0cca548f93e4be647341d53cdd6cc24c9f2e9dca7a401aded7fed97f418ab74c8784ea7c47a696e8d8b1b29ab1b93f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+    "sha512": "190d84591a5057cfe8f80c3c62ab5f6593df3515996246e2744f64e6ba65fe10b7bed1c705f1a6d887e2eaa595f9ca031a4ad42990311372e8b7991cb11961fa",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "parent-module-190d84591a5057cfe8f80c3c62ab5f6593df3515996246e2744f64e6ba65fe10b7bed1c705f1a6d887e2eaa595f9ca031a4ad42990311372e8b7991cb11961fa"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
     "sha512": "0a2c9e3b1153fc96723799b4cfd3df5f0e1208127a4b2833d43a65d30aa39610c418604fd469ec51510bd29eb78681b57dc8f77c7ca75e2f4d60ee2758e2fea9",
     "dest": "flatpak-node/npm",
@@ -1590,10 +2031,31 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-    "sha512": "440d468d454c9ef605c6eaa8beb12a668c715b935466a6f02ad633fd3b7b9d77ab9342db2db9509abb2075e3b15794851dfd140e08234bf6d278e670b75a6611",
+    "url": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+    "sha512": "6a4f50cb943b8d86f65b071ecb9169be0d8aa0073f64884b48b392066466ca03ec1b091556dd1f65ad2aaed333fa6ead2530077d943c167981e0c1b82d6cbbff",
     "dest": "flatpak-node/npm",
-    "dest-filename": "path-to-regexp-440d468d454c9ef605c6eaa8beb12a668c715b935466a6f02ad633fd3b7b9d77ab9342db2db9509abb2075e3b15794851dfd140e08234bf6d278e670b75a6611"
+    "dest-filename": "path-exists-6a4f50cb943b8d86f65b071ecb9169be0d8aa0073f64884b48b392066466ca03ec1b091556dd1f65ad2aaed333fa6ead2530077d943c167981e0c1b82d6cbbff"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+    "sha512": "a2399e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "path-key-a2399e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+    "sha512": "ee377054846db0ff0c6297574b0392d18743d03bbea8ea05fc010f22df3c3dc085ad90b3c78d68c64bb58c3f3c8590706cd50811fa6abee86315a300a8c4d69c",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "path-to-regexp-ee377054846db0ff0c6297574b0392d18743d03bbea8ea05fc010f22df3c3dc085ad90b3c78d68c64bb58c3f3c8590706cd50811fa6abee86315a300a8c4d69c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+    "sha512": "c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "picocolors-c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454"
   },
   {
     "type": "file",
@@ -1604,6 +2066,13 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+    "sha512": "bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "punycode-bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
     "sha512": "bb11481d4d189476210d0b55e11f49e9ae7648bc76f010a34fee227a1ec819b83054958efa49b8df5738c9195111402c026b7fb8c8d05324073443dfd0cdfd08",
     "dest": "flatpak-node/npm",
@@ -1611,10 +2080,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-    "sha512": "fb7f2a23d48eafcb5f67842624da65314c6a8db7bb2cabef66059d13104e99df9e8194ed8cb07aec6bb41d15f7bbf5ceabb514d8dc7a9ec8ef4b5e99f6ec1fa6",
+    "url": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+    "sha512": "6165938e000148a72fb3f9d6062f4fc9c63f2623c9a8e0f8240ea8f527a3d80b6f4866ab5f1282dce412938a406ab6dd4252808790f814242424d916f86027df",
     "dest": "flatpak-node/npm",
-    "dest-filename": "qs-fb7f2a23d48eafcb5f67842624da65314c6a8db7bb2cabef66059d13104e99df9e8194ed8cb07aec6bb41d15f7bbf5ceabb514d8dc7a9ec8ef4b5e99f6ec1fa6"
+    "dest-filename": "qs-6165938e000148a72fb3f9d6062f4fc9c63f2623c9a8e0f8240ea8f527a3d80b6f4866ab5f1282dce412938a406ab6dd4252808790f814242424d916f86027df"
   },
   {
     "type": "file",
@@ -1625,17 +2094,38 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-    "sha512": "f331aaca97c4363088a868605d3a02f1a076afb62b057f804007c83ecfcc964f81b4f4f3b4ebd34b4d4d456ff7121eb427e6b8f25b7caac0b38ab43a9680957c",
+    "url": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+    "sha512": "f46f1c03eb6e312ef9fba1bf4f35bc3ad2f39810cca3ca75251c4de4067e2c0a7cbb1180f15f06666e06438fcde503501272e683a492ef0cae4a66ca7a988aa8",
     "dest": "flatpak-node/npm",
-    "dest-filename": "raw-body-f331aaca97c4363088a868605d3a02f1a076afb62b057f804007c83ecfcc964f81b4f4f3b4ebd34b4d4d456ff7121eb427e6b8f25b7caac0b38ab43a9680957c"
+    "dest-filename": "raw-body-f46f1c03eb6e312ef9fba1bf4f35bc3ad2f39810cca3ca75251c4de4067e2c0a7cbb1180f15f06666e06438fcde503501272e683a492ef0cae4a66ca7a988aa8"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
-    "sha512": "c83333f60f9569992a0584bfa33a012706818536d9a3750d6101cd470d43dd415007ca07078b92fed00e0cef992e31969946ca9c894e58ef9a688880c6b5161c",
+    "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+    "sha512": "71fe8bd83b37879ed55669197be3e7fb900fb13ec5a6a26d1218627830afac4d8c2b9424f4cc9f7e0432bb14139ba04285f79936d70e2c7a7d21c59155c21c05",
     "dest": "flatpak-node/npm",
-    "dest-filename": "readdirp-c83333f60f9569992a0584bfa33a012706818536d9a3750d6101cd470d43dd415007ca07078b92fed00e0cef992e31969946ca9c894e58ef9a688880c6b5161c"
+    "dest-filename": "iconv-lite-71fe8bd83b37879ed55669197be3e7fb900fb13ec5a6a26d1218627830afac4d8c2b9424f4cc9f7e0432bb14139ba04285f79936d70e2c7a7d21c59155c21c05"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+    "sha512": "18387090b7f2c162f6b3abc48f286b8be79799f1fa8f52fb244dbb5a1a8b798ce887f0370c16981848f61ff1c56429ff90c7e29bbdc55f11094f0d3a5adc50c2",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "readdirp-18387090b7f2c162f6b3abc48f286b8be79799f1fa8f52fb244dbb5a1a8b798ce887f0370c16981848f61ff1c56429ff90c7e29bbdc55f11094f0d3a5adc50c2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+    "sha512": "a5bfcc6265ecb40932b11171f2988d235b4614d408140def904dc6ab812e035745ea01e9ffebe066ab021896a9bf2f0ddd0fb8a3b170beab8f25c9d9ed1632e2",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "resolve-from-a5bfcc6265ecb40932b11171f2988d235b4614d408140def904dc6ab812e035745ea01e9ffebe066ab021896a9bf2f0ddd0fb8a3b170beab8f25c9d9ed1632e2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+    "sha512": "9cb4eb50a9b653288beeb9616a9bbf665e3917036091919a0a965b2076a30d883094908eccb4a4f9c20f027b04a95f79e468c82c99ca6dd402d6754fcfe80061",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "router-9cb4eb50a9b653288beeb9616a9bbf665e3917036091919a0a965b2076a30d883094908eccb4a4f9c20f027b04a95f79e468c82c99ca6dd402d6754fcfe80061"
   },
   {
     "type": "file",
@@ -1653,24 +2143,17 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-    "sha512": "756e35bb955f2d7bbc4898796f0466c9851b028481ddcf6e421e8bf21fcab6c15110f5a96d7d65ae58c9a35f3a25ce2799c8bfb06519f5ad1ad09db381fab687",
+    "url": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+    "sha512": "b9a5b45b05caa4bf5b957136a346d18682f61065c8ad9c50d994389a071fa01c5d16642895dfaa5ac0f68cbadf674b6b8ca2fabcec348fffde0307002c58ca4b",
     "dest": "flatpak-node/npm",
-    "dest-filename": "send-756e35bb955f2d7bbc4898796f0466c9851b028481ddcf6e421e8bf21fcab6c15110f5a96d7d65ae58c9a35f3a25ce2799c8bfb06519f5ad1ad09db381fab687"
+    "dest-filename": "send-b9a5b45b05caa4bf5b957136a346d18682f61065c8ad9c50d994389a071fa01c5d16642895dfaa5ac0f68cbadf674b6b8ca2fabcec348fffde0307002c58ca4b"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-    "sha512": "4cf257abc26a15a5589b609698fbe73f6232a3865233bfd029c4a6b8c2c339b7e91f97e2ed150699dfeb4c37feaeeb7fb1a88389011e5533600262447403b1d3",
+    "url": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+    "sha512": "eb583da4287456787b22eb598ed2c61a94c0df9e7e38f9f64f20efffa8af3f687f01d0155fd6b3b28c66836fccea765e419358044c0872c9ded6625df68408b5",
     "dest": "flatpak-node/npm",
-    "dest-filename": "encodeurl-4cf257abc26a15a5589b609698fbe73f6232a3865233bfd029c4a6b8c2c339b7e91f97e2ed150699dfeb4c37feaeeb7fb1a88389011e5533600262447403b1d3"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-    "sha512": "56aa6325929a75007f3c46c4c2f15d3b8dc0c79745059d94102b33cfc6d0ee98bbc2dfff3d67b53fa30dede0a78ec6ad62d053e84ba20a56e34963f65ab2284f",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "serve-static-56aa6325929a75007f3c46c4c2f15d3b8dc0c79745059d94102b33cfc6d0ee98bbc2dfff3d67b53fa30dede0a78ec6ad62d053e84ba20a56e34963f65ab2284f"
+    "dest-filename": "serve-static-eb583da4287456787b22eb598ed2c61a94c0df9e7e38f9f64f20efffa8af3f687f01d0155fd6b3b28c66836fccea765e419358044c0872c9ded6625df68408b5"
   },
   {
     "type": "file",
@@ -1678,6 +2161,20 @@
     "sha512": "1392c35fb5aba7ce4a8a5e5b859bf8ea3f2339e6e82aae4932660cde05467461fcc45a4f59750cb0dae53830ab928c4c11e362fd7648c2e46f6385cdc18309a7",
     "dest": "flatpak-node/npm",
     "dest-filename": "setprototypeof-1392c35fb5aba7ce4a8a5e5b859bf8ea3f2339e6e82aae4932660cde05467461fcc45a4f59750cb0dae53830ab928c4c11e362fd7648c2e46f6385cdc18309a7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+    "sha512": "907c6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "shebang-command-907c6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+    "sha512": "efef9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "shebang-regex-efef9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4"
   },
   {
     "type": "file",
@@ -1709,10 +2206,17 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-    "sha512": "470340f59ffb3eb2b4eab60b23314c95a17e97bde2c29ceca9120581b30b6d370b0fa70e6a8f364da59e7cf5d0bc1d9f382e008ee612127752ecdfe64c26e475",
+    "url": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+    "sha512": "0ef132e795770c1eee927468fb888e193e5f3f5b2547cc10a2155d9278a064f32932cb5a289416870898040089137525da94e70138a18416274616501c606247",
     "dest": "flatpak-node/npm",
-    "dest-filename": "statuses-470340f59ffb3eb2b4eab60b23314c95a17e97bde2c29ceca9120581b30b6d370b0fa70e6a8f364da59e7cf5d0bc1d9f382e008ee612127752ecdfe64c26e475"
+    "dest-filename": "statuses-0ef132e795770c1eee927468fb888e193e5f3f5b2547cc10a2155d9278a064f32932cb5a289416870898040089137525da94e70138a18416274616501c606247"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+    "sha512": "e9f3dcf91e22870a8fe8dfda22fd9fd60307f25395b56407a2a0b8c8aea8483555a1cba602c7c2aa39179ea89832198cc12fe61072e9ed57a196ddea97a9448a",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "strip-json-comments-e9f3dcf91e22870a8fe8dfda22fd9fd60307f25395b56407a2a0b8c8aea8483555a1cba602c7c2aa39179ea89832198cc12fe61072e9ed57a196ddea97a9448a"
   },
   {
     "type": "file",
@@ -1730,10 +2234,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-    "sha512": "4e444aafdb144f1107f0c75fb8248fed58b3272cd134c8e3d89d9da3626bdcaca6e7df0955d124b2eccf4029e514f5b8932f50fa203e99af411a6d3a5d0072f2",
+    "url": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+    "sha512": "399b3a82c8c5e2f329df6aab09b8954a4ac5997b46fc0661637b7488032b30188067257da002ed5cef21b2b1db31717dc7a2f782b945bb05b6a00cfb71abfe1b",
     "dest": "flatpak-node/npm",
-    "dest-filename": "type-is-4e444aafdb144f1107f0c75fb8248fed58b3272cd134c8e3d89d9da3626bdcaca6e7df0955d124b2eccf4029e514f5b8932f50fa203e99af411a6d3a5d0072f2"
+    "dest-filename": "type-is-399b3a82c8c5e2f329df6aab09b8954a4ac5997b46fc0661637b7488032b30188067257da002ed5cef21b2b1db31717dc7a2f782b945bb05b6a00cfb71abfe1b"
   },
   {
     "type": "file",
@@ -1751,10 +2255,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-    "sha512": "a4c653bc8913d5df93146bc33aaa1d39c971d105a49208ba4dda1af200bc7df18002acfda733d36560326dbb071e8103ff3b4cb64bff5686136324a1527f3584",
+    "url": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+    "sha512": "eeb294cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06",
     "dest": "flatpak-node/npm",
-    "dest-filename": "utils-merge-a4c653bc8913d5df93146bc33aaa1d39c971d105a49208ba4dda1af200bc7df18002acfda733d36560326dbb071e8103ff3b4cb64bff5686136324a1527f3584"
+    "dest-filename": "uri-js-eeb294cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06"
   },
   {
     "type": "file",
@@ -1762,6 +2266,34 @@
     "sha512": "04d19b58b7ddd1e50f69b8645d4566d23f2ebaf444c93879a2f45afddca8c3f06a01b649c82fb97d4f88cd03b39802b362a6110084a8461750af778867f3d7aa",
     "dest": "flatpak-node/npm",
     "dest-filename": "vary-04d19b58b7ddd1e50f69b8645d4566d23f2ebaf444c93879a2f45afddca8c3f06a01b649c82fb97d4f88cd03b39802b362a6110084a8461750af778867f3d7aa"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+    "sha512": "04b2374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "which-04b2374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+    "sha512": "04ddb607979a30c23d50cb63ac677983978260fa423c3532d052576d8b1a4f9cd8c6314e7244b9dd2403137a56915a16a475d56f706b61c10de13c1ae7907970",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "word-wrap-04ddb607979a30c23d50cb63ac677983978260fa423c3532d052576d8b1a4f9cd8c6314e7244b9dd2403137a56915a16a475d56f706b61c10de13c1ae7907970"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+    "sha512": "9784a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "wrappy-9784a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+    "sha512": "ad592cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "yocto-queue-ad592cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9"
   },
   {
     "type": "file",
@@ -1884,10 +2416,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
-    "sha512": "7643b97e14bbfbfa28b387225b1c84ca359ee3cce61bac1b0a17a8fc6d999c7c787ecdc453a602e9433cae4e7a8008cd27d3f73131f68e8e636fddbf2bac1b9e",
+    "url": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+    "sha512": "f0fbdc5dfef48130d9060b7da6dc49f1e9417818dc2ce01c3ada0efe63c98ed8e2d7e09d19b1e09bbee89b51abb0fc6c884fae5c8a4d48aeb8518688c105dde1",
     "dest": "flatpak-node/npm",
-    "dest-filename": "babel__traverse-7643b97e14bbfbfa28b387225b1c84ca359ee3cce61bac1b0a17a8fc6d999c7c787ecdc453a602e9433cae4e7a8008cd27d3f73131f68e8e636fddbf2bac1b9e"
+    "dest-filename": "babel__traverse-f0fbdc5dfef48130d9060b7da6dc49f1e9417818dc2ce01c3ada0efe63c98ed8e2d7e09d19b1e09bbee89b51abb0fc6c884fae5c8a4d48aeb8518688c105dde1"
   },
   {
     "type": "file",
@@ -1919,13 +2451,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-    "sha512": "e7e7cff0ff0c14d0be0326420f1ac1da991914f1b3a90594ce949ebae54bbe6f1531ca2b3586af06aa057312bc6d0cf842c6e7e2850411e9b8c032df732b061c",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "json-schema-e7e7cff0ff0c14d0be0326420f1ac1da991914f1b3a90594ce949ebae54bbe6f1531ca2b3586af06aa057312bc6d0cf842c6e7e2850411e9b8c032df732b061c"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
     "sha512": "050e5a64d482a63ec3e8ada4b2b4424e62912c4a673ef58388b3dfa06ca167efbc62d88af5dff70c128f260af2df9f57fcfd4f7ebbb2630be7bf0163b8488422",
     "dest": "flatpak-node/npm",
@@ -1940,10 +2465,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@types/node/-/node-22.15.31.tgz",
-    "sha512": "8e755ee542ca97ab628f1521bd078d6d01bff387c77e0fb231a934d9c4fc415841c7f174e6b015c421816184e1d842b3db60fa245e64b57b8dc1dc7b6fd8841b",
+    "url": "https://registry.npmjs.org/@types/node/-/node-22.17.1.tgz",
+    "sha512": "cb7b416b3fab8eca434f294d8c05f7ee3102dd311310518d24beae403c7017dffc18b2c88d6d6bbd51e5ca7cae50a32732bd51a2af233afdef928a418c2e3f54",
     "dest": "flatpak-node/npm",
-    "dest-filename": "node-8e755ee542ca97ab628f1521bd078d6d01bff387c77e0fb231a934d9c4fc415841c7f174e6b015c421816184e1d842b3db60fa245e64b57b8dc1dc7b6fd8841b"
+    "dest-filename": "node-cb7b416b3fab8eca434f294d8c05f7ee3102dd311310518d24beae403c7017dffc18b2c88d6d6bbd51e5ca7cae50a32732bd51a2af233afdef928a418c2e3f54"
   },
   {
     "type": "file",
@@ -2157,10 +2682,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-    "sha512": "d9600b7d3978c68d9290609846deab0d315f93d475733981bd4432d7680ad8ab91288a5612171b6f3cbc1195edcff8e446a1d7f1b14473a142d478d7e1351663",
+    "url": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+    "sha512": "710cd60ad3ba0bc4d0898975aee28d9f653a028e28e1604171b2fad72265f38c7e8f9b0e596154f57ec3a4d0fc5d91b775a0e9a52b2280c75f008976ba940147",
     "dest": "flatpak-node/npm",
-    "dest-filename": "xmldom-d9600b7d3978c68d9290609846deab0d315f93d475733981bd4432d7680ad8ab91288a5612171b6f3cbc1195edcff8e446a1d7f1b14473a142d478d7e1351663"
+    "dest-filename": "xmldom-710cd60ad3ba0bc4d0898975aee28d9f653a028e28e1604171b2fad72265f38c7e8f9b0e596154f57ec3a4d0fc5d91b775a0e9a52b2280c75f008976ba940147"
   },
   {
     "type": "file",
@@ -2185,10 +2710,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-    "sha512": "9e77bdfc8890fe1cc8858ea97439db06dcfb0e33d32ab634d0fff3bcf4a6e69385925eb1b86ac69d79ff56d4cd35f36d01f67dff546d7a192ccd4f6a7138a2d1",
+    "url": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+    "sha512": "00ed9a73aa63441dd2266189a3ebf9fda2ba3a6820a7a7ec2ebb3ac0df5b777e6e96ee1c0b068053dfbb6615e37aa1d591a1d384bbb31f49d9af462908387282",
     "dest": "flatpak-node/npm",
-    "dest-filename": "abbrev-9e77bdfc8890fe1cc8858ea97439db06dcfb0e33d32ab634d0fff3bcf4a6e69385925eb1b86ac69d79ff56d4cd35f36d01f67dff546d7a192ccd4f6a7138a2d1"
+    "dest-filename": "abbrev-00ed9a73aa63441dd2266189a3ebf9fda2ba3a6820a7a7ec2ebb3ac0df5b777e6e96ee1c0b068053dfbb6615e37aa1d591a1d384bbb31f49d9af462908387282"
   },
   {
     "type": "file",
@@ -2199,17 +2724,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-    "sha512": "8d1479c1dca5abc0a439eea17a2d7d186667c4ceab046c05977060d1822d1838a6be31ad02f7599383eee82978bb8220b30b386b57ddd55ab77b3ae19f82a617",
+    "url": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+    "sha512": "32703e613f1fc1f24f801c779bad0c36a6a49b7d173a4c88a07d72ea1b9342f0b43f0646ee48bc35a70b05cacf6cda28f2f119cbb269ba4efe8cc3be094a2f4d",
     "dest": "flatpak-node/npm",
-    "dest-filename": "agent-base-8d1479c1dca5abc0a439eea17a2d7d186667c4ceab046c05977060d1822d1838a6be31ad02f7599383eee82978bb8220b30b386b57ddd55ab77b3ae19f82a617"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-    "sha512": "9236bc8fb3e39a770e36a693b01f1f43ec04da6494d8327d0f85caa09e4f15621d44c6ba48b48dd5f7f898eaf88c26df452b3147891e222c92254d0df53e6121",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "agentkeepalive-9236bc8fb3e39a770e36a693b01f1f43ec04da6494d8327d0f85caa09e4f15621d44c6ba48b48dd5f7f898eaf88c26df452b3147891e222c92254d0df53e6121"
+    "dest-filename": "agent-base-32703e613f1fc1f24f801c779bad0c36a6a49b7d173a4c88a07d72ea1b9342f0b43f0646ee48bc35a70b05cacf6cda28f2f119cbb269ba4efe8cc3be094a2f4d"
   },
   {
     "type": "file",
@@ -2217,13 +2735,6 @@
     "sha512": "e08ed3774d6ab96fd1a6871f35ac85745564d6a4aea21d04ec9adb449d7a9c7d351e128543cf0836af5277e9ddef6cea4724a5afd0660c0f3194427abc932b60",
     "dest": "flatpak-node/npm",
     "dest-filename": "aggregate-error-e08ed3774d6ab96fd1a6871f35ac85745564d6a4aea21d04ec9adb449d7a9c7d351e128543cf0836af5277e9ddef6cea4724a5afd0660c0f3194427abc932b60"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-    "sha512": "8f77d52e0bd3a39dbb6a7c98c893864d825b1bebe79d062f1349b99a691cd532be9f1029a6408b3082f4699e1d6e55423681928619be933138654ca4068320e2",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "ajv-8f77d52e0bd3a39dbb6a7c98c893864d825b1bebe79d062f1349b99a691cd532be9f1029a6408b3082f4699e1d6e55423681928619be933138654ca4068320e2"
   },
   {
     "type": "file",
@@ -2262,10 +2773,38 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.0.12.tgz",
-    "sha512": "fbf0843c7d5f54a7fa1e8c0152ce8b70022845c8deaa0bc07a8484f9c97b63b2e777243d56218f6226cd93bc2684c1f33601c8b886f0e275800cf3bee268e05b",
+    "url": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.1.0.tgz",
+    "sha512": "7715841888134cf0fc3a260df17ea7dcf577d7e0c5c2f3fda725c2143b15e5fcadea0fb44cc654557ac246b48f8f4f97fe98413da779b0d3cb2ef0510d50cf69",
     "dest": "flatpak-node/npm",
-    "dest-filename": "app-builder-lib-fbf0843c7d5f54a7fa1e8c0152ce8b70022845c8deaa0bc07a8484f9c97b63b2e777243d56218f6226cd93bc2684c1f33601c8b886f0e275800cf3bee268e05b"
+    "dest-filename": "app-builder-lib-7715841888134cf0fc3a260df17ea7dcf577d7e0c5c2f3fda725c2143b15e5fcadea0fb44cc654557ac246b48f8f4f97fe98413da779b0d3cb2ef0510d50cf69"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
+    "sha512": "cf1d0422aefc5a563f9416f5b97973899983648e2e6dc09720c278b868d7cd95b49d2d7d4e348f7973c08f3cd398a425254666d126e66613ca3fbb6e4354ac13",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "fuses-cf1d0422aefc5a563f9416f5b97973899983648e2e6dc09720c278b868d7cd95b49d2d7d4e348f7973c08f3cd398a425254666d126e66613ca3fbb6e4354ac13"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+    "sha512": "2e907fe7807eff627986a43b8a66477dd537d4e96042ac7b6627159649bd93383dff0f0628b11c15f265fedec30840ee78ec81003eb3082c133ba173b3436811",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "isexe-2e907fe7807eff627986a43b8a66477dd537d4e96042ac7b6627159649bd93383dff0f0628b11c15f265fedec30840ee78ec81003eb3082c133ba173b3436811"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+    "sha512": "445d05c3eacee4031ff4c0326915c8e005745258f994c1ea571c5d4a08956e2c52097a049a65ff8e4d02b89c38fb74aaae860ef55a1487e1dcb898afbed25e98",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "semver-445d05c3eacee4031ff4c0326915c8e005745258f994c1ea571c5d4a08956e2c52097a049a65ff8e4d02b89c38fb74aaae860ef55a1487e1dcb898afbed25e98"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+    "sha512": "244746cc7c3092b6d6a063a5207a90e60b69aca18e7a7a431e9c44f73551d5b59b3ad611c8f3c731ef4568feb1eb50a635a4d385291bd03009b5ee630fe0e6cd",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "which-244746cc7c3092b6d6a063a5207a90e60b69aca18e7a7a431e9c44f73551d5b59b3ad611c8f3c731ef4568feb1eb50a635a4d385291bd03009b5ee630fe0e6cd"
   },
   {
     "type": "file",
@@ -2402,13 +2941,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-    "sha512": "86d0940e5c72c822cc81a337c578340b42d6db1a9fb90ea9d39a42108b17bb243e6b592860a4ee04ccd13709b26df2e0bc90cc774af52d39f8f84d138ba0b600",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "async-86d0940e5c72c822cc81a337c578340b42d6db1a9fb90ea9d39a42108b17bb243e6b592860a4ee04ccd13709b26df2e0bc90cc774af52d39f8f84d138ba0b600"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/async-each/-/async-each-1.0.6.tgz",
     "sha512": "73ae3a8c7d5abf1afe695a6775531e01f630ef001aea276e7eb94ddcb3c0e0f98a4b44041a9e8f202f67c33d1642492f04600c1248b7a4576dc5a177f49f6fbe",
     "dest": "flatpak-node/npm",
@@ -2420,13 +2952,6 @@
     "sha512": "356d9c5fc9b543b28f03b6b933650b41e676c11e6a2393c06f0e4bd1438cc5d8a8564f4f319d21d539b264490f62b0af6230e51480aeb0ebb576510a00079707",
     "dest": "flatpak-node/npm",
     "dest-filename": "async-exit-hook-356d9c5fc9b543b28f03b6b933650b41e676c11e6a2393c06f0e4bd1438cc5d8a8564f4f319d21d539b264490f62b0af6230e51480aeb0ebb576510a00079707"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/async-limiter/-/async-limiter-2.0.0.tgz",
-    "sha512": "9f21c5cef55a47ee267c773dd3f56a39442396793dfa2a03c507ea0eea8a9e6de6f6c213ee3a15296f1d93179a2a96a6309dcc603ef7b7a33c3cc2845a540449",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "async-limiter-9f21c5cef55a47ee267c773dd3f56a39442396793dfa2a03c507ea0eea8a9e6de6f6c213ee3a15296f1d93179a2a96a6309dcc603ef7b7a33c3cc2845a540449"
   },
   {
     "type": "file",
@@ -2476,6 +3001,13 @@
     "sha512": "52381aa6e99695b3219018334fb624739617513e3a17488abbc4865ead1b7303f9773fe1d0f963e9e9c9aa3cf565bab697959aa989eb55bc16396332177178ee",
     "dest": "flatpak-node/npm",
     "dest-filename": "source-map-52381aa6e99695b3219018334fb624739617513e3a17488abbc4865ead1b7303f9773fe1d0f963e9e9c9aa3cf565bab697959aa989eb55bc16396332177178ee"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+    "sha512": "c2f52306d48637bfbb4a3369abff4cd93837e745190f7abad881592db4404756d23250a8d5969e5be049f83d3dd1ee2120864b05c4c359ee0c8788ef5036a3cd",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "available-typed-arrays-c2f52306d48637bfbb4a3369abff4cd93837e745190f7abad881592db4404756d23250a8d5969e5be049f83d3dd1ee2120864b05c4c359ee0c8788ef5036a3cd"
   },
   {
     "type": "file",
@@ -2556,24 +3088,24 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz",
-    "sha512": "dec5ff78e9acf24777ab6299e8302128f7347609b9db91aaab936d58a67b41861912fe7b390e782ad6e5cc9cc7d65405fde4313bc2a358620af483d424dbace6",
+    "url": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
+    "sha512": "0a8d98f705fce78b6ce94f200003d77e7d06980c9cb47b8af27d1885f8ddeaddf483bcaf2a3b29bef3a8f721becf9d8f65180512bb7b29ada96275c28cb284a6",
     "dest": "flatpak-node/npm",
-    "dest-filename": "babel-plugin-polyfill-corejs2-dec5ff78e9acf24777ab6299e8302128f7347609b9db91aaab936d58a67b41861912fe7b390e782ad6e5cc9cc7d65405fde4313bc2a358620af483d424dbace6"
+    "dest-filename": "babel-plugin-polyfill-corejs2-0a8d98f705fce78b6ce94f200003d77e7d06980c9cb47b8af27d1885f8ddeaddf483bcaf2a3b29bef3a8f721becf9d8f65180512bb7b29ada96275c28cb284a6"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
-    "sha512": "c860aabc14f8af031cce8dbcc641ff9e8c49e8c6789c97e45587680da0bfbad2ed5ab5f1bf6ec756bcc07926ea47c4b10eca78ea7d18178ec46c7a22c72eab5d",
+    "url": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
+    "sha512": "53e18dc0c752160cd599f84d9bc189517f3c01a741deea3d2a926a4b715aa8d20f2a0c92baf31bf9b1cfb0e9a6b96c8872ea998ffa73b75454214667b38cb6f8",
     "dest": "flatpak-node/npm",
-    "dest-filename": "babel-plugin-polyfill-corejs3-c860aabc14f8af031cce8dbcc641ff9e8c49e8c6789c97e45587680da0bfbad2ed5ab5f1bf6ec756bcc07926ea47c4b10eca78ea7d18178ec46c7a22c72eab5d"
+    "dest-filename": "babel-plugin-polyfill-corejs3-53e18dc0c752160cd599f84d9bc189517f3c01a741deea3d2a926a4b715aa8d20f2a0c92baf31bf9b1cfb0e9a6b96c8872ea998ffa73b75454214667b38cb6f8"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.4.tgz",
-    "sha512": "ee00f7a5169d3eb6e38632f2c5e6e6c7f5ab15872e4a36745db754ba340c67f7dc13da1e7b093653fecf0af7b3f3851eb8ade84a398f6740a1d1d96ea50bc6cf",
+    "url": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
+    "sha512": "212a90d9fadb88d53dbc8264ce0edd94fa739cf6788ce894435b92981d1f1077a8c2d37708e611b17affc5ec67eb8369535dcfd3a8dcfcbe538222573a0adb12",
     "dest": "flatpak-node/npm",
-    "dest-filename": "babel-plugin-polyfill-regenerator-ee00f7a5169d3eb6e38632f2c5e6e6c7f5ab15872e4a36745db754ba340c67f7dc13da1e7b093653fecf0af7b3f3851eb8ade84a398f6740a1d1d96ea50bc6cf"
+    "dest-filename": "babel-plugin-polyfill-regenerator-212a90d9fadb88d53dbc8264ce0edd94fa739cf6788ce894435b92981d1f1077a8c2d37708e611b17affc5ec67eb8369535dcfd3a8dcfcbe538222573a0adb12"
   },
   {
     "type": "file",
@@ -2696,13 +3228,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-    "sha512": "f53f548d6debd145b973543b193c25969b57c21bd8984cc587331f67d1fb1505adfae65e3e364f8c13ff5b5644c99d6dc065a89b9ff9e9317894f72a8e70c772",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "brace-expansion-f53f548d6debd145b973543b193c25969b57c21bd8984cc587331f67d1fb1505adfae65e3e364f8c13ff5b5644c99d6dc065a89b9ff9e9317894f72a8e70c772"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
     "sha512": "c906d780efce499543d88b222e5ae8fbb1dfe90d7c109aca484b1da0ccca78f29772dde0bc3f282dc390748cc6ba9af9163f840def203bf9717350737cca71bc",
     "dest": "flatpak-node/npm",
@@ -2773,10 +3298,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
-    "sha512": "3c9f2060a792e5eff0847061f31af060af9d02f123ec95edcfab93b9c9cc441f0e8864ec29c7057a4a11ae36a33c11d5f28398fb6b48e2ec5e71e4a298ac0c14",
+    "url": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.2.tgz",
+    "sha512": "d2c8b64892b7a281b321ac11bbad5974f08ed489dc6704bc233b97ef7b0f66c5d6e8443fc3f0c07cfc8a23c9751134c2af6327bea5a2b6694253181dba5e398c",
     "dest": "flatpak-node/npm",
-    "dest-filename": "browserslist-3c9f2060a792e5eff0847061f31af060af9d02f123ec95edcfab93b9c9cc441f0e8864ec29c7057a4a11ae36a33c11d5f28398fb6b48e2ec5e71e4a298ac0c14"
+    "dest-filename": "browserslist-d2c8b64892b7a281b321ac11bbad5974f08ed489dc6704bc233b97ef7b0f66c5d6e8443fc3f0c07cfc8a23c9751134c2af6327bea5a2b6694253181dba5e398c"
   },
   {
     "type": "file",
@@ -2843,17 +3368,17 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/builder-util/-/builder-util-26.0.11.tgz",
-    "sha512": "c4d8d77ec95d5047b5e778750eb683d17bc33a9a864742f978a164751781ede156e47ab2b036457e5cb8adc91d6bacbd745dfd377a643e539b95c7c7286c3eb8",
+    "url": "https://registry.npmjs.org/builder-util/-/builder-util-26.1.0.tgz",
+    "sha512": "0535219a9902b8400052673c1099093a0edf306b0349244c3e7d504e9a14a58a46a774a3c89575f0b9423d3bb7f9405fb90ff9b9aecaa832ebb0af4d0173bb7e",
     "dest": "flatpak-node/npm",
-    "dest-filename": "builder-util-c4d8d77ec95d5047b5e778750eb683d17bc33a9a864742f978a164751781ede156e47ab2b036457e5cb8adc91d6bacbd745dfd377a643e539b95c7c7286c3eb8"
+    "dest-filename": "builder-util-0535219a9902b8400052673c1099093a0edf306b0349244c3e7d504e9a14a58a46a774a3c89575f0b9423d3bb7f9405fb90ff9b9aecaa832ebb0af4d0173bb7e"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.3.1.tgz",
-    "sha512": "dbf7a0acd0c39d16b15702b703e709aba50e96a39d79d180ec93ea09e263376663935fd007fe90522ddbef5e12708192ec769f1574f2cc910eaf96f8e08de4bd",
+    "url": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.0.tgz",
+    "sha512": "eea991307f17fc8cc333ed53cac28d168e5c35605b7da71d2d7e04aa4b84e5a8914c408095888a1d2a8473a71cddce0bae6a60934bad6f138f923d2261a58059",
     "dest": "flatpak-node/npm",
-    "dest-filename": "builder-util-runtime-dbf7a0acd0c39d16b15702b703e709aba50e96a39d79d180ec93ea09e263376663935fd007fe90522ddbef5e12708192ec769f1574f2cc910eaf96f8e08de4bd"
+    "dest-filename": "builder-util-runtime-eea991307f17fc8cc333ed53cac28d168e5c35605b7da71d2d7e04aa4b84e5a8914c408095888a1d2a8473a71cddce0bae6a60934bad6f138f923d2261a58059"
   },
   {
     "type": "file",
@@ -2934,17 +3459,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-    "sha512": "3fc06302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69",
+    "url": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001734.tgz",
+    "sha512": "ba113561ee6f82a8eee8e23bd474d0a9c04266bbc7ba09343232da93b43e1dfa01828ab9062fb9627c233f87e30e0aed62bfe5f0c55106fcf3f5d3c3e0ac8ad0",
     "dest": "flatpak-node/npm",
-    "dest-filename": "callsites-3fc06302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001722.tgz",
-    "sha512": "0c240704166d88ae89564006c3b76bbc030ad10d0f383ff166f1260e9e9b6a230c3fa4175e4f47a43ea63580595a138f1ba2ef2036fcd884eab568e10dc90708",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "caniuse-lite-0c240704166d88ae89564006c3b76bbc030ad10d0f383ff166f1260e9e9b6a230c3fa4175e4f47a43ea63580595a138f1ba2ef2036fcd884eab568e10dc90708"
+    "dest-filename": "caniuse-lite-ba113561ee6f82a8eee8e23bd474d0a9c04266bbc7ba09343232da93b43e1dfa01828ab9062fb9627c233f87e30e0aed62bfe5f0c55106fcf3f5d3c3e0ac8ad0"
   },
   {
     "type": "file",
@@ -2983,10 +3501,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-    "sha512": "348c45e7986fe274aa42cc2401e88e8b5afcdf1cbc26574e1434d68ae839e4a06ef499db96771dd94e958879988077f4d533d94bbecd24184130a7568fd1d031",
+    "url": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+    "sha512": "59dcb6220bbc39c069236a5978f679a168cf0b7f2d983571e562945cac252d8900d28ce8f39b0bb0bbe405b067fec65a482305386649d787ef5bdb79fddee474",
     "dest": "flatpak-node/npm",
-    "dest-filename": "ci-info-348c45e7986fe274aa42cc2401e88e8b5afcdf1cbc26574e1434d68ae839e4a06ef499db96771dd94e958879988077f4d533d94bbecd24184130a7568fd1d031"
+    "dest-filename": "ci-info-59dcb6220bbc39c069236a5978f679a168cf0b7f2d983571e562945cac252d8900d28ce8f39b0bb0bbe405b067fec65a482305386649d787ef5bdb79fddee474"
   },
   {
     "type": "file",
@@ -3137,27 +3655,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.8-rc1.tgz",
-    "sha512": "1ad34409b548f366d3e1188323305256e4caa121ee7e753b09eeffe366e459925914b8e60c5d9606956cbd19212827ca0674c16f7a99ac1c0fa45054fcccaf86",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "config-file-ts-1ad34409b548f366d3e1188323305256e4caa121ee7e753b09eeffe366e459925914b8e60c5d9606956cbd19212827ca0674c16f7a99ac1c0fa45054fcccaf86"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-    "sha512": "ec1bfc445d24eb18e8edde00fcfc582db5027dbe9cf95a5ddbf981db244395ec3b25be611178820fd89b7ceef0a64f22e2c7af2ba0c59f2f61ec461b337fec1e",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "glob-ec1bfc445d24eb18e8edde00fcfc582db5027dbe9cf95a5ddbf981db244395ec3b25be611178820fd89b7ceef0a64f22e2c7af2ba0c59f2f61ec461b337fec1e"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-    "sha512": "a8e3b34b57014d6605e011fc7d578f0c138ef62a6d327194119c0d73f70c5a74d5da754b67b56835610f1e461ccd9034a5da00edd97a7bb14beb9f675fd4b66b",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "minipass-a8e3b34b57014d6605e011fc7d578f0c138ef62a6d327194119c0d73f70c5a74d5da754b67b56835610f1e461ccd9034a5da00edd97a7bb14beb9f675fd4b66b"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
     "sha512": "64c9183bf2e4175ed0bc23ea334831c3cc94ce28003993925921e0f75147ea8ad2eef7048f975565389d3767d0d78c8149d83ded1aa148dc0b517227779d8e4c",
     "dest": "flatpak-node/npm",
@@ -3172,10 +3669,24 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+    "sha512": "16f7994cdb86c34e1cc6502259bce2eb34c02ff9617a16966d3b6096e261e3f13de43a8cc139a16b7299375680580f1c148847ccc654bcb7af930e51aa4fad49",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "content-disposition-16f7994cdb86c34e1cc6502259bce2eb34c02ff9617a16966d3b6096e261e3f13de43a8cc139a16b7299375680580f1c148847ccc654bcb7af930e51aa4fad49"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
     "sha512": "2afa78e7d1eb576144275080b22d4abbe318de46ac1f5f53172913cf6c5698c7aae9b936354dd75ef7c9f90eb59b4c64b56c2dfb51d261fdc966c4e6b3769126",
     "dest": "flatpak-node/npm",
     "dest-filename": "convert-source-map-2afa78e7d1eb576144275080b22d4abbe318de46ac1f5f53172913cf6c5698c7aae9b936354dd75ef7c9f90eb59b4c64b56c2dfb51d261fdc966c4e6b3769126"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+    "sha512": "ca48b95e72ae7fbe74979d2e193965b7a90a20b6389d0d5e34841ab685c40726797568272aa6e7aa64eb044e41e0dee5acc24a436cad58c8933b6a34bfa130ff",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "cookie-ca48b95e72ae7fbe74979d2e193965b7a90a20b6389d0d5e34841ab685c40726797568272aa6e7aa64eb044e41e0dee5acc24a436cad58c8933b6a34bfa130ff"
   },
   {
     "type": "file",
@@ -3207,10 +3718,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.43.0.tgz",
-    "sha512": "d8630bd99b027392d1ee1658cf80179a3430f33bb2d93fffd909edc1d9e9b9823b8ed793e8655824bec5e82d82e7b47b81262b72a556de50002de7dd6e104b0c",
+    "url": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.0.tgz",
+    "sha512": "811a153016b0660d0e9f1695bf7ce9a8b2f16879acb9b106c939ea76923f08406f5f825a748d5d3121f16a04e1a6b611b5255bb90c6f8ba8946ad74fc68847a4",
     "dest": "flatpak-node/npm",
-    "dest-filename": "core-js-compat-d8630bd99b027392d1ee1658cf80179a3430f33bb2d93fffd909edc1d9e9b9823b8ed793e8655824bec5e82d82e7b47b81262b72a556de50002de7dd6e104b0c"
+    "dest-filename": "core-js-compat-811a153016b0660d0e9f1695bf7ce9a8b2f16879acb9b106c939ea76923f08406f5f825a748d5d3121f16a04e1a6b611b5255bb90c6f8ba8946ad74fc68847a4"
   },
   {
     "type": "file",
@@ -3256,17 +3767,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
-    "sha512": "f91d3cfe82349e5def7cf72a7ed651a72b64b015c3cce52f781abf341571d2c529d5ac70ccf42b2a29cdc79c9de6cc4fbbc8f5c08cbc01f9d543ee5e15d85ae9",
+    "url": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+    "sha512": "1ac628b209c00994c00dc984c8972d909228a808478edb70ed1b05ad5a093576ec596a9aaba626fbb9198eaea64b8e4ed238a3eafb6245ea6929012da96cba0f",
     "dest": "flatpak-node/npm",
-    "dest-filename": "cross-dirname-f91d3cfe82349e5def7cf72a7ed651a72b64b015c3cce52f781abf341571d2c529d5ac70ccf42b2a29cdc79c9de6cc4fbbc8f5c08cbc01f9d543ee5e15d85ae9"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-    "sha512": "fbf1ca77a1207100891a1d8f4a366e522b50050ca72a8af8c2b15b460e03b40812d5a58efa0539db1a47eccf52706817498980552f5b209f04cee686c34a0d03",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "cross-env-fbf1ca77a1207100891a1d8f4a366e522b50050ca72a8af8c2b15b460e03b40812d5a58efa0539db1a47eccf52706817498980552f5b209f04cee686c34a0d03"
+    "dest-filename": "cross-env-1ac628b209c00994c00dc984c8972d909228a808478edb70ed1b05ad5a093576ec596a9aaba626fbb9198eaea64b8e4ed238a3eafb6245ea6929012da96cba0f"
   },
   {
     "type": "file",
@@ -3274,13 +3778,6 @@
     "sha512": "96f6f5481b08d19ec60f09ae89dfa6537916541c135546deed2d07e76c9a680750397ab6624b5309976501c34a17313a42d473d2c9e9c3d6cd88f78e224910bf",
     "dest": "flatpak-node/npm",
     "dest-filename": "cross-fetch-96f6f5481b08d19ec60f09ae89dfa6537916541c135546deed2d07e76c9a680750397ab6624b5309976501c34a17313a42d473d2c9e9c3d6cd88f78e224910bf"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-    "sha512": "b95d903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "cross-spawn-b95d903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc"
   },
   {
     "type": "file",
@@ -3508,13 +4005,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-    "sha512": "a083f392c993838fccae289a6063bea245c34fbced9ffc37129b6fffe81221d31d2ac268d2ee027d834524fcbee1228cb82a86c36c319c0f9444c837b7c6bf6d",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "deep-is-a083f392c993838fccae289a6063bea245c34fbced9ffc37129b6fffe81221d31d2ac268d2ee027d834524fcbee1228cb82a86c36c319c0f9444c837b7c6bf6d"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
     "sha512": "785b9a2e8cbf4716a5bf692bfa5a8c9549eb0d657ede3e299633882602c8848d39f0841f589eef5e1c84207bbe1ed0bbdfc9251802d8c4e2833b46d03f7b60f0",
     "dest": "flatpak-node/npm",
@@ -3564,10 +4054,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-    "sha512": "dd40eff86f42b0228ed5628c1b0f5fc2afd258961b23473963b2d4d405d8a0375b844d801d0e8de8d6f7e2c1bc163ed3e403f2f2a5c308abae207775051d2d54",
+    "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+    "sha512": "06d8f604e38ef37a375b21f9f5ef0c817b3111055c6ab9143a9118aee6c1d2eaf09cdd74c90dfae2bb22072535d67665a966199b4e62fe87fb8a8e26ce2841b5",
     "dest": "flatpak-node/npm",
-    "dest-filename": "detect-libc-dd40eff86f42b0228ed5628c1b0f5fc2afd258961b23473963b2d4d405d8a0375b844d801d0e8de8d6f7e2c1bc163ed3e403f2f2a5c308abae207775051d2d54"
+    "dest-filename": "detect-libc-06d8f604e38ef37a375b21f9f5ef0c817b3111055c6ab9143a9118aee6c1d2eaf09cdd74c90dfae2bb22072535d67665a966199b4e62fe87fb8a8e26ce2841b5"
   },
   {
     "type": "file",
@@ -3613,10 +4103,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.0.12.tgz",
-    "sha512": "e7d0800230214da20c08df32f640f9ef7bc39316ecd6e84372b14b1d282eb5874f706394df945ff79ef6e6c9efcc43b2e01141efe78b27c76308d3e61b01baef",
+    "url": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.1.0.tgz",
+    "sha512": "d1e5c1eea5fd607890da8f3710c802f00e9543b05f0853fccf196152daadbeacb59c454865af176ce01c2223fc9dee7c461c0b60a5762c271f3753889971445a",
     "dest": "flatpak-node/npm",
-    "dest-filename": "dmg-builder-e7d0800230214da20c08df32f640f9ef7bc39316ecd6e84372b14b1d282eb5874f706394df945ff79ef6e6c9efcc43b2e01141efe78b27c76308d3e61b01baef"
+    "dest-filename": "dmg-builder-d1e5c1eea5fd607890da8f3710c802f00e9543b05f0853fccf196152daadbeacb59c454865af176ce01c2223fc9dee7c461c0b60a5762c271f3753889971445a"
   },
   {
     "type": "file",
@@ -3697,10 +4187,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-    "sha512": "9bf0be030380afdfd6d54388654a36df67a330d9c9009b5842351b1e835304d4c94afab3cc387bbe7ade8b7a37af79bd6e57fa6680e4bdcc34566a33351149c6",
+    "url": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+    "sha512": "b81ab87a05874dc4eddf76bbdafa521b4cf71e73ee225e8da98713aca120d9ace81329768695b4cea971cacab6a4af47943207c87c9a91e61a627480c1df1ba3",
     "dest": "flatpak-node/npm",
-    "dest-filename": "dotenv-9bf0be030380afdfd6d54388654a36df67a330d9c9009b5842351b1e835304d4c94afab3cc387bbe7ade8b7a37af79bd6e57fa6680e4bdcc34566a33351149c6"
+    "dest-filename": "dotenv-b81ab87a05874dc4eddf76bbdafa521b4cf71e73ee225e8da98713aca120d9ace81329768695b4cea971cacab6a4af47943207c87c9a91e61a627480c1df1ba3"
   },
   {
     "type": "file",
@@ -3858,45 +4348,38 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-    "sha512": "51553d7626ead897055b140f03a282aa3e4ee3654e980637cd051f10ac54d0aa53197c0da028e45f57b5dde1cdbf0ff13f29edea9534ad9d61b63593353497b2",
+    "url": "https://registry.npmjs.org/electron/-/electron-38.3.0.tgz",
+    "sha512": "5a28f80335f84805745ff92dabe36b5aba79a624c2492f05e985a1d4a01c1be411b4dcf29ecf572ca1113faf271472307e9ae1c45d9808ddae8fb9f1f4369e27",
     "dest": "flatpak-node/npm",
-    "dest-filename": "jsbn-51553d7626ead897055b140f03a282aa3e4ee3654e980637cd051f10ac54d0aa53197c0da028e45f57b5dde1cdbf0ff13f29edea9534ad9d61b63593353497b2"
+    "dest-filename": "electron-5a28f80335f84805745ff92dabe36b5aba79a624c2492f05e985a1d4a01c1be411b4dcf29ecf572ca1113faf271472307e9ae1c45d9808ddae8fb9f1f4369e27"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/electron/-/electron-36.4.0.tgz",
-    "sha512": "2cb38e644b96e68aaf9e30bb1c142122a8c820901908816343196d4062df102ed716c068660437bb78858fe2b3c3af178fdeeed67e7b25db7b3fdf2a2ef5226d",
+    "url": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.1.0.tgz",
+    "sha512": "76fcbdb0e0d613bbaacfb97af1ca29800b4ed842ae99d90ba82828a0d5a5edb4858ebb9b3268dfda1552ea2c12adc6fb84b1cbd363942c13cda78e5a78601ca4",
     "dest": "flatpak-node/npm",
-    "dest-filename": "electron-2cb38e644b96e68aaf9e30bb1c142122a8c820901908816343196d4062df102ed716c068660437bb78858fe2b3c3af178fdeeed67e7b25db7b3fdf2a2ef5226d"
+    "dest-filename": "electron-builder-76fcbdb0e0d613bbaacfb97af1ca29800b4ed842ae99d90ba82828a0d5a5edb4858ebb9b3268dfda1552ea2c12adc6fb84b1cbd363942c13cda78e5a78601ca4"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.0.12.tgz",
-    "sha512": "703d64cf9836b203d33051e32f17cc8d42b924006adfffc9e233ecc22f77b4e3c5cfa6edcd762d2b936b0edef5ecd45bba40940ceaebbe661539611196aa225c",
+    "url": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.1.0.tgz",
+    "sha512": "c9ece3ecf9584f6f2ceb4353ba5df4ef5062ce90facee53c684c324d54a7d6d44db276cfc8aa706ccea8de9ac292e5db19ca250716aa3fe4abe63ba998da421a",
     "dest": "flatpak-node/npm",
-    "dest-filename": "electron-builder-703d64cf9836b203d33051e32f17cc8d42b924006adfffc9e233ecc22f77b4e3c5cfa6edcd762d2b936b0edef5ecd45bba40940ceaebbe661539611196aa225c"
+    "dest-filename": "electron-builder-squirrel-windows-c9ece3ecf9584f6f2ceb4353ba5df4ef5062ce90facee53c684c324d54a7d6d44db276cfc8aa706ccea8de9ac292e5db19ca250716aa3fe4abe63ba998da421a"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.0.12.tgz",
-    "sha512": "929c1733b73f6b24546d8544ad06ec6749d0657e1a2c742b3c41bd0b887dbee2425f2970147f1aec9822d95a4a20e6f30973bb2ca1e20b0e0a762a052c53a0a8",
+    "url": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.1.0.tgz",
+    "sha512": "1b08210c83a4e6fccdb5b88c7971c421137ef613d1f1ca93392ccc89d5f8bc20bb53d18587cc21aee845840c9a23a318e589724cd993ef3e8ba4b94ef2770e5b",
     "dest": "flatpak-node/npm",
-    "dest-filename": "electron-builder-squirrel-windows-929c1733b73f6b24546d8544ad06ec6749d0657e1a2c742b3c41bd0b887dbee2425f2970147f1aec9822d95a4a20e6f30973bb2ca1e20b0e0a762a052c53a0a8"
+    "dest-filename": "electron-publish-1b08210c83a4e6fccdb5b88c7971c421137ef613d1f1ca93392ccc89d5f8bc20bb53d18587cc21aee845840c9a23a318e589724cd993ef3e8ba4b94ef2770e5b"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.0.11.tgz",
-    "sha512": "6bc4111f4ac03c8587f56cb24b92db36f5bd02b93aa9eeb7fcba8307bbeed895d8a62d0699ae50eb40e1e2d993aa138142dd31b2bcc3f2a13b0be0fb8fe076e0",
+    "url": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.200.tgz",
+    "sha512": "ac50b144ec3b68e7b8b8f4df200c7ead7bfd704706c7e6ee005e27a6786d4ea0899392831519e1dfe2988fbadd561ea5b05b79fda3ecf88ae3f6b677dd6300ef",
     "dest": "flatpak-node/npm",
-    "dest-filename": "electron-publish-6bc4111f4ac03c8587f56cb24b92db36f5bd02b93aa9eeb7fcba8307bbeed895d8a62d0699ae50eb40e1e2d993aa138142dd31b2bcc3f2a13b0be0fb8fe076e0"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.167.tgz",
-    "sha512": "2f1711be760ee5ecf66cc385a5bbae56e008e5035e6359dc572b44fca5da2fa64d7f35f5c8f9403b49d23b2207c767d502e529acca8fb3f4dd561505672ed221",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "electron-to-chromium-2f1711be760ee5ecf66cc385a5bbae56e008e5035e6359dc572b44fca5da2fa64d7f35f5c8f9403b49d23b2207c767d502e529acca8fb3f4dd561505672ed221"
+    "dest-filename": "electron-to-chromium-ac50b144ec3b68e7b8b8f4df200c7ead7bfd704706c7e6ee005e27a6786d4ea0899392831519e1dfe2988fbadd561ea5b05b79fda3ecf88ae3f6b677dd6300ef"
   },
   {
     "type": "file",
@@ -3942,10 +4425,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-    "sha512": "faec358a720754f428695b87cd1c97776d6270cf9c9ede02cc3e6b5be342d708ce5124ceb3e4deec53afec084deef4bdc7fa08ca12cfe4f4751fea614001eee5",
+    "url": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+    "sha512": "a2810673a1cfdbac57abf37e18218e4f424a08b0c6aead9b41466b43b832ac989900d27ff180d3c53a5005718c9fe59b2105cd569c96ca69bb2985480909f23a",
     "dest": "flatpak-node/npm",
-    "dest-filename": "end-of-stream-faec358a720754f428695b87cd1c97776d6270cf9c9ede02cc3e6b5be342d708ce5124ceb3e4deec53afec084deef4bdc7fa08ca12cfe4f4751fea614001eee5"
+    "dest-filename": "end-of-stream-a2810673a1cfdbac57abf37e18218e4f424a08b0c6aead9b41466b43b832ac989900d27ff180d3c53a5005718c9fe59b2105cd569c96ca69bb2985480909f23a"
   },
   {
     "type": "file",
@@ -4026,13 +4509,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-    "sha512": "4eda5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "escape-string-regexp-4eda5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
     "sha512": "ea14e33b53405a41e70e4dcea90e18ac2bb0c261872fd4b79cf97304e506fd1e38add6b7c0b36b7ef4397e44868f284714a33b00b3ca70a1abc2f08b7b4942ed",
     "dest": "flatpak-node/npm",
@@ -4054,31 +4530,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-    "sha512": "2a67ca2f76fa1be457bcff0dd6faf74ead642ffa021609f63585c4b6a3fcfcbde929aa540381bc70555aa05dd2537db7083e17ca947f7df8a81e692d8bafd36a",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "esrecurse-2a67ca2f76fa1be457bcff0dd6faf74ead642ffa021609f63585c4b6a3fcfcbde929aa540381bc70555aa05dd2537db7083e17ca947f7df8a81e692d8bafd36a"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-    "sha512": "30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "estraverse-30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
     "sha512": "dfd9e729f7d6cfcc4dd4153fd9cefd9fd9c1f470f3a349e2614ab1eb1caa527ca8027432c96a4e4dd6447a209c87c041bb9d79b78c29f599a055f5619fd101a7",
     "dest": "flatpak-node/npm",
     "dest-filename": "estraverse-dfd9e729f7d6cfcc4dd4153fd9cefd9fd9c1f470f3a349e2614ab1eb1caa527ca8027432c96a4e4dd6447a209c87c041bb9d79b78c29f599a055f5619fd101a7"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-    "sha512": "915b1ca97938382a7af126747648042958baffc8a3df4d0a0564c9ab7d8ffdd61e5934b02b8d56c93c5a94dd5e46603967d514fcb5fd0fb1564a657d480631ea",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "esutils-915b1ca97938382a7af126747648042958baffc8a3df4d0a0564c9ab7d8ffdd61e5934b02b8d56c93c5a94dd5e46603967d514fcb5fd0fb1564a657d480631ea"
   },
   {
     "type": "file",
@@ -4110,10 +4565,24 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
-    "sha512": "f10c584d55d492ecbb7c82288ad4243f01a89c1f05dd98fc7843bc4aa83d66ffdb908ed1240ce8c1e7b882bf351da93f7544e903667b55f420a228e33cd95464",
+    "url": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+    "sha512": "6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730",
     "dest": "flatpak-node/npm",
-    "dest-filename": "exponential-backoff-f10c584d55d492ecbb7c82288ad4243f01a89c1f05dd98fc7843bc4aa83d66ffdb908ed1240ce8c1e7b882bf351da93f7544e903667b55f420a228e33cd95464"
+    "dest-filename": "debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+    "sha512": "4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+    "sha512": "66011e6578f7d2af88d0437e09b492a48c8f689e475500f5f19d66faed455db01e4fde26af5cf0e74ab8aba8e2882e38ecd97f61370861201fb621aa7adc1708",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "exponential-backoff-66011e6578f7d2af88d0437e09b492a48c8f689e475500f5f19d66faed455db01e4fde26af5cf0e74ab8aba8e2882e38ecd97f61370861201fb621aa7adc1708"
   },
   {
     "type": "file",
@@ -4180,31 +4649,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-    "sha512": "7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "fast-deep-equal-7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
     "sha512": "ecca6d2fc53472a705773233c0e4c7a22957f71e41acdab27bb67f2ee0bb9023118a8d44312caa44adc1100503eec5d1ab8893e00cd356e65d8604364c2bd82e",
     "dest": "flatpak-node/npm",
     "dest-filename": "fast-glob-ecca6d2fc53472a705773233c0e4c7a22957f71e41acdab27bb67f2ee0bb9023118a8d44312caa44adc1100503eec5d1ab8893e00cd356e65d8604364c2bd82e"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-    "sha512": "96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "fast-json-stable-stringify-96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-    "sha512": "0c25eee887e1a9c92ced364a6371f1a77cbaaa9858e522599ab58c0eb29c11148e5d641d32153d220fcf62bcf2c3fba5f63388ca1d0de0cd2d6c2e61a1d83c77",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "fast-levenshtein-0c25eee887e1a9c92ced364a6371f1a77cbaaa9858e522599ab58c0eb29c11148e5d641d32153d220fcf62bcf2c3fba5f63388ca1d0de0cd2d6c2e61a1d83c77"
   },
   {
     "type": "file",
@@ -4320,6 +4768,13 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+    "sha512": "74ac75d9e442548cea0b1146a65c8528930fbcb11682636d52ba53889211e6ef7bcc48511bcc92aed6e83c7657c7b75a2f1415ae5eb8ddc4f36da6f6b64423c6",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "for-each-74ac75d9e442548cea0b1146a65c8528930fbcb11682636d52ba53889211e6ef7bcc48511bcc92aed6e83c7657c7b75a2f1415ae5eb8ddc4f36da6f6b64423c6"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
     "sha512": "ec4c265eb3a3c8bf82871321986e659d6f4c3edd5a21e644c0a850ce8054753574377ceec160d961525ab43bd9d8ecb33d4bdd200643b027ad937728c8c7dc9d",
     "dest": "flatpak-node/npm",
@@ -4348,10 +4803,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-    "sha512": "aac21340f7e6bcc39201d7b267ed7623573e08a4acb40140c2efbdef3ae75806c8af9bbcc1fb04c54cc27ac54b0bc3601ee454a8d378672e943d6513446b2570",
+    "url": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+    "sha512": "2ab1a12fd438ce38f492252de4e3b832bfc0fe3948da30d8b397870696073dc0445528a2a40be7d8aa361e73dedb4ae672ebaf30735d645a7ee089464cc1743b",
     "dest": "flatpak-node/npm",
-    "dest-filename": "form-data-aac21340f7e6bcc39201d7b267ed7623573e08a4acb40140c2efbdef3ae75806c8af9bbcc1fb04c54cc27ac54b0bc3601ee454a8d378672e943d6513446b2570"
+    "dest-filename": "form-data-2ab1a12fd438ce38f492252de4e3b832bfc0fe3948da30d8b397870696073dc0445528a2a40be7d8aa361e73dedb4ae672ebaf30735d645a7ee089464cc1743b"
   },
   {
     "type": "file",
@@ -4411,10 +4866,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-    "sha512": "85c8376667a94b7d3fec1485a91be8a370ce310bbb223ab13b99c20edfb333d5d68dbdf75a0ef388d4fe42fa9bb9cdfe816a733b4d89b9b5729361b866fa3539",
+    "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+    "sha512": "a115c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d",
     "dest": "flatpak-node/npm",
-    "dest-filename": "fs-extra-85c8376667a94b7d3fec1485a91be8a370ce310bbb223ab13b99c20edfb333d5d68dbdf75a0ef388d4fe42fa9bb9cdfe816a733b4d89b9b5729361b866fa3539"
+    "dest-filename": "fs-extra-a115c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d"
   },
   {
     "type": "file",
@@ -4527,13 +4982,6 @@
     "sha512": "a0da5cbad8fe9d85f61637445bb3c696d5a15ee9409c594cd0ccbf938f0bf74840442389b6f05b41773fea2b55da30ef539c4002da273feafac2642009c6c050",
     "dest": "flatpak-node/npm",
     "dest-filename": "process-a0da5cbad8fe9d85f61637445bb3c696d5a15ee9409c594cd0ccbf938f0bf74840442389b6f05b41773fea2b55da30ef539c4002da273feafac2642009c6c050"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-    "sha512": "58e069fc410652222c252a7bc1cbffcba30efa557d5289dc5aac6e15f9bc781c3358d8327c177a1b3f8878a43d8c29b28681fdf60d793374fe41a5471638b354",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "globals-58e069fc410652222c252a7bc1cbffcba30efa557d5289dc5aac6e15f9bc781c3358d8327c177a1b3f8878a43d8c29b28681fdf60d793374fe41a5471638b354"
   },
   {
     "type": "file",
@@ -4768,20 +5216,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/hull.js/-/hull.js-0.2.10.tgz",
-    "sha512": "50edd6df41f185681e4a934a09d5edd34c64c234531a68506a864d3fc965e74f4d97e0cff63b97137c111a2ce286ea29d3c152078c6d01621b5927be471128a2",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "hull.js-50edd6df41f185681e4a934a09d5edd34c64c234531a68506a864d3fc965e74f4d97e0cff63b97137c111a2ce286ea29d3c152078c6d01621b5927be471128a2"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-    "sha512": "165ef4bd8b6c0056ff0b4e8f4d2f5d641a3b8a16aef93bbf0cd0a4fcec8785e6b4ed2f9a78c5a914591469745af1f23e49c65b108f1d7d2c7063b83167d48055",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "humanize-ms-165ef4bd8b6c0056ff0b4e8f4d2f5d641a3b8a16aef93bbf0cd0a4fcec8785e6b4ed2f9a78c5a914591469745af1f23e49c65b108f1d7d2c7063b83167d48055"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
     "sha512": "5830bfba2d95551af3de33958be5ed8ea9038e25634ed15a006896dfb93a6fea21c90e7060338692f0996bcf87d27c77832befd3e0524fdc6e3a0232190d3483",
     "dest": "flatpak-node/npm",
@@ -4793,13 +5227,6 @@
     "sha512": "4f5d2abe4c34cf3e309e6e7ad253848343e8bd5a945ee3858611c0922c70f3fb32732ed326deeffd1ae410a1109c0c36be23d226eea202412bc67cd1d20f0fa5",
     "dest": "flatpak-node/npm",
     "dest-filename": "iconv-corefoundation-4f5d2abe4c34cf3e309e6e7ad253848343e8bd5a945ee3858611c0922c70f3fb32732ed326deeffd1ae410a1109c0c36be23d226eea202412bc67cd1d20f0fa5"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-    "sha512": "e1f0a4efdc2c84c773329dab1f4eaa5ab244e22a25a8b842507f8e8ae22053ef91074fbde0d9432fcd5ab4eec65f9e6e50ab9ea34b711cdb6f13223a0fb59d33",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "iconv-lite-e1f0a4efdc2c84c773329dab1f4eaa5ab244e22a25a8b842507f8e8ae22053ef91074fbde0d9432fcd5ab4eec65f9e6e50ab9ea34b711cdb6f13223a0fb59d33"
   },
   {
     "type": "file",
@@ -4838,13 +5265,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-    "sha512": "86c053354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "ignore-86c053354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
     "sha512": "5d7385b72a838cd0c043155f631b85ee0f4897f21b5a69a5420d8c60a387f04c484f5aa0eb1738cf24b71da10401382cd5bb5fcf1ab5e5c894898ee08d25d119",
     "dest": "flatpak-node/npm",
@@ -4863,13 +5283,6 @@
     "sha512": "130e4067325016aace5790535b7108a07027a227b52e88d92d729c090ff24d1c95668b0184ad71d558988c719fe690053aaf19c82859a7a9bf7d237ba49c99b6",
     "dest": "flatpak-node/npm",
     "dest-filename": "import-cwd-130e4067325016aace5790535b7108a07027a227b52e88d92d729c090ff24d1c95668b0184ad71d558988c719fe690053aaf19c82859a7a9bf7d237ba49c99b6"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-    "sha512": "4d1dca7eb4d94d82cf07a8d48dfc7a305f56716ac72fdb2ee5339b2b866462005d58a3ce1684a8408744b93b91f36a66b711f6b29586f61e9eb707ebd692c1a9",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "import-fresh-4d1dca7eb4d94d82cf07a8d48dfc7a305f56716ac72fdb2ee5339b2b866462005d58a3ce1684a8408744b93b91f36a66b711f6b29586f61e9eb707ebd692c1a9"
   },
   {
     "type": "file",
@@ -4898,13 +5311,6 @@
     "sha512": "91758bed2729f0a438e79d9971d55379a4026522d6f9eea725fa7773050c07aef74fb1ebf7c5e3c7924afaa97b00394952f8f5252e4ed3544b6caa2eb4de500d",
     "dest": "flatpak-node/npm",
     "dest-filename": "imports-loader-91758bed2729f0a438e79d9971d55379a4026522d6f9eea725fa7773050c07aef74fb1ebf7c5e3c7924afaa97b00394952f8f5252e4ed3544b6caa2eb4de500d"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-    "sha512": "2665cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "imurmurhash-2665cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c"
   },
   {
     "type": "file",
@@ -4992,10 +5398,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-    "sha512": "cc7b50cc6a236574f06531d0aab6be11329de129f7be08bbb819a53e85d5599a98bee2a6b48d25fd56538ea1a6258f71f3c18639a67df86f444bc842e13e17f2",
+    "url": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+    "sha512": "356bfd60b5b83e85b607bc6dcda4b7342a2def99ba9caec871dbf4a3795f31c7895517d2a10c2a0f8c041f9acbc28289c14899feb7e98950619da17414ae07a0",
     "dest": "flatpak-node/npm",
-    "dest-filename": "ip-address-cc7b50cc6a236574f06531d0aab6be11329de129f7be08bbb819a53e85d5599a98bee2a6b48d25fd56538ea1a6258f71f3c18639a67df86f444bc842e13e17f2"
+    "dest-filename": "ip-address-356bfd60b5b83e85b607bc6dcda4b7342a2def99ba9caec871dbf4a3795f31c7895517d2a10c2a0f8c041f9acbc28289c14899feb7e98950619da17414ae07a0"
   },
   {
     "type": "file",
@@ -5027,10 +5433,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-    "sha512": "658bc282b79fc2aa10eb24f26146d0bbae07b084d9dcd7ca5f597368461d9130dc7cacf3088ff0b6145160a91d8c72855603625ca00a9bae59a35a64d9ab3f41",
+    "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+    "sha512": "d410b40551614bfa74aadc3a7a7a7c7bef0e0f452b2b4a052f3b528cdce170a037583b89c7100f5f33ee3ed2a48c463d514a045a55fff1f80a7aed92f22f494c",
     "dest": "flatpak-node/npm",
-    "dest-filename": "is-ci-658bc282b79fc2aa10eb24f26146d0bbae07b084d9dcd7ca5f597368461d9130dc7cacf3088ff0b6145160a91d8c72855603625ca00a9bae59a35a64d9ab3f41"
+    "dest-filename": "is-callable-d410b40551614bfa74aadc3a7a7a7c7bef0e0f452b2b4a052f3b528cdce170a037583b89c7100f5f33ee3ed2a48c463d514a045a55fff1f80a7aed92f22f494c"
   },
   {
     "type": "file",
@@ -5069,13 +5475,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-    "sha512": "49b29b00d90deb4dd58b88c466fe3d2de549327e321b0b1bcd9c28ac4a32122badb0dde725875b3b7eb37e1189e90103a4e6481640ed9eae494719af9778eca1",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "is-extglob-49b29b00d90deb4dd58b88c466fe3d2de549327e321b0b1bcd9c28ac4a32122badb0dde725875b3b7eb37e1189e90103a4e6481640ed9eae494719af9778eca1"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
     "sha512": "cf29a6e7ebbeb02b125b20fda8d69e8d5dc316f84229c94a762cd868952e1c0f3744b8dbee74ae1a775d0871afd2193e298ec130096c59e2b851e83a115e9742",
     "dest": "flatpak-node/npm",
@@ -5090,13 +5489,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-    "sha512": "c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "is-glob-c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
     "sha512": "15e5c80601bf08f19dfd6531b84caf8064c47f0886f59e04286c6334c46abe288821fb2682ba671cb7df103770507a8dbdad55116f75a37c414ff9bc125825f6",
     "dest": "flatpak-node/npm",
@@ -5108,13 +5500,6 @@
     "sha512": "d87bc810a468a92eb682e102faa063a6f46e6dd5fdd7458232e25367e23dcafa8a536ff5d9e48be78f47330b5a6dbe28ba9763dac30fe7493e5c97c1ffc244eb",
     "dest": "flatpak-node/npm",
     "dest-filename": "is-interactive-d87bc810a468a92eb682e102faa063a6f46e6dd5fdd7458232e25367e23dcafa8a536ff5d9e48be78f47330b5a6dbe28ba9763dac30fe7493e5c97c1ffc244eb"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-    "sha512": "cfb08c14636b10dab988507d06aa3ae1793a63db20f9ea6ad66c8871d1da1a76cc4d83b1bf3b04b5d62a414ca507b2f17e4be0aeb8cfdf64fa6307228a8f5421",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "is-lambda-cfb08c14636b10dab988507d06aa3ae1793a63db20f9ea6ad66c8871d1da1a76cc4d83b1bf3b04b5d62a414ca507b2f17e4be0aeb8cfdf64fa6307228a8f5421"
   },
   {
     "type": "file",
@@ -5167,6 +5552,13 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+    "sha512": "a7711cb227178e2b7b49ab245c7b35840f75431813c38e85bfa10528a192e434452c3f322a7a218c5de1c688eef786ff39c319a10ba4ce93e9044f6e2d52b381",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "is-typed-array-a7711cb227178e2b7b49ab245c7b35840f75431813c38e85bfa10528a192e434452c3f322a7a218c5de1c688eef786ff39c319a10ba4ce93e9044f6e2d52b381"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
     "sha512": "732039ea208c1c087909dce32486b86a8849c9e3b561bc0b8b725cdf9326454ea9a2ba058c8199cd4ceea468913ce8e01e0f532eee37c5ba705e4e76ddf33128",
     "dest": "flatpak-node/npm",
@@ -5195,17 +5587,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.4.tgz",
-    "sha512": "60a04a5642a1b72eecf2bc5d75be34a0e92e3f435b69e5eb42f2e29fa40c1cbed8a62cb6456f4bc0e56b560651c8eae14256b231df6df83f320f2f0c2854d20d",
+    "url": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.6.tgz",
+    "sha512": "23e36621f047525fabdb070377a27013dc968defcf21563f479fc2995f1d5cb65de4af8bf57da49403b07c01cd9e89dd2d791b1f24c095e4005a89e94c9053b7",
     "dest": "flatpak-node/npm",
-    "dest-filename": "isbinaryfile-60a04a5642a1b72eecf2bc5d75be34a0e92e3f435b69e5eb42f2e29fa40c1cbed8a62cb6456f4bc0e56b560651c8eae14256b231df6df83f320f2f0c2854d20d"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-    "sha512": "447c4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "isexe-447c4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23"
+    "dest-filename": "isbinaryfile-23e36621f047525fabdb070377a27013dc968defcf21563f479fc2995f1d5cb65de4af8bf57da49403b07c01cd9e89dd2d791b1f24c095e4005a89e94c9053b7"
   },
   {
     "type": "file",
@@ -5237,17 +5622,17 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
-    "sha512": "d8fe124341eb2d0f9fc3a965a4b9ce68602f37666eebbefc48932b094c27b387cea06f5acab4e2664dd557cb023e455917c69bd3392c5694bc143639a5108d04",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "jake-d8fe124341eb2d0f9fc3a965a4b9ce68602f37666eebbefc48932b094c27b387cea06f5acab4e2664dd557cb023e455917c69bd3392c5694bc143639a5108d04"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
     "sha512": "2966155757388be8db3296810be53efb855ad1ca7c3a2b14d7ce68ef74f5be8f7d86a8bbc3cb5225f51762cc30aaaae3cf0c5ae8aa512b9e1684fbf07f9c3a3d",
     "dest": "flatpak-node/npm",
     "dest-filename": "jest-worker-2966155757388be8db3296810be53efb855ad1ca7c3a2b14d7ce68ef74f5be8f7d86a8bbc3cb5225f51762cc30aaaae3cf0c5ae8aa512b9e1684fbf07f9c3a3d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
+    "sha512": "b7042879c60f8950392bf87a4b1b4e470fc1b376abfa62d4b683d273b88c5f34332bc77b789fd1d3dc264f002389a9844e7d5c5d83c67cd9eeec33281e0bb5db",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "jiti-b7042879c60f8950392bf87a4b1b4e470fc1b376abfa62d4b683d273b88c5f34332bc77b789fd1d3dc264f002389a9844e7d5c5d83c67cd9eeec33281e0bb5db"
   },
   {
     "type": "file",
@@ -5272,17 +5657,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-    "sha512": "c29c59b3d368c596891122462194f20c4698a65d0529203e141f5a262c9e98a84cc24c5083ade1e13d4a2605061e94ea3c33517269982ee82b46326506d5af44",
+    "url": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+    "sha512": "51553d7626ead897055b140f03a282aa3e4ee3654e980637cd051f10ac54d0aa53197c0da028e45f57b5dde1cdbf0ff13f29edea9534ad9d61b63593353497b2",
     "dest": "flatpak-node/npm",
-    "dest-filename": "js-yaml-c29c59b3d368c596891122462194f20c4698a65d0529203e141f5a262c9e98a84cc24c5083ade1e13d4a2605061e94ea3c33517269982ee82b46326506d5af44"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-    "sha512": "e1b61557768032d0d34eee3ec6c0d86bab32f46c89ebdfda9acbbdb18176cea8e2128640e71262dc1adf5f7b98fbf21e908bbb33074e6dd6c35a9a19741bf7fc",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "jsbn-e1b61557768032d0d34eee3ec6c0d86bab32f46c89ebdfda9acbbdb18176cea8e2128640e71262dc1adf5f7b98fbf21e908bbb33074e6dd6c35a9a19741bf7fc"
+    "dest-filename": "jsbn-51553d7626ead897055b140f03a282aa3e4ee3654e980637cd051f10ac54d0aa53197c0da028e45f57b5dde1cdbf0ff13f29edea9534ad9d61b63593353497b2"
   },
   {
     "type": "file",
@@ -5290,13 +5668,6 @@
     "sha512": "fec33774ed853b35e3290849ba8d10d7bdf07f628ea3cb7823cbc7cba945f69a14a7b6ca4f4fcd1c4f1f3d7db73f07e19f291faa70b6c51c4e9d5c395ee18868",
     "dest": "flatpak-node/npm",
     "dest-filename": "jsesc-fec33774ed853b35e3290849ba8d10d7bdf07f628ea3cb7823cbc7cba945f69a14a7b6ca4f4fcd1c4f1f3d7db73f07e19f291faa70b6c51c4e9d5c395ee18868"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-    "sha512": "e1b57905f4769aa7d04c99be579b4f3dd7fe669ba1888bd3b8007983c91cad7399a534ff430c15456072c17d68cebea512e3dd6c7c70689966f46ea6236b1f49",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "json-buffer-e1b57905f4769aa7d04c99be579b4f3dd7fe669ba1888bd3b8007983c91cad7399a534ff430c15456072c17d68cebea512e3dd6c7c70689966f46ea6236b1f49"
   },
   {
     "type": "file",
@@ -5321,13 +5692,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-    "sha512": "c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "json-schema-traverse-c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
     "sha512": "642960e80698bda9af60413cd9ddc8c9ddef49222343ea1d823693cd1b8edeceeda0274529cce86f68b4cc287b244f245a7d7bcaf016854571bea1b051a96c44",
     "dest": "flatpak-node/npm",
@@ -5342,10 +5706,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-    "sha512": "e5d8277563ab8984a6e5c9d86893616a52cd0ca3aa170c8307faebd44f59b067221af28fb3c476c5818269cb9fdf3e8ad58283cf5f367ddf9f637727de932a5d",
+    "url": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+    "sha512": "146b8fc37d0074e2144d1302d8e311b5057e8e4563d9c7cfa927965efd4d100275a99e736f55facf598585b7ce07f8b2decb09083fb72ae67cafc0b7b9516502",
     "dest": "flatpak-node/npm",
-    "dest-filename": "jsonfile-e5d8277563ab8984a6e5c9d86893616a52cd0ca3aa170c8307faebd44f59b067221af28fb3c476c5818269cb9fdf3e8ad58283cf5f367ddf9f637727de932a5d"
+    "dest-filename": "jsonfile-146b8fc37d0074e2144d1302d8e311b5057e8e4563d9c7cfa927965efd4d100275a99e736f55facf598585b7ce07f8b2decb09083fb72ae67cafc0b7b9516502"
   },
   {
     "type": "file",
@@ -5367,13 +5731,6 @@
     "sha512": "bc89190055a80e28e0413fcdbe5d801c23269de80dd9e8604cf62ecb2da15909104a7b48d12ec4498a9d2e4a127b51f21011471e40a0488bd57521225b02af0a",
     "dest": "flatpak-node/npm",
     "dest-filename": "keymirror-bc89190055a80e28e0413fcdbe5d801c23269de80dd9e8604cf62ecb2da15909104a7b48d12ec4498a9d2e4a127b51f21011471e40a0488bd57521225b02af0a"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-    "sha512": "a3154790747f1097f608d5e75b144b5ba9a0ec9c82094706d03b441a62f672d528d4f3538a7d4f52297eafffb8af93295600bf7e7d648ecc7b9a34ae8caa88a7",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "keyv-a3154790747f1097f608d5e75b144b5ba9a0ec9c82094706d03b441a62f672d528d4f3538a7d4f52297eafffb8af93295600bf7e7d648ecc7b9a34ae8caa88a7"
   },
   {
     "type": "file",
@@ -5559,80 +5916,101 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
-    "sha512": "36038f6d189a40cd740d85ef377fe1846548d8ce4cb484c5af2cc11b11cce69e309c5c6c5426f192b06b0ec93e119e4e0788c4393ec08c3c6d745f8a544153ef",
+    "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz",
+    "sha512": "40c8c66c54cfd1b963f7b11e89d1b9864fd084a4374f82027244062e0cf7f1017b5606e4e9ee854c044df0a84ac7205b5a7f11d0753e6e7c3c692a053c3e2ab5",
     "dest": "flatpak-node/npm",
-    "dest-filename": "make-fetch-happen-36038f6d189a40cd740d85ef377fe1846548d8ce4cb484c5af2cc11b11cce69e309c5c6c5426f192b06b0ec93e119e4e0788c4393ec08c3c6d745f8a544153ef"
+    "dest-filename": "make-fetch-happen-40c8c66c54cfd1b963f7b11e89d1b9864fd084a4374f82027244062e0cf7f1017b5606e4e9ee854c044df0a84ac7205b5a7f11d0753e6e7c3c692a053c3e2ab5"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
-    "sha512": "c8e24a46fa2114e68baa2a4db70601f56ba0c992a10bf0d90b85583e6a5a0b30c1ac0f18a4adea1d9f3f1c6b1c3271381aa6e42cdb957029f191e404746b7a2d",
+    "url": "https://registry.npmjs.org/@npmcli/fs/-/fs-4.0.0.tgz",
+    "sha512": "ff11a57b323ac5f18ef4dc2e2659f0cff2b5e2a0f59024801ad69c0479c6cde008b8919acdca78e4a3f936ec80457a0a6fb730ba5006595b1b792c5d1bf71bd1",
     "dest": "flatpak-node/npm",
-    "dest-filename": "fs-c8e24a46fa2114e68baa2a4db70601f56ba0c992a10bf0d90b85583e6a5a0b30c1ac0f18a4adea1d9f3f1c6b1c3271381aa6e42cdb957029f191e404746b7a2d"
+    "dest-filename": "fs-ff11a57b323ac5f18ef4dc2e2659f0cff2b5e2a0f59024801ad69c0479c6cde008b8919acdca78e4a3f936ec80457a0a6fb730ba5006595b1b792c5d1bf71bd1"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
-    "sha512": "9897766794e3616abfb6d3cb2c6a80addb670bbe09e9b3b3838acc0e737ea75c5369c676c8f442936cb4a12590b7280b47d61541780e70e36bc2d9e4dc9ba9c5",
+    "url": "https://registry.npmjs.org/cacache/-/cacache-19.0.1.tgz",
+    "sha512": "85db14c6e9570a2e524c877bf2f455604b43023abdf48080524b4b4de4d8b0ba1313a67c752d1cf2958d0b1c1dae4f587c97a86c365cd98d7cea10ffe5942015",
     "dest": "flatpak-node/npm",
-    "dest-filename": "move-file-9897766794e3616abfb6d3cb2c6a80addb670bbe09e9b3b3838acc0e737ea75c5369c676c8f442936cb4a12590b7280b47d61541780e70e36bc2d9e4dc9ba9c5"
+    "dest-filename": "cacache-85db14c6e9570a2e524c877bf2f455604b43023abdf48080524b4b4de4d8b0ba1313a67c752d1cf2958d0b1c1dae4f587c97a86c365cd98d7cea10ffe5942015"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-    "sha512": "45937035c945efe312ffc6c383bd1a9a0df6772799199c620ee42667128b025423af78c6c8bc7ee0a924e7c50eec3d90760148402a2fb92b991129dee911ba5d",
+    "url": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+    "sha512": "f88c7363d05939077f5ee60f466aef1158c5fe7aa3e64813e2412aed5a1fac3a0cd4cc6846311692b082dc4b4b8b9f5355ac314c09fea2b27015072ba84375fa",
     "dest": "flatpak-node/npm",
-    "dest-filename": "agent-base-45937035c945efe312ffc6c383bd1a9a0df6772799199c620ee42667128b025423af78c6c8bc7ee0a924e7c50eec3d90760148402a2fb92b991129dee911ba5d"
+    "dest-filename": "chownr-f88c7363d05939077f5ee60f466aef1158c5fe7aa3e64813e2412aed5a1fac3a0cd4cc6846311692b082dc4b4b8b9f5355ac314c09fea2b27015072ba84375fa"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
-    "sha512": "ffe126723f43017c57e1cc252e6448f5cd7ae91b8bdf0df4ce9e11ec9a22bf67104ed4ed03e8deb820231f76651a7612ded284352aca840cd554ff46572cde61",
+    "url": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+    "sha512": "5d4040f570a51db9c95927c1ce3926e91bcfb32837b2bc99b74e81110a17705ec42bfc6919a41826040a0c94941f948667be98ee9171d500675f3d3dad4e456f",
     "dest": "flatpak-node/npm",
-    "dest-filename": "cacache-ffe126723f43017c57e1cc252e6448f5cd7ae91b8bdf0df4ce9e11ec9a22bf67104ed4ed03e8deb820231f76651a7612ded284352aca840cd554ff46572cde61"
+    "dest-filename": "fs-minipass-5d4040f570a51db9c95927c1ce3926e91bcfb32837b2bc99b74e81110a17705ec42bfc6919a41826040a0c94941f948667be98ee9171d500675f3d3dad4e456f"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-    "sha512": "9f6858f18768444d62eebe8cd30f43230e468193741b6e4ff332c2450f2b8d7b53537bec345048fef58afd421e13a839314533e9abf000f5e62fa172f43ffdd3",
+    "url": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+    "sha512": "ec1bfc445d24eb18e8edde00fcfc582db5027dbe9cf95a5ddbf981db244395ec3b25be611178820fd89b7ceef0a64f22e2c7af2ba0c59f2f61ec461b337fec1e",
     "dest": "flatpak-node/npm",
-    "dest-filename": "http-proxy-agent-9f6858f18768444d62eebe8cd30f43230e468193741b6e4ff332c2450f2b8d7b53537bec345048fef58afd421e13a839314533e9abf000f5e62fa172f43ffdd3"
+    "dest-filename": "glob-ec1bfc445d24eb18e8edde00fcfc582db5027dbe9cf95a5ddbf981db244395ec3b25be611178820fd89b7ceef0a64f22e2c7af2ba0c59f2f61ec461b337fec1e"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-    "sha512": "7457008e94d0160a0b3330b657053e0bf09b4bbb912f49569b10c84e6aa6ec2fbb17439d9a3eacf65e9a95973a0042d786b9e080cd827964971c639d5f662dc0",
+    "url": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+    "sha512": "0fb57c3cef686b3ecf5862db0800ae235a843acabb50a7cba2dc7f0b401eb78ddf09407fc1f43b0d87aada847fb2f1491980c73ebdfc48701379a8ff6682872b",
     "dest": "flatpak-node/npm",
-    "dest-filename": "https-proxy-agent-7457008e94d0160a0b3330b657053e0bf09b4bbb912f49569b10c84e6aa6ec2fbb17439d9a3eacf65e9a95973a0042d786b9e080cd827964971c639d5f662dc0"
+    "dest-filename": "minipass-collect-0fb57c3cef686b3ecf5862db0800ae235a843acabb50a7cba2dc7f0b401eb78ddf09407fc1f43b0d87aada847fb2f1491980c73ebdfc48701379a8ff6682872b"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-    "sha512": "8ee9a573404852b4b7a891a0224599b327c033b3425a205c08386777edcd34ce4a6c198b4e01d57d605c83a5beacb52c229ce91113ecbf050fec272401048ea0",
+    "url": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+    "sha512": "299c58a350549160f64d514baf4310a0cf2f5148a0583dcb943f376bfef906a0bee2a1341dbd55a39bf516071f68d5ef7d7cebfb912143a8a783f09a0628d397",
     "dest": "flatpak-node/npm",
-    "dest-filename": "lru-cache-8ee9a573404852b4b7a891a0224599b327c033b3425a205c08386777edcd34ce4a6c198b4e01d57d605c83a5beacb52c229ce91113ecbf050fec272401048ea0"
+    "dest-filename": "minizlib-299c58a350549160f64d514baf4310a0cf2f5148a0583dcb943f376bfef906a0bee2a1341dbd55a39bf516071f68d5ef7d7cebfb912143a8a783f09a0628d397"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
-    "sha512": "a39ed6727eba8cc42f7c71b516561b59e6565bf7476612578e921c4df5e5757124e67cf9952b4fa3798ad0e2507c647745b65495b2127b16e58e4273b848fff1",
+    "url": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+    "sha512": "5649dd22fd9f201f7db30bd0a00eb96e6f9fb26b7a50d746788074a3106cf9684085d874f10034e095e923badb07daf4f3f9e46f2b0aa326bdaed0c445839830",
     "dest": "flatpak-node/npm",
-    "dest-filename": "ssri-a39ed6727eba8cc42f7c71b516561b59e6565bf7476612578e921c4df5e5757124e67cf9952b4fa3798ad0e2507c647745b65495b2127b16e58e4273b848fff1"
+    "dest-filename": "p-map-5649dd22fd9f201f7db30bd0a00eb96e6f9fb26b7a50d746788074a3106cf9684085d874f10034e095e923badb07daf4f3f9e46f2b0aa326bdaed0c445839830"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
-    "sha512": "383587b6491dc7720047ebde2b1155f9506450c70df856aacd451dec8673b7ed338436453c5c6196ac0f177610bcc1f1d530f4b5d81897e92e3e727c13aaa5ec",
+    "url": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
+    "sha512": "4bb886368b1ea71f5169d5fcda88a6524bebd02b7b22325b11bb38989713c6cb7cba6f79277b03614d510443af76eea82f559e9363832398b8300c3e759e9c01",
     "dest": "flatpak-node/npm",
-    "dest-filename": "unique-filename-383587b6491dc7720047ebde2b1155f9506450c70df856aacd451dec8673b7ed338436453c5c6196ac0f177610bcc1f1d530f4b5d81897e92e3e727c13aaa5ec"
+    "dest-filename": "ssri-4bb886368b1ea71f5169d5fcda88a6524bebd02b7b22325b11bb38989713c6cb7cba6f79277b03614d510443af76eea82f559e9363832398b8300c3e759e9c01"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
-    "sha512": "f04c8cca787aefdc7fd20a84f5f4fda22946faa12dfa26c5caa8ee553b199f5f823311fe5cb969bebd94671e2755c0b04e9c7cd67202af625016433e1cf2eae3",
+    "url": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
+    "sha512": "9e51a9c5ffa1bf4bfb1a45812b657db2981a72d18ea74aaf7d647150c8ea1f2cebb774a0c04e3c0c8bff161a8f1c960b1e9816d68a6ade71116f3e409eaee7d6",
     "dest": "flatpak-node/npm",
-    "dest-filename": "unique-slug-f04c8cca787aefdc7fd20a84f5f4fda22946faa12dfa26c5caa8ee553b199f5f823311fe5cb969bebd94671e2755c0b04e9c7cd67202af625016433e1cf2eae3"
+    "dest-filename": "tar-9e51a9c5ffa1bf4bfb1a45812b657db2981a72d18ea74aaf7d647150c8ea1f2cebb774a0c04e3c0c8bff161a8f1c960b1e9816d68a6ade71116f3e409eaee7d6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/unique-filename/-/unique-filename-4.0.0.tgz",
+    "sha512": "5d29c47b05e643ebde3fbc57d9d4b9438c9902f3b8d1c04dd8c5a427b0ffeac5b80e0eb060137033556b9f3d45847e4075e2c89545d123d7b6f33d58662ef535",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "unique-filename-5d29c47b05e643ebde3fbc57d9d4b9438c9902f3b8d1c04dd8c5a427b0ffeac5b80e0eb060137033556b9f3d45847e4075e2c89545d123d7b6f33d58662ef535"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-5.0.0.tgz",
+    "sha512": "f4e75aa8ee64c2a47ed645601c086ca79bcf354d219f145adbaac114d7cd80ceccea936d8337819f7b3fc5bc8240bddd723cce6ad71e7fa5141e907fe8c6844e",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "unique-slug-f4e75aa8ee64c2a47ed645601c086ca79bcf354d219f145adbaac114d7cd80ceccea936d8337819f7b3fc5bc8240bddd723cce6ad71e7fa5141e907fe8c6844e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+    "sha512": "620bd44dfc2ac9ced45d532b07e4889ac5584a64d2f17fed4abb5d35930898cfa7efe413ae2457c978a6d2606b4d735eab3545d0a5868073de8b2562145acd0f",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "yallist-620bd44dfc2ac9ced45d532b07e4889ac5584a64d2f17fed4abb5d35930898cfa7efe413ae2457c978a6d2606b4d735eab3545d0a5868073de8b2562145acd0f"
   },
   {
     "type": "file",
@@ -5748,6 +6126,20 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+    "sha512": "b0f538b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "mime-db-b0f538b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+    "sha512": "64363e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "mime-types-64363e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
     "sha512": "3aa6ce939a0441e019f165d6c9d96ef47263cfd59574422f6a63027179aea946234e49c7fecaac5af850def830285451d47a63bcd04a437ee76c9818cc6a8672",
     "dest": "flatpak-node/npm",
@@ -5818,10 +6210,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
-    "sha512": "2d3e3d662dbf58c44e1d8a2a1a0765408661f262cf6663ab37635d263317c587b89e437a154cae3ee38039e74d243af1d0844683dfb882e65ec2da7c844e93c4",
+    "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-4.0.1.tgz",
+    "sha512": "8fb535d42e475e2815baeb7179b15a7686016dded549d65682049eeb835576f58d06a1808973cbd905427a18e6c3b958d6817d80e96561b39187e8623607cf81",
     "dest": "flatpak-node/npm",
-    "dest-filename": "minipass-fetch-2d3e3d662dbf58c44e1d8a2a1a0765408661f262cf6663ab37635d263317c587b89e437a154cae3ee38039e74d243af1d0844683dfb882e65ec2da7c844e93c4"
+    "dest-filename": "minipass-fetch-8fb535d42e475e2815baeb7179b15a7686016dded549d65682049eeb835576f58d06a1808973cbd905427a18e6c3b958d6817d80e96561b39187e8623607cf81"
   },
   {
     "type": "file",
@@ -5944,10 +6336,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
-    "sha512": "0c03608711644b5a650dd46c5f45fda66d19e9224d37a80176d5df6a7c2867c868a02e60a2c1854811916075153f3d5ab0a03f90c46a0d1747ae5b99eb54a905",
+    "url": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
+    "sha512": "d54c6ec9819da101dc1a0f3b2e4aa6dc5cde7ee7136b434088e72e46c0e6cac7a9ddcd4b54244ada4aeb50369f316b63486d3886dbc09af83debe4839273a681",
     "dest": "flatpak-node/npm",
-    "dest-filename": "nan-0c03608711644b5a650dd46c5f45fda66d19e9224d37a80176d5df6a7c2867c868a02e60a2c1854811916075153f3d5ab0a03f90c46a0d1747ae5b99eb54a905"
+    "dest-filename": "nan-d54c6ec9819da101dc1a0f3b2e4aa6dc5cde7ee7136b434088e72e46c0e6cac7a9ddcd4b54244ada4aeb50369f316b63486d3886dbc09af83debe4839273a681"
   },
   {
     "type": "file",
@@ -5986,10 +6378,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
-    "sha512": "3a161a639b03b0891aec7ec0b628ed23d8f01982f2976f5e427fd6eb6dc388dfcc22fe6c52a73883b0480d3857fa06fb762f5feb12b4da7929f2c75f15664b4e",
+    "url": "https://registry.npmjs.org/node-abi/-/node-abi-4.14.0.tgz",
+    "sha512": "1389fdd4ae0d93545c8762b30fe79d5366df6533f85b8d86ca90140d7538beed40fb8bbd3ef50d0e4188d1d5dbb32f19785dd61a3d120ffb87c675c3fec5bedf",
     "dest": "flatpak-node/npm",
-    "dest-filename": "node-abi-3a161a639b03b0891aec7ec0b628ed23d8f01982f2976f5e427fd6eb6dc388dfcc22fe6c52a73883b0480d3857fa06fb762f5feb12b4da7929f2c75f15664b4e"
+    "dest-filename": "node-abi-1389fdd4ae0d93545c8762b30fe79d5366df6533f85b8d86ca90140d7538beed40fb8bbd3ef50d0e4188d1d5dbb32f19785dd61a3d120ffb87c675c3fec5bedf"
   },
   {
     "type": "file",
@@ -6011,6 +6403,13 @@
     "sha512": "66330f1447d5c798fecb6c85df92b3c79b05ee40f3c6e0e3eb3887e0515b3a9f3bcca0d9371f321312486f4e4e185e0d96df481c520c064465e3555dbdc35d6d",
     "dest": "flatpak-node/npm",
     "dest-filename": "node-fetch-66330f1447d5c798fecb6c85df92b3c79b05ee40f3c6e0e3eb3887e0515b3a9f3bcca0d9371f321312486f4e4e185e0d96df481c520c064465e3555dbdc35d6d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.4.2.tgz",
+    "sha512": "de00feeb3b2b2d01fb0f260e508bad69abae5eb732c5e4cfc90b9940242834f64c1cc312e66e32d31725369bd8ce82b754dceecb14fa785e269082f859267579",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "node-gyp-de00feeb3b2b2d01fb0f260e508bad69abae5eb732c5e4cfc90b9940242834f64c1cc312e66e32d31725369bd8ce82b754dceecb14fa785e269082f859267579"
   },
   {
     "type": "file",
@@ -6042,10 +6441,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
-    "sha512": "6702e96d381d86e6549d9ce377b9dbd5957ee03a220bafec7e254aa24ef6ca6ff84e57fe0c57651d8993d893e670d35657a3e2dd20dfd644fe038afd453b93f6",
+    "url": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+    "sha512": "89e1aee36bbf42c6b84c592d99a284c0ce8c407d293969da07786dce1d0946dc7ce3e31e6dcd1c6d960de5b0bee964d9e3eefbc6b2fd3e7e66ec257a548915ec",
     "dest": "flatpak-node/npm",
-    "dest-filename": "nopt-6702e96d381d86e6549d9ce377b9dbd5957ee03a220bafec7e254aa24ef6ca6ff84e57fe0c57651d8993d893e670d35657a3e2dd20dfd644fe038afd453b93f6"
+    "dest-filename": "nopt-89e1aee36bbf42c6b84c592d99a284c0ce8c407d293969da07786dce1d0946dc7ce3e31e6dcd1c6d960de5b0bee964d9e3eefbc6b2fd3e7e66ec257a548915ec"
   },
   {
     "type": "file",
@@ -6154,13 +6553,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-    "sha512": "94d689808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "once-94d689808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
     "sha512": "91ba5a4921894d674063928f55e30e2974ab3edafc0bc0bbc287496dcb1de758d19e60fe199bbc63456853a0e6e59e2f5abd0883fd4d2ae59129fee3e5a6984a",
     "dest": "flatpak-node/npm",
@@ -6214,13 +6606,6 @@
     "sha512": "ccbed51382554b62054a447619028348f115c64a07e37fe9ee8127c297429dd29824ed0755e441edf03c4c9c2e2ce4c1444b4ad1e6bc7876b1770729a1be5d9a",
     "dest": "flatpak-node/npm",
     "dest-filename": "p-is-promise-ccbed51382554b62054a447619028348f115c64a07e37fe9ee8127c297429dd29824ed0755e441edf03c4c9c2e2ce4c1444b4ad1e6bc7876b1770729a1be5d9a"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-    "sha512": "4d839a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "p-limit-4d839a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945"
   },
   {
     "type": "file",
@@ -6280,13 +6665,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-    "sha512": "190d84591a5057cfe8f80c3c62ab5f6593df3515996246e2744f64e6ba65fe10b7bed1c705f1a6d887e2eaa595f9ca031a4ad42990311372e8b7991cb11961fa",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "parent-module-190d84591a5057cfe8f80c3c62ab5f6593df3515996246e2744f64e6ba65fe10b7bed1c705f1a6d887e2eaa595f9ca031a4ad42990311372e8b7991cb11961fa"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.7.tgz",
     "sha512": "09333992e591decc7d2056a6725e44adf3e5e9e6bf37c218c2227ebe9781da0fb58a49efef3065e6e3f06cc6d15739d155bacd63a946b83a04e5bdf482b99baa",
     "dest": "flatpak-node/npm",
@@ -6343,24 +6721,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-    "sha512": "6a4f50cb943b8d86f65b071ecb9169be0d8aa0073f64884b48b392066466ca03ec1b091556dd1f65ad2aaed333fa6ead2530077d943c167981e0c1b82d6cbbff",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "path-exists-6a4f50cb943b8d86f65b071ecb9169be0d8aa0073f64884b48b392066466ca03ec1b091556dd1f65ad2aaed333fa6ead2530077d943c167981e0c1b82d6cbbff"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
     "sha512": "0156f0dd42767bd6eaeb8bd2692f409b47e37b53daf296c6a934ec9977da2223299ebe4394385f24eb8b8fd49ff7964f5430147ab0df124f3c30f98f7bb50242",
     "dest": "flatpak-node/npm",
     "dest-filename": "path-is-absolute-0156f0dd42767bd6eaeb8bd2692f409b47e37b53daf296c6a934ec9977da2223299ebe4394385f24eb8b8fd49ff7964f5430147ab0df124f3c30f98f7bb50242"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-    "sha512": "a2399e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "path-key-a2399e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9"
   },
   {
     "type": "file",
@@ -6378,13 +6742,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-    "sha512": "24d03365c5eb0ade365462ee633d337c0cc37c0bc9596e807d8943050c835790c2948da6e6c0262be3883bbb39f577ec46c587a74da3009ad169d3d1193b7a49",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "lru-cache-24d03365c5eb0ade365462ee633d337c0cc37c0bc9596e807d8943050c835790c2948da6e6c0262be3883bbb39f577ec46c587a74da3009ad169d3d1193b7a49"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
     "sha512": "80329bf1a64c0de0ffb595acf4febeab427d33091d97ac4c57c4e39c63f7a89549d3a6dd32091b0652d4f0875f3ac22c173d815b5acd553dd7b8d125f333c0bf",
     "dest": "flatpak-node/npm",
@@ -6392,10 +6749,31 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
-    "sha512": "8ae87b2fa8c0ec9106bb65b10f0b503f575d3a9689342e0a9431057dd41a8d21a018f362e0ec8373647b4276d8d9b47d4230551b082f4dd34966813b45ac5430",
+    "url": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
+    "sha512": "c1f44b059d1f796461088928301e9eb5eedccc9727367a91a5ca164012ea6ada975e67a5491a9f7432b8177bbd4f6b367176acfe140972bc88ff89402fe5d394",
     "dest": "flatpak-node/npm",
-    "dest-filename": "pbkdf2-8ae87b2fa8c0ec9106bb65b10f0b503f575d3a9689342e0a9431057dd41a8d21a018f362e0ec8373647b4276d8d9b47d4230551b082f4dd34966813b45ac5430"
+    "dest-filename": "pbkdf2-c1f44b059d1f796461088928301e9eb5eedccc9727367a91a5ca164012ea6ada975e67a5491a9f7432b8177bbd4f6b367176acfe140972bc88ff89402fe5d394"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+    "sha512": "b27469721fe4c1085c7659d92986a7345d66d110e5ac2752290687f3bc3514214f54f34243f225f5024a017da354165d75175a1c1302fb35daf46c3db6690d50",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "create-hash-b27469721fe4c1085c7659d92986a7345d66d110e5ac2752290687f3bc3514214f54f34243f225f5024a017da354165d75175a1c1302fb35daf46c3db6690d50"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+    "sha512": "d1344e810d7f4b113a2a6c564af5c7bd18fdd3f5e8d49bd94a1a1f9d817e7fa66c1ad4787844bb59fad0ccf6a59b26a07ca6425e95678ad89179b66e956b1b8b",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "hash-base-d1344e810d7f4b113a2a6c564af5c7bd18fdd3f5e8d49bd94a1a1f9d817e7fa66c1ad4787844bb59fad0ccf6a59b26a07ca6425e95678ad89179b66e956b1b8b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+    "sha512": "27b7f8c2eb4df2675b574f0c2675e26d8a4238f1d1fb2cf2fa243f02c8ccbf68fc70b6af43c5466a00c5530c1301d17c16644a55e3696d34c4c0d1c25b583de3",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "ripemd160-27b7f8c2eb4df2675b574f0c2675e26d8a4238f1d1fb2cf2fa243f02c8ccbf68fc70b6af43c5466a00c5530c1301d17c16644a55e3696d34c4c0d1c25b583de3"
   },
   {
     "type": "file",
@@ -6417,13 +6795,6 @@
     "sha512": "ec40079722c7239e9510874ae7bbb01dd1ca21a0066e75cf8b0d3259b6ab41938a68aa6f508816d2359154b89ab6733e5d7952c2c6a72011ff87318c26e94ca3",
     "dest": "flatpak-node/npm",
     "dest-filename": "performance-now-ec40079722c7239e9510874ae7bbb01dd1ca21a0066e75cf8b0d3259b6ab41938a68aa6f508816d2359154b89ab6733e5d7952c2c6a72011ff87318c26e94ca3"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-    "sha512": "c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "picocolors-c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454"
   },
   {
     "type": "file",
@@ -6476,10 +6847,17 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/postcss/-/postcss-8.5.5.tgz",
-    "sha512": "77f8ed9beadd353f2da57b8763930cb5c6c91419215c4eb9f775d547d5281821fc8d2146722ee31af3061f94587793c1256fb4d0d650b7a81fec26da8090ab86",
+    "url": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+    "sha512": "ffee55153721243a158f76e1a2a8ba51eca6703d340c0c1bd672706a6ccfbc712ccc9e05a45e9234d6d46ce4bcc88e7aa87cdd57c78ad2a11f3928a87644ddc6",
     "dest": "flatpak-node/npm",
-    "dest-filename": "postcss-77f8ed9beadd353f2da57b8763930cb5c6c91419215c4eb9f775d547d5281821fc8d2146722ee31af3061f94587793c1256fb4d0d650b7a81fec26da8090ab86"
+    "dest-filename": "possible-typed-array-names-ffee55153721243a158f76e1a2a8ba51eca6703d340c0c1bd672706a6ccfbc712ccc9e05a45e9234d6d46ce4bcc88e7aa87cdd57c78ad2a11f3928a87644ddc6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+    "sha512": "dd86e2d6d02ec003fdb34af5510d89e27e58d06d396c99295083b4fdb23d321c260fbd12e5a4d66d7181c311eb7a54fe5ccd64e9d334a64f92c0d9294d137b3e",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "postcss-dd86e2d6d02ec003fdb34af5510d89e27e58d06d396c99295083b4fdb23d321c260fbd12e5a4d66d7181c311eb7a54fe5ccd64e9d334a64f92c0d9294d137b3e"
   },
   {
     "type": "file",
@@ -6595,20 +6973,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
-    "sha512": "6fd11bf21d9e56a344f1e76f29dc2a92b63a3bb900c2623c91c9c1bf535272895825ba39f57505d27a05abe9716c2d72376d1b982d160446c30b91ffec049bd0",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "postject-6fd11bf21d9e56a344f1e76f29dc2a92b63a3bb900c2623c91c9c1bf535272895825ba39f57505d27a05abe9716c2d72376d1b982d160446c30b91ffec049bd0"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-    "sha512": "291b3b5950ca83ce8f5a2b80aa10eb0109d35d92ab69570273abc574bd78aab67f0dc5b0b91a3b5688985da9573bb4b918aa6a622544c026e01437f134728905",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "commander-291b3b5950ca83ce8f5a2b80aa10eb0109d35d92ab69570273abc574bd78aab67f0dc5b0b91a3b5688985da9573bb4b918aa6a622544c026e01437f134728905"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
     "sha512": "112176dd5e12286ea55521998183696ec89a02475a6fa6603b17b9da9efe2a27775b7bb76f147855f77fa36d5d98dee34add08c20678bf9314776e8512d5c4f7",
     "dest": "flatpak-node/npm",
@@ -6623,10 +6987,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
-    "sha512": "29c9a8d8585f0d35dd71b7c31fbe8deee0581c837173ff065bb50056e54ff48f956b7b8749eaeb9ca57a74ba2881afe087b1a5833b820abfdea257672f59ae1b",
+    "url": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
+    "sha512": "033c33be5f741da174682cf526b0dd5d0ca415a91248d3da3e8899f5f9b9a8920c1e2a036448bb380751c129baad2a0fb58dd0bad9e6dcbee882683775cfb06d",
     "dest": "flatpak-node/npm",
-    "dest-filename": "proc-log-29c9a8d8585f0d35dd71b7c31fbe8deee0581c837173ff065bb50056e54ff48f956b7b8749eaeb9ca57a74ba2881afe087b1a5833b820abfdea257672f59ae1b"
+    "dest-filename": "proc-log-033c33be5f741da174682cf526b0dd5d0ca415a91248d3da3e8899f5f9b9a8920c1e2a036448bb380751c129baad2a0fb58dd0bad9e6dcbee882683775cfb06d"
   },
   {
     "type": "file",
@@ -6693,17 +7057,17 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-    "sha512": "b543d7b7394633c144dcfd192fa0d5b3fdcfe7c93d9e4f3f8d97900aead327295003ca856331c57e104992eab21341627ceb10d2e2967a4899e60f30b6bdbc73",
+    "url": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+    "sha512": "b68770c4b318eff85e49c2a69edc101bc09756459439d63122f636b34556000321fe777c4a862245a2a396befe882b3df387f63fccefadf59c0c36156fbdcd7c",
     "dest": "flatpak-node/npm",
-    "dest-filename": "pump-b543d7b7394633c144dcfd192fa0d5b3fdcfe7c93d9e4f3f8d97900aead327295003ca856331c57e104992eab21341627ceb10d2e2967a4899e60f30b6bdbc73"
+    "dest-filename": "pump-b68770c4b318eff85e49c2a69edc101bc09756459439d63122f636b34556000321fe777c4a862245a2a396befe882b3df387f63fccefadf59c0c36156fbdcd7c"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-    "sha512": "bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16",
+    "url": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+    "sha512": "fb7f2a23d48eafcb5f67842624da65314c6a8db7bb2cabef66059d13104e99df9e8194ed8cb07aec6bb41d15f7bbf5ceabb514d8dc7a9ec8ef4b5e99f6ec1fa6",
     "dest": "flatpak-node/npm",
-    "dest-filename": "punycode-bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16"
+    "dest-filename": "qs-fb7f2a23d48eafcb5f67842624da65314c6a8db7bb2cabef66059d13104e99df9e8194ed8cb07aec6bb41d15f7bbf5ceabb514d8dc7a9ec8ef4b5e99f6ec1fa6"
   },
   {
     "type": "file",
@@ -6938,13 +7302,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-    "sha512": "18387090b7f2c162f6b3abc48f286b8be79799f1fa8f52fb244dbb5a1a8b798ce887f0370c16981848f61ff1c56429ff90c7e29bbdc55f11094f0d3a5adc50c2",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "readdirp-18387090b7f2c162f6b3abc48f286b8be79799f1fa8f52fb244dbb5a1a8b798ce887f0370c16981848f61ff1c56429ff90c7e29bbdc55f11094f0d3a5adc50c2"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
     "sha512": "fe78e667cb35c15791ea98d367ed270a7bfc4a964d44c4f60f544b3894044a56050c1bf0a5303829626967eb01278faf86320b45c2bb24815d182771100022b6",
     "dest": "flatpak-node/npm",
@@ -7113,13 +7470,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-    "sha512": "a5bfcc6265ecb40932b11171f2988d235b4614d408140def904dc6ab812e035745ea01e9ffebe066ab021896a9bf2f0ddd0fb8a3b170beab8f25c9d9ed1632e2",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "resolve-from-a5bfcc6265ecb40932b11171f2988d235b4614d408140def904dc6ab812e035745ea01e9ffebe066ab021896a9bf2f0ddd0fb8a3b170beab8f25c9d9ed1632e2"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
     "sha512": "66e179e6155441a69cce0388c2a5b390470489d9a50ffc65e38c755199e1397718b853764bafab731a46f82d4ddd2a34c2f348dc39892025057eed92c61066be",
     "dest": "flatpak-node/npm",
@@ -7232,10 +7582,122 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-    "sha512": "445d05c3eacee4031ff4c0326915c8e005745258f994c1ea571c5d4a08956e2c52097a049a65ff8e4d02b89c38fb74aaae860ef55a1487e1dcb898afbed25e98",
+    "url": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+    "sha512": "df4899b403e0cfe2d3218a1e8afa98a3ce777f4da305849de6e1a71a9905574337c4eb7d68def77ab920600999538df1e157ea7272f15bd2a98374792c2e1863",
     "dest": "flatpak-node/npm",
-    "dest-filename": "semver-445d05c3eacee4031ff4c0326915c8e005745258f994c1ea571c5d4a08956e2c52097a049a65ff8e4d02b89c38fb74aaae860ef55a1487e1dcb898afbed25e98"
+    "dest-filename": "remapping-df4899b403e0cfe2d3218a1e8afa98a3ce777f4da305849de6e1a71a9905574337c4eb7d68def77ab920600999538df1e157ea7272f15bd2a98374792c2e1863"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@babel/cli/-/cli-7.27.2.tgz",
+    "sha512": "71f77b0e71a5847e8e232b8f4928f7bdc7c87676d7ba4840c8a63c35a66b15a742ee95f22fd98e2f95a08dca6d88424b8b99378fc698bcb2150b37b3ad64da88",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "cli-71f77b0e71a5847e8e232b8f4928f7bdc7c87676d7ba4840c8a63c35a66b15a742ee95f22fd98e2f95a08dca6d88424b8b99378fc698bcb2150b37b3ad64da88"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.5.tgz",
+    "sha512": "2a2440a7f56825a5a492d7bce13bd477daa375b640762ab2bccc6b1a5d4deafcc5a202a668b8283372f5920b4b89ca761cfe5f0494bc26b64a2d521919524056",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "compat-data-2a2440a7f56825a5a492d7bce13bd477daa375b640762ab2bccc6b1a5d4deafcc5a202a668b8283372f5920b4b89ca761cfe5f0494bc26b64a2d521919524056"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
+    "sha512": "6d7631ad716e6de61dbc1d0d843fcd041dd08ba699795db418e595238eedd9d91e7021289de47834f55c6fb69ba570c4bde8e0ad47c5b46eaf1bfcf100a9a0fa",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "core-6d7631ad716e6de61dbc1d0d843fcd041dd08ba699795db418e595238eedd9d91e7021289de47834f55c6fb69ba570c4bde8e0ad47c5b46eaf1bfcf100a9a0fa"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
+    "sha512": "646840dfb9747bf836b350a7cdd8b1d0edda2d89bae9e17c6ae7e256d78e827c3182744ff06a32323ed55ac8169d06d5297ca07bb86aac58762b64d033ab751f",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "generator-646840dfb9747bf836b350a7cdd8b1d0edda2d89bae9e17c6ae7e256d78e827c3182744ff06a32323ed55ac8169d06d5297ca07bb86aac58762b64d033ab751f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
+    "sha512": "7523af630bf22ec58178847239e1d7a79bcf8f9975234d75af9d85335fabd6308446ff9a157624e3086041c7181066312b61f7640200f27b8f910d07694a37aa",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "helper-module-transforms-7523af630bf22ec58178847239e1d7a79bcf8f9975234d75af9d85335fabd6308446ff9a157624e3086041c7181066312b61f7640200f27b8f910d07694a37aa"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
+    "sha512": "9ae13c4edf0cdb6eb7f07537d40dc281f494722c33d5f8404dfa156a2d3968f5c6a2bfff09d58309b9e5635caf04fa34ee78ee54e08d1824a9fc64edd76948ba",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "helpers-9ae13c4edf0cdb6eb7f07537d40dc281f494722c33d5f8404dfa156a2d3968f5c6a2bfff09d58309b9e5635caf04fa34ee78ee54e08d1824a9fc64edd76948ba"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
+    "sha512": "3ac41dd7be52c569069736e7cbc2772bc4e79c30f437796b214b41f76c70c91a7369e9c6661c43bf137f260534d14dc20d9363f6d3ee0c9e47d164b836ddef2a",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "parser-3ac41dd7be52c569069736e7cbc2772bc4e79c30f437796b214b41f76c70c91a7369e9c6661c43bf137f260534d14dc20d9363f6d3ee0c9e47d164b836ddef2a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
+    "sha512": "a0d72ed906c7aadb3d06d396268b0e5496a95a30434b1182a45be290d4794c60d80d07f7270a48a0ccc82abbdfa2d8bdddc2df3c9106e2d1fd48f55ec821a074",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "traverse-a0d72ed906c7aadb3d06d396268b0e5496a95a30434b1182a45be290d4794c60d80d07f7270a48a0ccc82abbdfa2d8bdddc2df3c9106e2d1fd48f55ec821a074"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
+    "sha512": "113c87124d951c7be5f5bf6364fe481cf6af1d8939ec485a9e5451b9a7bd5c2a5bfe3e5b0c26cf3cc3817c25a19e5ffb103273d2310c0a2fd185c70213caf5f9",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "types-113c87124d951c7be5f5bf6364fe481cf6af1d8939ec485a9e5451b9a7bd5c2a5bfe3e5b0c26cf3cc3817c25a19e5ffb103273d2310c0a2fd185c70213caf5f9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+    "sha512": "8a601b04691bf9e6d0cb12a0cefe47bb69e644ec680ce5c787cd1ebf17685cd3abbc09d5c7bce29b37353a8e61f5195f578bcf5da13688ce693856ef3820a558",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "gen-mapping-8a601b04691bf9e6d0cb12a0cefe47bb69e644ec680ce5c787cd1ebf17685cd3abbc09d5c7bce29b37353a8e61f5195f578bcf5da13688ce693856ef3820a558"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+    "sha512": "47c80b45365eca9d37ca6ccfffa2e297fdbcb46786133871d6ada4ef4dca19644023555dbcf217746ef4549736a40330dcd03a24a2f986116ed6c257d0c9e7fc",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "set-array-47c80b45365eca9d37ca6ccfffa2e297fdbcb46786133871d6ada4ef4dca19644023555dbcf217746ef4549736a40330dcd03a24a2f986116ed6c257d0c9e7fc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+    "sha512": "d5925365e6e0aa594eefdb9ed9b9b7ac81ae77f6ce7b4a4fe418d2442471c58904652f124d5ef337ce1405b898bbb8f2f9e08a4a7548520a16584fedb7eb2131",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "source-map-d5925365e6e0aa594eefdb9ed9b9b7ac81ae77f6ce7b4a4fe418d2442471c58904652f124d5ef337ce1405b898bbb8f2f9e08a4a7548520a16584fedb7eb2131"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+    "sha512": "82fdd945a2125377e33c080db2b88146a19640beaab85c74e1830f5bfcc3f1730bb14df69a10826df6cee8a6452e3bd8a4267ccf20c482ab207fe3f03da33b19",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "sourcemap-codec-82fdd945a2125377e33c080db2b88146a19640beaab85c74e1830f5bfcc3f1730bb14df69a10826df6cee8a6452e3bd8a4267ccf20c482ab207fe3f03da33b19"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+    "sha512": "bcd93a684c326c6b5ac169b2fcfcf09c60ce8c290b5920f6c2abe3186020380c02196c926177d8a31b74d082644c5fbc2dbe7b0f039bdc06b4a3d080a5ea6261",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "trace-mapping-bcd93a684c326c6b5ac169b2fcfcf09c60ce8c290b5920f6c2abe3186020380c02196c926177d8a31b74d082644c5fbc2dbe7b0f039bdc06b4a3d080a5ea6261"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/core-js/-/core-js-3.43.0.tgz",
+    "sha512": "37ac046d34d9498398dab6009fce42baf5969022ba43078c9fbff836bdf0fa00c1781864ff1e0425e63a14fa384330e8259c554eff14ec232f81693aa4e1c7a8",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "core-js-37ac046d34d9498398dab6009fce42baf5969022ba43078c9fbff836bdf0fa00c1781864ff1e0425e63a14fa384330e8259c554eff14ec232f81693aa4e1c7a8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
+    "sha512": "7643b97e14bbfbfa28b387225b1c84ca359ee3cce61bac1b0a17a8fc6d999c7c787ecdc453a602e9433cae4e7a8008cd27d3f73131f68e8e636fddbf2bac1b9e",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "babel__traverse-7643b97e14bbfbfa28b387225b1c84ca359ee3cce61bac1b0a17a8fc6d999c7c787ecdc453a602e9433cae4e7a8008cd27d3f73131f68e8e636fddbf2bac1b9e"
   },
   {
     "type": "file",
@@ -7246,10 +7708,17 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-    "sha512": "359c896ab05f2fb9d6c08abe1432fa669ff21c485e3cc3679c9d32dea7e2782ae636f61cb7cbafb62578d54be549ee9aa407e4d1f63515b5b1f8dc1f9a9bed4e",
+    "url": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
+    "sha512": "3c9f2060a792e5eff0847061f31af060af9d02f123ec95edcfab93b9c9cc441f0e8864ec29c7057a4a11ae36a33c11d5f28398fb6b48e2ec5e71e4a298ac0c14",
     "dest": "flatpak-node/npm",
-    "dest-filename": "acorn-359c896ab05f2fb9d6c08abe1432fa669ff21c485e3cc3679c9d32dea7e2782ae636f61cb7cbafb62578d54be549ee9aa407e4d1f63515b5b1f8dc1f9a9bed4e"
+    "dest-filename": "browserslist-3c9f2060a792e5eff0847061f31af060af9d02f123ec95edcfab93b9c9cc441f0e8864ec29c7057a4a11ae36a33c11d5f28398fb6b48e2ec5e71e4a298ac0c14"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001722.tgz",
+    "sha512": "0c240704166d88ae89564006c3b76bbc030ad10d0f383ff166f1260e9e9b6a230c3fa4175e4f47a43ea63580595a138f1ba2ef2036fcd884eab568e10dc90708",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "caniuse-lite-0c240704166d88ae89564006c3b76bbc030ad10d0f383ff166f1260e9e9b6a230c3fa4175e4f47a43ea63580595a138f1ba2ef2036fcd884eab568e10dc90708"
   },
   {
     "type": "file",
@@ -7267,10 +7736,31 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.167.tgz",
+    "sha512": "2f1711be760ee5ecf66cc385a5bbae56e008e5035e6359dc572b44fca5da2fa64d7f35f5c8f9403b49d23b2207c767d502e529acca8fb3f4dd561505672ed221",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "electron-to-chromium-2f1711be760ee5ecf66cc385a5bbae56e008e5035e6359dc572b44fca5da2fa64d7f35f5c8f9403b49d23b2207c767d502e529acca8fb3f4dd561505672ed221"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+    "sha512": "faec358a720754f428695b87cd1c97776d6270cf9c9ede02cc3e6b5be342d708ce5124ceb3e4deec53afec084deef4bdc7fa08ca12cfe4f4751fea614001eee5",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "end-of-stream-faec358a720754f428695b87cd1c97776d6270cf9c9ede02cc3e6b5be342d708ce5124ceb3e4deec53afec084deef4bdc7fa08ca12cfe4f4751fea614001eee5"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
     "sha512": "64298e25dbce583058265cc0a05902f90d3e6d4c84392d65b60a75306534ddfa871be75b8bdb41154d9177d40a883645018ae13e1d8951feeb65122e1d12ad3a",
     "dest": "flatpak-node/npm",
     "dest-filename": "type-check-64298e25dbce583058265cc0a05902f90d3e6d4c84392d65b60a75306534ddfa871be75b8bdb41154d9177d40a883645018ae13e1d8951feeb65122e1d12ad3a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+    "sha512": "58e069fc410652222c252a7bc1cbffcba30efa557d5289dc5aac6e15f9bc781c3358d8327c177a1b3f8878a43d8c29b28681fdf60d793374fe41a5471638b354",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "globals-58e069fc410652222c252a7bc1cbffcba30efa557d5289dc5aac6e15f9bc781c3358d8327c177a1b3f8878a43d8c29b28681fdf60d793374fe41a5471638b354"
   },
   {
     "type": "file",
@@ -7281,17 +7771,24 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-    "sha512": "694e4426e20dd960de982700a76bc505fa7f9b810085626750d492c348b1b3bfe45db77a3e0eb8126c0990d745841f1a5add6c1f60935eb2f1a3f880195de83d",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "mime-db-694e4426e20dd960de982700a76bc505fa7f9b810085626750d492c348b1b3bfe45db77a3e0eb8126c0990d745841f1a5add6c1f60935eb2f1a3f880195de83d"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
     "sha512": "eae08fe10734b16b2030bcb510eaaa4bfdeb8c31ce127b12b55affe2fb4020ad98e62da403b94515e8d8ae923288df70d2961fe1c91e0984fd7f5af53fd297e6",
     "dest": "flatpak-node/npm",
     "dest-filename": "mkdirp-eae08fe10734b16b2030bcb510eaaa4bfdeb8c31ce127b12b55affe2fb4020ad98e62da403b94515e8d8ae923288df70d2961fe1c91e0984fd7f5af53fd297e6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
+    "sha512": "0c03608711644b5a650dd46c5f45fda66d19e9224d37a80176d5df6a7c2867c868a02e60a2c1854811916075153f3d5ab0a03f90c46a0d1747ae5b99eb54a905",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "nan-0c03608711644b5a650dd46c5f45fda66d19e9224d37a80176d5df6a7c2867c868a02e60a2c1854811916075153f3d5ab0a03f90c46a0d1747ae5b99eb54a905"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+    "sha512": "8ae87b2fa8c0ec9106bb65b10f0b503f575d3a9689342e0a9431057dd41a8d21a018f362e0ec8373647b4276d8d9b47d4230551b082f4dd34966813b45ac5430",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "pbkdf2-8ae87b2fa8c0ec9106bb65b10f0b503f575d3a9689342e0a9431057dd41a8d21a018f362e0ec8373647b4276d8d9b47d4230551b082f4dd34966813b45ac5430"
   },
   {
     "type": "file",
@@ -7320,6 +7817,13 @@
     "sha512": "c5622e7f106820d26fe8988b6fb8e5e68125829fbaa6e270bd3e73647962512c9da0bcf80c00d10773430ec6207ca570a239f84c32e2b1ea02eb932e4bca061a",
     "dest": "flatpak-node/npm",
     "dest-filename": "postcss-simple-vars-c5622e7f106820d26fe8988b6fb8e5e68125829fbaa6e270bd3e73647962512c9da0bcf80c00d10773430ec6207ca570a239f84c32e2b1ea02eb932e4bca061a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+    "sha512": "b543d7b7394633c144dcfd192fa0d5b3fdcfe7c93d9e4f3f8d97900aead327295003ca856331c57e104992eab21341627ceb10d2e2967a4899e60f30b6bdbc73",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "pump-b543d7b7394633c144dcfd192fa0d5b3fdcfe7c93d9e4f3f8d97900aead327295003ca856331c57e104992eab21341627ceb10d2e2967a4899e60f30b6bdbc73"
   },
   {
     "type": "file",
@@ -7442,13 +7946,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-    "sha512": "04ddb607979a30c23d50cb63ac677983978260fa423c3532d052576d8b1a4f9cd8c6314e7244b9dd2403137a56915a16a475d56f706b61c10de13c1ae7907970",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "word-wrap-04ddb607979a30c23d50cb63ac677983978260fa423c3532d052576d8b1a4f9cd8c6314e7244b9dd2403137a56915a16a475d56f706b61c10de13c1ae7907970"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/scratch-sb1-converter/-/scratch-sb1-converter-0.2.7.tgz",
     "sha512": "305d4dce644b6e00a2abbc22493ba4d82f6b402f2e3395a3ed2698b27d5210c58d2bdaed2b4b9cdcb4a6f059c4b75e104bfd48731d9880cb143ca4741da3c375",
     "dest": "flatpak-node/npm",
@@ -7509,6 +8006,13 @@
     "sha512": "5e9363e860d0cdd7d6fabd969e7ef189201ded33378f39311970464ed58ab925efd71515f9acf1026f2375664dd3a413424fb63765c1f6344392f6e6426711b6",
     "dest": "flatpak-node/npm",
     "dest-filename": "bluebird-5e9363e860d0cdd7d6fabd969e7ef189201ded33378f39311970464ed58ab925efd71515f9acf1026f2375664dd3a413424fb63765c1f6344392f6e6426711b6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+    "sha512": "882b8f1c3160ac75fb1f6bc423fe71a73d3bcd21c1d344e9ba0aa1998b5598c3bae75f260ae44ca0e60595d101974835f3bb9fa3375a1e058a71815beb5a8688",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "brace-expansion-882b8f1c3160ac75fb1f6bc423fe71a73d3bcd21c1d344e9ba0aa1998b5598c3bae75f260ae44ca0e60595d101974835f3bb9fa3375a1e058a71815beb5a8688"
   },
   {
     "type": "file",
@@ -8100,13 +8604,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-    "sha512": "eeb294cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "uri-js-eeb294cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
     "sha512": "026d68bac02148b05e07d706ffb93baf6474ce3e74b834656473c66dace2779b3dae517517f40a60e6c429222e9d28c83a4259ab04512e9bdec2312433ba52aa",
     "dest": "flatpak-node/npm",
@@ -8265,13 +8762,6 @@
     "sha512": "bff8b053ac2fc062bc1db53dca2dff9e11b33f4c864ae8503332fac9289e735152ad96439219b89e83925b3acd168fe311cf92258ea3453c2ec1b49724f0d49d",
     "dest": "flatpak-node/npm",
     "dest-filename": "schema-utils-bff8b053ac2fc062bc1db53dca2dff9e11b33f4c864ae8503332fac9289e735152ad96439219b89e83925b3acd168fe311cf92258ea3453c2ec1b49724f0d49d"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-    "sha512": "9784a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "wrappy-9784a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71"
   },
   {
     "type": "file",
@@ -8674,13 +9164,6 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-    "sha512": "6165938e000148a72fb3f9d6062f4fc9c63f2623c9a8e0f8240ea8f527a3d80b6f4866ab5f1282dce412938a406ab6dd4252808790f814242424d916f86027df",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "qs-6165938e000148a72fb3f9d6062f4fc9c63f2623c9a8e0f8240ea8f527a3d80b6f4866ab5f1282dce412938a406ab6dd4252808790f814242424d916f86027df"
-  },
-  {
-    "type": "file",
     "url": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
     "sha512": "0e92a6d948bfc4deff1d0282b69671a11581859f59d24aadca01bc5c280d43c6650e7c6e4265a18f9eba8fc7cde02bb7fc999b86c0e8edf70026ae2cf61dbb13",
     "dest": "flatpak-node/npm",
@@ -8744,10 +9227,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-    "sha512": "ad592cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9",
+    "url": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+    "sha512": "49db0a32b23d4dd823770794491f4cc1e1c0e0427c6311e7f0315a0e2b2f85595439ee01175b4b0fb1808f4948a96565f9d3dbfeb131af406d6f2e65a109b6d1",
     "dest": "flatpak-node/npm",
-    "dest-filename": "yocto-queue-ad592cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9"
+    "dest-filename": "semver-49db0a32b23d4dd823770794491f4cc1e1c0e0427c6311e7f0315a0e2b2f85595439ee01175b4b0fb1808f4948a96565f9d3dbfeb131af406d6f2e65a109b6d1"
   },
   {
     "type": "file",
@@ -8765,24 +9248,17 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+    "sha512": "f0bcc2e7e6ef238e418e97d753c5797dd53699f78a8907b50f5808327ed752517739352ba5d2693cf1f810c0271740ec1c775266a09d4acb39a829892ae88edf",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "sha.js-f0bcc2e7e6ef238e418e97d753c5797dd53699f78a8907b50f5808327ed752517739352ba5d2693cf1f810c0271740ec1c775266a09d4acb39a829892ae88edf"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
     "sha512": "ffa2aa5fe19551da8fb8f3ddd8bc430f1cd7e8201b8c97a100038a94da6aa94a40a8f33a1de2fc7fea376be26cc868e7da5bf4598f14b1381426353d3a4e7934",
     "dest": "flatpak-node/npm",
     "dest-filename": "shallow-clone-ffa2aa5fe19551da8fb8f3ddd8bc430f1cd7e8201b8c97a100038a94da6aa94a40a8f33a1de2fc7fea376be26cc868e7da5bf4598f14b1381426353d3a4e7934"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-    "sha512": "907c6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "shebang-command-907c6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c"
-  },
-  {
-    "type": "file",
-    "url": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-    "sha512": "efef9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4",
-    "dest": "flatpak-node/npm",
-    "dest-filename": "shebang-regex-efef9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4"
   },
   {
     "type": "file",
@@ -8814,17 +9290,17 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/socks/-/socks-2.8.5.tgz",
-    "sha512": "885fad3434256b6da0789753c89075c0cfeaad7f43311c16adc8843f058b3d158050433cb108b2c607242f1593d5fefef5569b252d234c61abe10801baf8ba5b",
+    "url": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+    "sha512": "1cba6dfae2f2fe9c41f9bba6ffd0f302088a4bc097d44bdb5b1238ce59a01821312262dd89a776882c174f967873d73712af2b3f6df5f263d6d9cf906ed8caf0",
     "dest": "flatpak-node/npm",
-    "dest-filename": "socks-885fad3434256b6da0789753c89075c0cfeaad7f43311c16adc8843f058b3d158050433cb108b2c607242f1593d5fefef5569b252d234c61abe10801baf8ba5b"
+    "dest-filename": "socks-1cba6dfae2f2fe9c41f9bba6ffd0f302088a4bc097d44bdb5b1238ce59a01821312262dd89a776882c174f967873d73712af2b3f6df5f263d6d9cf906ed8caf0"
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
-    "sha512": "16097460f67dd36c04b00ca243e89d19dd40eeb485c7f6b20b509054cc393fe110c765744a0a46b5fe8e2858558cf7e53d497d60c9843a799f8c274c52cca0c3",
+    "url": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+    "sha512": "1de84212ca2d16a6cf5bdb09f1655807a51b98832fee4514391205d8d9dcab8550bc17cd04b89b5bd619479765602494870703eb6f29465966ee7f84f984f327",
     "dest": "flatpak-node/npm",
-    "dest-filename": "socks-proxy-agent-16097460f67dd36c04b00ca243e89d19dd40eeb485c7f6b20b509054cc393fe110c765744a0a46b5fe8e2858558cf7e53d497d60c9843a799f8c274c52cca0c3"
+    "dest-filename": "socks-proxy-agent-1de84212ca2d16a6cf5bdb09f1655807a51b98832fee4514391205d8d9dcab8550bc17cd04b89b5bd619479765602494870703eb6f29465966ee7f84f984f327"
   },
   {
     "type": "file",
@@ -8832,6 +9308,13 @@
     "sha512": "51758c2a12cec1529bef6f0852d40f5f17d853ebac7726ed52b2bff2e184f0240cbeb84ea70bf30c1c23d108522fb31073bbc8b084811bc550f3e203431a5f40",
     "dest": "flatpak-node/npm",
     "dest-filename": "source-map-js-51758c2a12cec1529bef6f0852d40f5f17d853ebac7726ed52b2bff2e184f0240cbeb84ea70bf30c1c23d108522fb31073bbc8b084811bc550f3e203431a5f40"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+    "sha512": "e0f453e2787510898f6edda301238a1d7ecf07b23e7b821634bbe42850f13612657e36d8965798421dbce59ff798f4c74802bf02f74c9b0e4134db981fc4a181",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "spdx-license-ids-e0f453e2787510898f6edda301238a1d7ecf07b23e7b821634bbe42850f13612657e36d8965798421dbce59ff798f4c74802bf02f74c9b0e4134db981fc4a181"
   },
   {
     "type": "file",
@@ -8891,6 +9374,13 @@
   },
   {
     "type": "file",
+    "url": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
+    "sha512": "fba7ab2db066d3e2d1397dac3d7954631feec793f213d2bf6bdd96aedea803e5830281537691c4e6d098088e4f373ab6cbc75fe2b03e4201cb26e4788cdca6b2",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "terser-fba7ab2db066d3e2d1397dac3d7954631feec793f213d2bf6bdd96aedea803e5830281537691c4e6d098088e4f373ab6cbc75fe2b03e4201cb26e4788cdca6b2"
+  },
+  {
+    "type": "file",
     "url": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
     "sha512": "d35100c39103adc56b760c822e0a123efab39c2d2c5710d255e88ecf4f455298e1ef51bbf550aa9de3abfb1beded3d6befa085e9965f3e31e8acddbe77ede6a8",
     "dest": "flatpak-node/npm",
@@ -8898,10 +9388,31 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-    "sha512": "9d90fb9bd8823c2e60d2962671ac688182a08127cbb1dc65f287f743fa086ea0aa2cb20ef48005d065a35f5cfd3594473e25eff167b1e320c2699b20130d18f3",
+    "url": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+    "sha512": "8f666ae0dc90606e573124f871bb34d8093c88951dc513345c8e50cb15ee64ecca3883665aeae9dec997bb7cb9c03709ae9b70a528e05c7cc8431474a265e58d",
     "dest": "flatpak-node/npm",
-    "dest-filename": "tmp-9d90fb9bd8823c2e60d2962671ac688182a08127cbb1dc65f287f743fa086ea0aa2cb20ef48005d065a35f5cfd3594473e25eff167b1e320c2699b20130d18f3"
+    "dest-filename": "tinyglobby-8f666ae0dc90606e573124f871bb34d8093c88951dc513345c8e50cb15ee64ecca3883665aeae9dec997bb7cb9c03709ae9b70a528e05c7cc8431474a265e58d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+    "sha512": "b486d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "fdir-b486d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+    "sha512": "e604e680463fb2a2ba8055cb22c40d1f5f6559be1e6cf0cb03849d2cfeddb169085c75a51baea83ee56f5d21853e9a58673f190d9ab475862b6c77c109551bd5",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "picomatch-e604e680463fb2a2ba8055cb22c40d1f5f6559be1e6cf0cb03849d2cfeddb169085c75a51baea83ee56f5d21853e9a58673f190d9ab475862b6c77c109551bd5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+    "sha512": "be8cb3e8c0296b5ad0194c53dc4f812bbfd139ef22b44c7bbc3f3f1c4bede31c17b9cbd0e46e687848879261d926e04edb546939ff98626f4c3a2be3ef4f63a3",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "tmp-be8cb3e8c0296b5ad0194c53dc4f812bbfd139ef22b44c7bbc3f3f1c4bede31c17b9cbd0e46e687848879261d926e04edb546939ff98626f4c3a2be3ef4f63a3"
   },
   {
     "type": "file",
@@ -8909,6 +9420,13 @@
     "sha512": "47033b3283e88cfc6c381627c9dda1cb46f1b48955ae284db3da63e5252f63c673d6c41c406dad1b5852afc3c3c5f80407c44d28386a6c896ba086ab48d0cdb1",
     "dest": "flatpak-node/npm",
     "dest-filename": "tmp-promise-47033b3283e88cfc6c381627c9dda1cb46f1b48955ae284db3da63e5252f63c673d6c41c406dad1b5852afc3c3c5f80407c44d28386a6c896ba086ab48d0cdb1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
+    "sha512": "b41f362e90085a384b61baa3c775f8cc478737a33c0a2b8e132d8963c48441575845edc20873856aaac15b57682c3adfa5686995c5bb04bf9b3b7ffa4b7a5c0d",
+    "dest": "flatpak-node/npm",
+    "dest-filename": "to-buffer-b41f362e90085a384b61baa3c775f8cc478737a33c0a2b8e132d8963c48441575845edc20873856aaac15b57682c3adfa5686995c5bb04bf9b3b7ffa4b7a5c0d"
   },
   {
     "type": "file",
@@ -8926,10 +9444,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-    "sha512": "a757625ba4ea2fd2f4ee7371bd130cee130cc387395cea3fd626cbe1a0081a6480b7db254c4d57830e4a5aea1fdae4cebc283d058ed9462f86685fbbb1f80f79",
+    "url": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+    "sha512": "9c0618c1f637aa7cd7df422403a01066355bb4ae9db86a27b5c426d56486d4c0fde182ea2b4e75e46340a57928c4a39632eb15b2c00758b87d49e6a879f6051b",
     "dest": "flatpak-node/npm",
-    "dest-filename": "typescript-a757625ba4ea2fd2f4ee7371bd130cee130cc387395cea3fd626cbe1a0081a6480b7db254c4d57830e4a5aea1fdae4cebc283d058ed9462f86685fbbb1f80f79"
+    "dest-filename": "typed-array-buffer-9c0618c1f637aa7cd7df422403a01066355bb4ae9db86a27b5c426d56486d4c0fde182ea2b4e75e46340a57928c4a39632eb15b2c00758b87d49e6a879f6051b"
   },
   {
     "type": "file",
@@ -9024,10 +9542,10 @@
   },
   {
     "type": "file",
-    "url": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-    "sha512": "04b2374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c",
+    "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+    "sha512": "ac4bebf7405c938599b7d1c7142e0324cb23beeef1fabe9b226cf4fc1adb59bec0d9d8c9f219d932b5a71e8f45f2cb2fd0e304adab0385fb6b7d1393caa483af",
     "dest": "flatpak-node/npm",
-    "dest-filename": "which-04b2374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c"
+    "dest-filename": "which-typed-array-ac4bebf7405c938599b7d1c7142e0324cb23beeef1fabe9b226cf4fc1adb59bec0d9d8c9f219d932b5a71e8f45f2cb2fd0e304adab0385fb6b7d1393caa483af"
   },
   {
     "type": "file",
@@ -9081,14 +9599,20 @@
   {
     "type": "git",
     "url": "https://github.com/TurboWarp/types-tw.git",
-    "commit": "0cf07a4b9b5fe05bc1766db216d726c5bf373ec7",
-    "dest": "flatpak-node/git/types-tw-0cf07a4b9b5fe05bc1766db216d726c5bf373ec7"
+    "commit": "dfefbd12587ac30be1963d414648e44b14e223d4",
+    "dest": "flatpak-node/git/types-tw-dfefbd12587ac30be1963d414648e44b14e223d4"
   },
   {
     "type": "git",
     "url": "https://github.com/TurboWarp/extensions.git",
-    "commit": "b7b3a4881b546b482400c33443e188a945dfa9e5",
-    "dest": "flatpak-node/git/extensions-b7b3a4881b546b482400c33443e188a945dfa9e5"
+    "commit": "847e6d0f0f0ecb9721878c7e2c3e94cd039ab809",
+    "dest": "flatpak-node/git/extensions-847e6d0f0f0ecb9721878c7e2c3e94cd039ab809"
+  },
+  {
+    "type": "git",
+    "url": "https://github.com/TurboWarp/types-tw.git",
+    "commit": "0cf07a4b9b5fe05bc1766db216d726c5bf373ec7",
+    "dest": "flatpak-node/git/types-tw-0cf07a4b9b5fe05bc1766db216d726c5bf373ec7"
   },
   {
     "type": "git",
@@ -9099,8 +9623,8 @@
   {
     "type": "git",
     "url": "https://github.com/TurboWarp/scratch-blocks.git",
-    "commit": "67121bfdb8ae5448abdd90de37c2d56921f261a5",
-    "dest": "flatpak-node/git/scratch-blocks-67121bfdb8ae5448abdd90de37c2d56921f261a5"
+    "commit": "6a7e7e5561f25dce86d4ffe664703a110f5945e7",
+    "dest": "flatpak-node/git/scratch-blocks-6a7e7e5561f25dce86d4ffe664703a110f5945e7"
   },
   {
     "type": "git",
@@ -9123,8 +9647,8 @@
   {
     "type": "git",
     "url": "https://github.com/TurboWarp/scratch-render.git",
-    "commit": "49f714ec63edfb84a6e450ce2c2daf30e0b53632",
-    "dest": "flatpak-node/git/scratch-render-49f714ec63edfb84a6e450ce2c2daf30e0b53632"
+    "commit": "dd5d399eace4b5bae11906e2237fe67ee6b79d84",
+    "dest": "flatpak-node/git/scratch-render-dd5d399eace4b5bae11906e2237fe67ee6b79d84"
   },
   {
     "type": "git",
@@ -9147,27 +9671,21 @@
   {
     "type": "git",
     "url": "https://github.com/TurboWarp/scratch-vm.git",
-    "commit": "6222be2a3c1e1fe22add331685a4f5b746eec969",
-    "dest": "flatpak-node/git/scratch-vm-6222be2a3c1e1fe22add331685a4f5b746eec969"
+    "commit": "55674f82eef8d901affdb2e6061d5127020be489",
+    "dest": "flatpak-node/git/scratch-vm-55674f82eef8d901affdb2e6061d5127020be489"
   },
   {
     "type": "git",
     "url": "https://github.com/TurboWarp/scratch-gui.git",
-    "commit": "063c399a77f99c4bc60e7b633da7a0990170fab1",
-    "dest": "flatpak-node/git/scratch-gui-063c399a77f99c4bc60e7b633da7a0990170fab1"
+    "commit": "63a507a3ee7f12662408dfb20c7ad393c6ff1dd0",
+    "dest": "flatpak-node/git/scratch-gui-63a507a3ee7f12662408dfb20c7ad393c6ff1dd0"
   },
   {
     "type": "script",
     "commands": [
       "set -x",
-      "mkdir -p \"node_modules/@ampproject/remapping\"",
-      "tar -xzf \"flatpak-node/npm/remapping-df4899b403e0cfe2d3218a1e8afa98a3ce777f4da305849de6e1a71a9905574337c4eb7d68def77ab920600999538df1e157ea7272f15bd2a98374792c2e1863\" -C \"node_modules/@ampproject/remapping\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@ampproject/remapping\"",
-      "tar -xzf \"flatpak-node/npm/remapping-df4899b403e0cfe2d3218a1e8afa98a3ce777f4da305849de6e1a71a9905574337c4eb7d68def77ab920600999538df1e157ea7272f15bd2a98374792c2e1863\" -C \"node_modules/scratch-gui/node_modules/@ampproject/remapping\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/cli\"",
-      "tar -xzf \"flatpak-node/npm/cli-71f77b0e71a5847e8e232b8f4928f7bdc7c87676d7ba4840c8a63c35a66b15a742ee95f22fd98e2f95a08dca6d88424b8b99378fc698bcb2150b37b3ad64da88\" -C \"node_modules/@babel/cli\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/cli\"",
-      "tar -xzf \"flatpak-node/npm/cli-71f77b0e71a5847e8e232b8f4928f7bdc7c87676d7ba4840c8a63c35a66b15a742ee95f22fd98e2f95a08dca6d88424b8b99378fc698bcb2150b37b3ad64da88\" -C \"node_modules/scratch-gui/node_modules/@babel/cli\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/cli-098ad91bb15a82d13c45e28305f22dc67ac405fda486ad9e4cc9cfbaa3bc515374c33869d5e317d707dd6bc6f56b7da5d9aa982f045120e18da2f9bc155ce633\" -C \"node_modules/@babel/cli\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/cli/node_modules/chokidar\"",
       "tar -xzf \"flatpak-node/npm/chokidar-ed54f5ddf9a3a2d2a91a2a425bd244400bac10f13e122f2797afe0e050409889b418e38b32e6bd3430e8fc35a9d190310abddc3eae59a41aa63c04200dd6b63f\" -C \"node_modules/@babel/cli/node_modules/chokidar\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/chokidar\"",
@@ -9235,13 +9753,9 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/code-frame\"",
       "tar -xzf \"flatpak-node/npm/code-frame-72343b66543432fddbe3b84006e4debf24ee60de22fa5a09286795f5f95c0a020adfb7025d187e2f56ddde20479729deae143b0610a49f604f6d050bfab1aa16\" -C \"node_modules/scratch-gui/node_modules/@babel/code-frame\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/compat-data\"",
-      "tar -xzf \"flatpak-node/npm/compat-data-2a2440a7f56825a5a492d7bce13bd477daa375b640762ab2bccc6b1a5d4deafcc5a202a668b8283372f5920b4b89ca761cfe5f0494bc26b64a2d521919524056\" -C \"node_modules/@babel/compat-data\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/compat-data\"",
-      "tar -xzf \"flatpak-node/npm/compat-data-2a2440a7f56825a5a492d7bce13bd477daa375b640762ab2bccc6b1a5d4deafcc5a202a668b8283372f5920b4b89ca761cfe5f0494bc26b64a2d521919524056\" -C \"node_modules/scratch-gui/node_modules/@babel/compat-data\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/compat-data-eb45fbaa4825beb6a9f269f5961d9e6f15dd658b5472977b82c9b2f642da049e22fd6758f0fa9349dc7203caab6a292a2902b90b529104a5eace7ad56a9c8d6b\" -C \"node_modules/@babel/compat-data\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/core\"",
-      "tar -xzf \"flatpak-node/npm/core-6d7631ad716e6de61dbc1d0d843fcd041dd08ba699795db418e595238eedd9d91e7021289de47834f55c6fb69ba570c4bde8e0ad47c5b46eaf1bfcf100a9a0fa\" -C \"node_modules/@babel/core\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/core\"",
-      "tar -xzf \"flatpak-node/npm/core-6d7631ad716e6de61dbc1d0d843fcd041dd08ba699795db418e595238eedd9d91e7021289de47834f55c6fb69ba570c4bde8e0ad47c5b46eaf1bfcf100a9a0fa\" -C \"node_modules/scratch-gui/node_modules/@babel/core\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/core-d8108e3fb4cdf0cfa05438fbfe1b7786c68efc1fe7e680db880cb2be746534eb3ebb5a3e2563584d0ae6a6e369d7f5aada0705ac8d352405bea5a10a0ccc7f08\" -C \"node_modules/@babel/core\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/core/node_modules/semver\"",
       "tar -xzf \"flatpak-node/npm/semver-051ed5bc30951cefaadb10445ac9314ba0c9135a919dbec3c7352ba206fbd425a849f89c07162c88019df8a9749a6abf329ac6f7202b464cab4314cee978cccc\" -C \"node_modules/@babel/core/node_modules/semver\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/helper-compilation-targets/node_modules/semver\"",
@@ -9261,9 +9775,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/semver\"",
       "tar -xzf \"flatpak-node/npm/semver-051ed5bc30951cefaadb10445ac9314ba0c9135a919dbec3c7352ba206fbd425a849f89c07162c88019df8a9749a6abf329ac6f7202b464cab4314cee978cccc\" -C \"node_modules/scratch-gui/node_modules/semver\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/generator\"",
-      "tar -xzf \"flatpak-node/npm/generator-646840dfb9747bf836b350a7cdd8b1d0edda2d89bae9e17c6ae7e256d78e827c3182744ff06a32323ed55ac8169d06d5297ca07bb86aac58762b64d033ab751f\" -C \"node_modules/@babel/generator\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/generator\"",
-      "tar -xzf \"flatpak-node/npm/generator-646840dfb9747bf836b350a7cdd8b1d0edda2d89bae9e17c6ae7e256d78e827c3182744ff06a32323ed55ac8169d06d5297ca07bb86aac58762b64d033ab751f\" -C \"node_modules/scratch-gui/node_modules/@babel/generator\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/generator-de54a9c4682f9e66739e60640919d54443d4149bf6c2bbfd880a050ef00325cd32a6674ec5d52d70b78180127acc4d0f31e4ca9f1790cf2934c5306ae04a7bcf\" -C \"node_modules/@babel/generator\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/helper-annotate-as-pure\"",
       "tar -xzf \"flatpak-node/npm/helper-annotate-as-pure-7d74b0310aa2b5319e1cb042d3c12ae725f3da6dfb138a495f5a80535fb670d79dcff89fbff6d55dfb7dd157926afe6714eeb511c360c2bd1a2716f23da5813e\" -C \"node_modules/@babel/helper-annotate-as-pure\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/helper-compilation-targets\"",
@@ -9275,7 +9787,9 @@
       "mkdir -p \"node_modules/@babel/helper-create-regexp-features-plugin\"",
       "tar -xzf \"flatpak-node/npm/helper-create-regexp-features-plugin-b950c2ef65d57fc51bac7e6a413735f0081bf1e9b08d3899ad0135d4dbf70ae04466656f4f0c04f4205412f1e4bb4ea040203261ff0dbfa8dad4837ee8b31bc5\" -C \"node_modules/@babel/helper-create-regexp-features-plugin\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/helper-define-polyfill-provider\"",
-      "tar -xzf \"flatpak-node/npm/helper-define-polyfill-provider-8e58df475ac69d75cd5a79908362b7f9bbe1931079d51977d9045a393bb0c23be21ab1f321b49cf3ec7d0a9ada0ed6d3ee67f28d739b50b3f8c3f69dba737003\" -C \"node_modules/@babel/helper-define-polyfill-provider\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/helper-define-polyfill-provider-b899c615c3ec5902bc7ef8e018fe4b654659b18188a0f7918d21793c6c2b7a5620abb435e7f16df4d185a75ce0970808bfffd6d2e1b805ebd1b92251cb29593e\" -C \"node_modules/@babel/helper-define-polyfill-provider\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@babel/helper-globals\"",
+      "tar -xzf \"flatpak-node/npm/helper-globals-f96e9c21291715ad635ec0c475803c1de7af413fc550b871cd1f7da71a6196d65c55aba0a6ce774c709e89603c4a0bb1c694a9de028f8ae61f496a2990b43887\" -C \"node_modules/@babel/helper-globals\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/helper-member-expression-to-functions\"",
       "tar -xzf \"flatpak-node/npm/helper-member-expression-to-functions-13972133c7968d3a7f68da15a5c6df33b98bc6ef5718b5988ac7b678128642898093f31be17a31caa5d365bb93a216ec97c10aa9d94c8670c8d8208b7dcb3dc0\" -C \"node_modules/@babel/helper-member-expression-to-functions\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/helper-module-imports\"",
@@ -9283,9 +9797,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/helper-module-imports\"",
       "tar -xzf \"flatpak-node/npm/helper-module-imports-d204855943cd5cda29aad20f42f943e56817608e4663690fd9c0afa13f247338db7dc7ee2258d36dc5abba50f50883c85f682dd708216c3cb4f32135a7efebdf\" -C \"node_modules/scratch-gui/node_modules/@babel/helper-module-imports\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/helper-module-transforms\"",
-      "tar -xzf \"flatpak-node/npm/helper-module-transforms-7523af630bf22ec58178847239e1d7a79bcf8f9975234d75af9d85335fabd6308446ff9a157624e3086041c7181066312b61f7640200f27b8f910d07694a37aa\" -C \"node_modules/@babel/helper-module-transforms\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/helper-module-transforms\"",
-      "tar -xzf \"flatpak-node/npm/helper-module-transforms-7523af630bf22ec58178847239e1d7a79bcf8f9975234d75af9d85335fabd6308446ff9a157624e3086041c7181066312b61f7640200f27b8f910d07694a37aa\" -C \"node_modules/scratch-gui/node_modules/@babel/helper-module-transforms\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/helper-module-transforms-832b5751bb3c936b174bd3e7429b73e68d109e92cbe754b001220e458e97681285f3c9ec393d19c3db332ea9521900cfff84e58c1003e72f7ca765357ea91db3\" -C \"node_modules/@babel/helper-module-transforms\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/helper-optimise-call-expression\"",
       "tar -xzf \"flatpak-node/npm/helper-optimise-call-expression-5113061f4f0dcd8161b9b352189ae9504a6118a430310601c92cdab79700072635fd880846450b9c8cb7b4031eb3394bfeca361db7a29589685264a977b19d57\" -C \"node_modules/@babel/helper-optimise-call-expression\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/helper-plugin-utils\"",
@@ -9313,13 +9825,9 @@
       "mkdir -p \"node_modules/@babel/helper-wrap-function\"",
       "tar -xzf \"flatpak-node/npm/helper-wrap-function-34524adac1d4beb8e8f30014fe7413594f3dd3fcc1da38f4a817026d96db7fed34e5c02cbfab4c8d7cf7d5f062827e8ce68bf5a3406596efbd9dbaa47ec8e325\" -C \"node_modules/@babel/helper-wrap-function\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/helpers\"",
-      "tar -xzf \"flatpak-node/npm/helpers-9ae13c4edf0cdb6eb7f07537d40dc281f494722c33d5f8404dfa156a2d3968f5c6a2bfff09d58309b9e5635caf04fa34ee78ee54e08d1824a9fc64edd76948ba\" -C \"node_modules/@babel/helpers\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/helpers\"",
-      "tar -xzf \"flatpak-node/npm/helpers-9ae13c4edf0cdb6eb7f07537d40dc281f494722c33d5f8404dfa156a2d3968f5c6a2bfff09d58309b9e5635caf04fa34ee78ee54e08d1824a9fc64edd76948ba\" -C \"node_modules/scratch-gui/node_modules/@babel/helpers\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/helpers-1c5379f4c9905c61d5c9869d28b56e998b00f5d045ba7fe5758c62a448f3038d7dea3a4b65df148c41012e46c492f7d8ade0ea2616716005853edadf84da63e3\" -C \"node_modules/@babel/helpers\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/parser\"",
-      "tar -xzf \"flatpak-node/npm/parser-3ac41dd7be52c569069736e7cbc2772bc4e79c30f437796b214b41f76c70c91a7369e9c6661c43bf137f260534d14dc20d9363f6d3ee0c9e47d164b836ddef2a\" -C \"node_modules/@babel/parser\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/parser\"",
-      "tar -xzf \"flatpak-node/npm/parser-3ac41dd7be52c569069736e7cbc2772bc4e79c30f437796b214b41f76c70c91a7369e9c6661c43bf137f260534d14dc20d9363f6d3ee0c9e47d164b836ddef2a\" -C \"node_modules/scratch-gui/node_modules/@babel/parser\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/parser-c996c1a9e33a4e4a4ff5dbbf236a5466726c44c186bceb88ae18f30b50301f05beea17b89a78ba069fe6f228e7d223ae66e3c8d817e40a8491ba7a728e7ad02a\" -C \"node_modules/@babel/parser\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key\"",
       "tar -xzf \"flatpak-node/npm/plugin-bugfix-firefox-class-in-computed-class-key-40f1b70bd70255140bc4057099e7c49b07536a7102b9404c419ff29b9922c375ca08603baa4b902dc8d658772b0ff18a6e7fd6989c1a7b37eeb8039cc8a9513c\" -C \"node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope\"",
@@ -9343,23 +9851,23 @@
       "mkdir -p \"node_modules/@babel/plugin-transform-arrow-functions\"",
       "tar -xzf \"flatpak-node/npm/plugin-transform-arrow-functions-f19e131a273ac56ef414a4e10391d810a2b206938eb2e713383d438d4ddf6710e0f8adf30497173059edff8c908999dfe7e32238c49743d3da10afc8961d4378\" -C \"node_modules/@babel/plugin-transform-arrow-functions\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-async-generator-functions\"",
-      "tar -xzf \"flatpak-node/npm/plugin-transform-async-generator-functions-7924fd46bc25a5aa090431d285cf834b6486e004d38b631835be0ec5891fde7fbb79be3d2d6a674be1d2a557d6e31f76eea430824f00da118d55a6a3004c3410\" -C \"node_modules/@babel/plugin-transform-async-generator-functions\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/plugin-transform-async-generator-functions-04439dbd7e3e33beb989c34f65e89dc800c8bd0d66d609ae9d7b9f5f1bd1112cbf8cd3727e8bc8a94c84ecc5601818d692d0a8265cef140d53a363b8ca620edd\" -C \"node_modules/@babel/plugin-transform-async-generator-functions\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-async-to-generator\"",
       "tar -xzf \"flatpak-node/npm/plugin-transform-async-to-generator-35112466c655252e31993afcab3139cbc01f20faac7507d1b9488b4531336fb4228bc885582c8329a515d9cd2b0ae8789630d9f7c00b1cffcf7ad8815769dd74\" -C \"node_modules/@babel/plugin-transform-async-to-generator\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-block-scoped-functions\"",
       "tar -xzf \"flatpak-node/npm/plugin-transform-block-scoped-functions-727aa4b8eb592daa56619518339ad521dbf59d762e155225b59e9927b9c88f9f3942c8ca3397612f616efe52025d9d4ec8800573b432f9bbc302d4d7a86ae586\" -C \"node_modules/@babel/plugin-transform-block-scoped-functions\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-block-scoping\"",
-      "tar -xzf \"flatpak-node/npm/plugin-transform-block-scoping-245eae136b3aedfd32d9165c9b692901411b0f9d2f1fad93c9655e6f1c070256d274ce3d56a3f3f2de1ad6e223a78348388678c732df8d8e5e9adfd10b20bb4d\" -C \"node_modules/@babel/plugin-transform-block-scoping\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/plugin-transform-block-scoping-80a2a7c23a5dc79b0447fc25d1637479f50117317fe7a6193b4449ad260fe029635e73f7d41c98edfa25f3d033a267652cdcc8dfa02f3939981ec9d94c292af1\" -C \"node_modules/@babel/plugin-transform-block-scoping\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-class-properties\"",
       "tar -xzf \"flatpak-node/npm/plugin-transform-class-properties-0f455c6a50a10ccb6e46f248bb753f7f05a37fc64cca4cf9899b20efb36e8fcdb5bc2288df30b244bc117566ecb89fee470661674d3642d0aa224c02fd992f6c\" -C \"node_modules/@babel/plugin-transform-class-properties\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-class-static-block\"",
       "tar -xzf \"flatpak-node/npm/plugin-transform-class-static-block-b3bdf81e6614efc315cd9fbe8e860cf8d909bac22d6dd45c6e6f801918090adde203ecaec744290fd70155dcf7b4acab8d5616465ee3d261d29afe25855d1aa0\" -C \"node_modules/@babel/plugin-transform-class-static-block\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-classes\"",
-      "tar -xzf \"flatpak-node/npm/plugin-transform-classes-ee22e17c502e6e6a5e25efd6a364d5b83af2921ff39565cbccf35d2f426a9ff5eef11dd043c87d7dff0542821264eb30ef8fc716a148ecd5fadc737b40520728\" -C \"node_modules/@babel/plugin-transform-classes\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/plugin-transform-classes-22333522824dc3bd80645963df70aef17d2ad972bfe806950b78d0bbe7204399538560f96a39ee5009a5f3476a4663a198f9131fcb80c27a4cbbd46f8f42d344\" -C \"node_modules/@babel/plugin-transform-classes\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-computed-properties\"",
       "tar -xzf \"flatpak-node/npm/plugin-transform-computed-properties-963f4f196bcc4d592c6d68834f6b56ebccc64bf732a3802467f413a74b104f49a33e8a429ab4a4cf17979339e3a81c730c8e937256613896c199b04b8ee39953\" -C \"node_modules/@babel/plugin-transform-computed-properties\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-destructuring\"",
-      "tar -xzf \"flatpak-node/npm/plugin-transform-destructuring-b3826ba24f3626989a229aed6369c7b189ab4e12afbf0807c2381ded432262165a3746ac75734baf4cbe3634df900ed2c901398b615bede6b050e6662efcaa38\" -C \"node_modules/@babel/plugin-transform-destructuring\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/plugin-transform-destructuring-bf59eb48c06229ca1d86cc89e067fe67453fc9ac2624304e4e9101de6710639dabf512323e7786c804bfc8ceac78fffc23e9962377a538cb53e5d07c18956cf8\" -C \"node_modules/@babel/plugin-transform-destructuring\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-dotall-regex\"",
       "tar -xzf \"flatpak-node/npm/plugin-transform-dotall-regex-8046e40d5191be38fbf93d62bf1adf8328294fb194778be6383b58a5bb348190137645fcfe24a73ad652c62667b209b56234e08c8e952811922497af92b725cf\" -C \"node_modules/@babel/plugin-transform-dotall-regex\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-duplicate-keys\"",
@@ -9368,6 +9876,8 @@
       "tar -xzf \"flatpak-node/npm/plugin-transform-duplicate-named-capturing-groups-regex-86419cb9e4c4cee841df407778909b09878269a1103a6411d0076fce90f82e8374197316cf3192b91af1476c539c2aef35b5702bd37afe343dd8648b7e2656a1\" -C \"node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-dynamic-import\"",
       "tar -xzf \"flatpak-node/npm/plugin-transform-dynamic-import-307ce45907049a3cf3556f63daaf0b1a3c065a91b69a3c1a681d01350c2cb771488eab20f02b7f988665bd23c9bdf8bdcb6002f268bf92dc5b1552fda59d48e0\" -C \"node_modules/@babel/plugin-transform-dynamic-import\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@babel/plugin-transform-explicit-resource-management\"",
+      "tar -xzf \"flatpak-node/npm/plugin-transform-explicit-resource-management-2bc9e151c9f77fa881f8fde0c02bff9e8ece77339941c29c856e8ddfcf55e8f0fc35458a647ce774e77db0f0d56cca01b1b9a332a941e0bf5f9be7c414d565c1\" -C \"node_modules/@babel/plugin-transform-explicit-resource-management\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-exponentiation-operator\"",
       "tar -xzf \"flatpak-node/npm/plugin-transform-exponentiation-operator-baca6f5e7847bc629fdabe1556d0697859ee0d6b092d0e8c17a94624b0bcf63051d6ea157aa338d7a019b53ba14decce7e01e27292509a80f96146a43bf6265d\" -C \"node_modules/@babel/plugin-transform-exponentiation-operator\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-export-namespace-from\"",
@@ -9401,7 +9911,7 @@
       "mkdir -p \"node_modules/@babel/plugin-transform-numeric-separator\"",
       "tar -xzf \"flatpak-node/npm/plugin-transform-numeric-separator-7dd3ca01cba3baf1028710c127973ed014da4baadebcb57b0892f4f1ee26ddd7bca897cd22e09cda773b5c960e8c1a133097aa4a6c17274ca9135e110a32f06b\" -C \"node_modules/@babel/plugin-transform-numeric-separator\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-object-rest-spread\"",
-      "tar -xzf \"flatpak-node/npm/plugin-transform-object-rest-spread-ed966dce717d8389762422260a8e4b34a1470797979cddfd94bb4b6394e0f95911d23c0eb7b4c172231c92e89020e216ecbe6d9103828776d519879780cc79d9\" -C \"node_modules/@babel/plugin-transform-object-rest-spread\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/plugin-transform-object-rest-spread-f553468a45f1ceee5e0a2423744e08667f2c6fdabb5ec9391172c304a5188357bf4ef7bcff4e7e28912d7311b1020098e6dfc1a4a40cf8910bff24f8b6f82250\" -C \"node_modules/@babel/plugin-transform-object-rest-spread\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-object-super\"",
       "tar -xzf \"flatpak-node/npm/plugin-transform-object-super-485cbc4bda6544f6c8731949f00ea64ff0b115d271fdcd3824472dcf88dff1865a552da9c77e23ecd5d1ae51a51e437f336827a4bdfb66919119514b77797c36\" -C \"node_modules/@babel/plugin-transform-object-super\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-optional-catch-binding\"",
@@ -9409,7 +9919,7 @@
       "mkdir -p \"node_modules/@babel/plugin-transform-optional-chaining\"",
       "tar -xzf \"flatpak-node/npm/plugin-transform-optional-chaining-05098a3cf22e73c12466034ab2fd17e1b3e63a86b27aee05d580b0c76fc27e60d25c36e9ec69f39541fefee9795467d183502814fb2b2138651018f6c5be0202\" -C \"node_modules/@babel/plugin-transform-optional-chaining\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-parameters\"",
-      "tar -xzf \"flatpak-node/npm/plugin-transform-parameters-d35f0a464efa1d629e679978a138f6ccfa5287e35b19db74b2de52eb1d2981ae8782b8c13896f6e263031e8ac5a2938e77a60790b80e67ecda0a36463cee1a2a\" -C \"node_modules/@babel/plugin-transform-parameters\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/plugin-transform-parameters-a819184d809befa451c5433a09c640e4a46ef0ae1233c6a3cd579481574c54ef4d37db88fc669598183f58a2491a7368915f5263c17134e556197ceacd489d06\" -C \"node_modules/@babel/plugin-transform-parameters\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-private-methods\"",
       "tar -xzf \"flatpak-node/npm/plugin-transform-private-methods-d74155b7e5f9e408d101823d06b74848df7f010587aa574e7990d4a0bca27f52a7d396b9eb15415dbf19a2e2fca59f637a6f10a5768eb7c4d2ed11d4212f863c\" -C \"node_modules/@babel/plugin-transform-private-methods\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-private-property-in-object\"",
@@ -9417,7 +9927,7 @@
       "mkdir -p \"node_modules/@babel/plugin-transform-property-literals\"",
       "tar -xzf \"flatpak-node/npm/plugin-transform-property-literals-a13872dc10ae0a16bc90367c66480e8367b1bcf614969accba42905c8d6bd69278ecd0afc5f904cbcbcafabfe14fd9c5d006b81f55943d96631d316d02119f99\" -C \"node_modules/@babel/plugin-transform-property-literals\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-react-display-name\"",
-      "tar -xzf \"flatpak-node/npm/plugin-transform-react-display-name-a7df95977cae1cf9a48ab46b834db55e23fe1044e63cc4132ebe80ca38fce512cd11b6f71326bfe15234bc0773406f521009762e7b7b7f2e656723338d8a1941\" -C \"node_modules/@babel/plugin-transform-react-display-name\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/plugin-transform-react-display-name-0fa12e8dcdb33312a37dae19c65e061ccb2684a299f55a5ca8872124bbf04f169df7358862e970608b41a2fa433a834b212a5c6525e80c9e606866d0503a9588\" -C \"node_modules/@babel/plugin-transform-react-display-name\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-react-jsx\"",
       "tar -xzf \"flatpak-node/npm/plugin-transform-react-jsx-d8a1f82d6192ac922455fe6d4a204562e5c3028591ab630cc208af09ffbdddd7741908bc4572e3280ff412f467555e46d21ac7733b2ab97b83d352fcb3a76607\" -C \"node_modules/@babel/plugin-transform-react-jsx\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-react-jsx-development\"",
@@ -9425,7 +9935,7 @@
       "mkdir -p \"node_modules/@babel/plugin-transform-react-pure-annotations\"",
       "tar -xzf \"flatpak-node/npm/plugin-transform-react-pure-annotations-25fba29ef0ceb03f4554c4c7a7303fa412e2b31a6fd5a49ff8e215f25807dccb96ae4b35f51dbb7ba6ba0e2a48838697d599bd5a96f4e29f309637caad54a73c\" -C \"node_modules/@babel/plugin-transform-react-pure-annotations\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-regenerator\"",
-      "tar -xzf \"flatpak-node/npm/plugin-transform-regenerator-ba107cc877ab7dedcc5a7b8b02111b790e1a7d5a2abfc050b0faab4efedefe367dcb4d2424bea5f5afdfe0e59a2b1a2d9a3cdec1f1325c4d6f80325e9e4436fd\" -C \"node_modules/@babel/plugin-transform-regenerator\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/plugin-transform-regenerator-3f442257fb5a69ade45e92d8fac5e56b9cde73813ee2de00a9cf6080795f67b6b6729f3fc7f1afd3c8dfc04b67f609e760832f1f1e9aa0e67c5c92fc794ef50e\" -C \"node_modules/@babel/plugin-transform-regenerator\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-regexp-modifiers\"",
       "tar -xzf \"flatpak-node/npm/plugin-transform-regexp-modifiers-4ed11c8aba1a88e0ed5ef2d9bf8ae67cc8640aff23c77c202a92faf0fba23e1d8ce1fbf3e6386c03bebdecdd6032f92faff253175dc3ac563211b63d53b7153c\" -C \"node_modules/@babel/plugin-transform-regexp-modifiers\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/plugin-transform-reserved-words\"",
@@ -9449,7 +9959,7 @@
       "mkdir -p \"node_modules/@babel/plugin-transform-unicode-sets-regex\"",
       "tar -xzf \"flatpak-node/npm/plugin-transform-unicode-sets-regex-12d90eba36dce1c82f6f49a5a5079f8b83533c1ce14887af6e515ebc008d2d4b299ab00b82610174bfd77e7cb22137ddf1f28166b672b3ddb339672293b8fd4f\" -C \"node_modules/@babel/plugin-transform-unicode-sets-regex\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/preset-env\"",
-      "tar -xzf \"flatpak-node/npm/preset-env-31ae334ae6129463519422cef840332e70a624adaf76cb60bfe9fb6943fefc8299ace7d61ce25575226dbae6fc4731d38f76a10f7ee4e4e2895afcdfd7a4d0c9\" -C \"node_modules/@babel/preset-env\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/preset-env-5666b17863b0b83ab32e5e495242113355f642edae286c471105a1f9cbef6e5ec9b894602862527ec105fdb51ac4584997f5c0cb105eeeaeea4ae4db285b82ca\" -C \"node_modules/@babel/preset-env\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/preset-modules\"",
       "tar -xzf \"flatpak-node/npm/preset-modules-1eb7207081122e6f5a211f38db2849e5159a9ff81e6d0509e84fc4e7eadfd32f68ea88fbc3406bfac5ae2fa90443fa3f01d7ef47525ef631b5f3f827a708c4c8\" -C \"node_modules/@babel/preset-modules\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/preset-react\"",
@@ -9463,29 +9973,29 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/template\"",
       "tar -xzf \"flatpak-node/npm/template-2cf0d9f39684272612775f3f0e48cd878ff2d67b641392b05075938aa811c6bbae64bd85d72b879628151cbbdc1d8daf3075edb4a169267e8bc1f23b730ece0f\" -C \"node_modules/scratch-gui/node_modules/@babel/template\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/traverse\"",
-      "tar -xzf \"flatpak-node/npm/traverse-a0d72ed906c7aadb3d06d396268b0e5496a95a30434b1182a45be290d4794c60d80d07f7270a48a0ccc82abbdfa2d8bdddc2df3c9106e2d1fd48f55ec821a074\" -C \"node_modules/@babel/traverse\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/traverse\"",
-      "tar -xzf \"flatpak-node/npm/traverse-a0d72ed906c7aadb3d06d396268b0e5496a95a30434b1182a45be290d4794c60d80d07f7270a48a0ccc82abbdfa2d8bdddc2df3c9106e2d1fd48f55ec821a074\" -C \"node_modules/scratch-gui/node_modules/@babel/traverse\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/traverse-604cee6e83f6aaf41abc072381035582cbc7203bfa669c17bdcbe39b2c923f60c832e0724bfea2a14e46f6962b58733a4f66037dcef181af6237360eb35d8215\" -C \"node_modules/@babel/traverse\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@babel/types\"",
-      "tar -xzf \"flatpak-node/npm/types-113c87124d951c7be5f5bf6364fe481cf6af1d8939ec485a9e5451b9a7bd5c2a5bfe3e5b0c26cf3cc3817c25a19e5ffb103273d2310c0a2fd185c70213caf5f9\" -C \"node_modules/@babel/types\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/types\"",
-      "tar -xzf \"flatpak-node/npm/types-113c87124d951c7be5f5bf6364fe481cf6af1d8939ec485a9e5451b9a7bd5c2a5bfe3e5b0c26cf3cc3817c25a19e5ffb103273d2310c0a2fd185c70213caf5f9\" -C \"node_modules/scratch-gui/node_modules/@babel/types\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/types-6e416a90b861de9301510424a558160d6abf96acdcdbaefc794c8395306146a8421c582e61818cd047e06bbb589384e8806ff7c7410497aebf390f9619b581fd\" -C \"node_modules/@babel/types\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@develar/schema-utils\"",
       "tar -xzf \"flatpak-node/npm/schema-utils-d1ca783ec590ffd6afa9354c0ad67e1a2ae2908037ea292f8ed1f0794e3f8fcc8bb6039b234f8950f858152720c25b5ebde181d6bb770a6f1484dd385dac838a\" -C \"node_modules/@develar/schema-utils\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@discoveryjs/json-ext\"",
       "tar -xzf \"flatpak-node/npm/json-ext-74156e5d1d3cda09378ec169ed177f248e24cadc061de7270a84ed5c56fb0c1e82347a78ae0e64d5b860d2759d2c62e7395ef59660f319068b332f223cb634a7\" -C \"node_modules/@discoveryjs/json-ext\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@electron/asar\"",
-      "tar -xzf \"flatpak-node/npm/asar-d97caf31edcddcdaecf1c577f482842d11d36145852ab9aaa9263553e18c95cd23bea8c8567a3184d7761f826895642771b262d430af6f94cdc59b88d9f1235a\" -C \"node_modules/@electron/asar\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/asar-8b8feb34f452f38b74bd245ad87a2b7ab1915d6c85e2f4e17c77acc347667161e9f9cb292bbe3751a9c0d2cb80e50e72f24cd8db2e982abbdb2149faf4108088\" -C \"node_modules/@electron/asar\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@electron/asar/node_modules/minimatch\"",
       "tar -xzf \"flatpak-node/npm/minimatch-27ba7ade1462023c35343130c355bb8b7efe07222b3963b95d0400cd9dd539c2f43cdc9bc297e657f374e73140cf043d512c84717eaddd43be2b96aa0503881f\" -C \"node_modules/@electron/asar/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@eslint/config-array/node_modules/minimatch\"",
+      "tar -xzf \"flatpak-node/npm/minimatch-27ba7ade1462023c35343130c355bb8b7efe07222b3963b95d0400cd9dd539c2f43cdc9bc297e657f374e73140cf043d512c84717eaddd43be2b96aa0503881f\" -C \"node_modules/@eslint/config-array/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@eslint/eslintrc/node_modules/minimatch\"",
+      "tar -xzf \"flatpak-node/npm/minimatch-27ba7ade1462023c35343130c355bb8b7efe07222b3963b95d0400cd9dd539c2f43cdc9bc297e657f374e73140cf043d512c84717eaddd43be2b96aa0503881f\" -C \"node_modules/@eslint/eslintrc/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/minimatch\"",
       "tar -xzf \"flatpak-node/npm/minimatch-27ba7ade1462023c35343130c355bb8b7efe07222b3963b95d0400cd9dd539c2f43cdc9bc297e657f374e73140cf043d512c84717eaddd43be2b96aa0503881f\" -C \"node_modules/@turbowarp/extensions/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/dir-compare/node_modules/minimatch\"",
       "tar -xzf \"flatpak-node/npm/minimatch-27ba7ade1462023c35343130c355bb8b7efe07222b3963b95d0400cd9dd539c2f43cdc9bc297e657f374e73140cf043d512c84717eaddd43be2b96aa0503881f\" -C \"node_modules/dir-compare/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/eslint/node_modules/minimatch\"",
+      "tar -xzf \"flatpak-node/npm/minimatch-27ba7ade1462023c35343130c355bb8b7efe07222b3963b95d0400cd9dd539c2f43cdc9bc297e657f374e73140cf043d512c84717eaddd43be2b96aa0503881f\" -C \"node_modules/eslint/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/glob/node_modules/minimatch\"",
       "tar -xzf \"flatpak-node/npm/minimatch-27ba7ade1462023c35343130c355bb8b7efe07222b3963b95d0400cd9dd539c2f43cdc9bc297e657f374e73140cf043d512c84717eaddd43be2b96aa0503881f\" -C \"node_modules/glob/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/jake/node_modules/minimatch\"",
-      "tar -xzf \"flatpak-node/npm/minimatch-27ba7ade1462023c35343130c355bb8b7efe07222b3963b95d0400cd9dd539c2f43cdc9bc297e657f374e73140cf043d512c84717eaddd43be2b96aa0503881f\" -C \"node_modules/jake/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/mocha/node_modules/minimatch\"",
       "tar -xzf \"flatpak-node/npm/minimatch-27ba7ade1462023c35343130c355bb8b7efe07222b3963b95d0400cd9dd539c2f43cdc9bc297e657f374e73140cf043d512c84717eaddd43be2b96aa0503881f\" -C \"node_modules/mocha/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/minimatch\"",
@@ -9495,7 +10005,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/minimatch\"",
       "tar -xzf \"flatpak-node/npm/minimatch-27ba7ade1462023c35343130c355bb8b7efe07222b3963b95d0400cd9dd539c2f43cdc9bc297e657f374e73140cf043d512c84717eaddd43be2b96aa0503881f\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@electron/fuses\"",
-      "tar -xzf \"flatpak-node/npm/fuses-cf1d0422aefc5a563f9416f5b97973899983648e2e6dc09720c278b868d7cd95b49d2d7d4e348f7973c08f3cd398a425254666d126e66613ca3fbb6e4354ac13\" -C \"node_modules/@electron/fuses\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/fuses-9726f5ccadd81de5948dacfbca22b41a7c523ddbb001228cca20db0ad6e7deca4fe8412df945ad92d82059e846d22705ad7024dc6c2f709e270ab24ed0df4885\" -C \"node_modules/@electron/fuses\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@electron/get\"",
       "tar -xzf \"flatpak-node/npm/get-424ce9836b3d1a7555d88d818d192c522e375397bafb369031c8e8272d02f82e68c5a2a5f9f99c9060d016d469669655d0d41e92e659fad1b3ec403d4d59d0b5\" -C \"node_modules/@electron/get\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@electron/get/node_modules/fs-extra\"",
@@ -9520,68 +10030,140 @@
       "tar -xzf \"flatpak-node/npm/universalify-ac125e2390970259b2d6957eeb5ed607d27add4e9771acc71c5d9fd9d6c98b1e17ce9505d114b765b8f414620e080bdae4ffddfc604e61a002435c3ed1acd492\" -C \"node_modules/electron-winstaller/node_modules/universalify\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/universalify\"",
       "tar -xzf \"flatpak-node/npm/universalify-ac125e2390970259b2d6957eeb5ed607d27add4e9771acc71c5d9fd9d6c98b1e17ce9505d114b765b8f414620e080bdae4ffddfc604e61a002435c3ed1acd492\" -C \"node_modules/scratch-gui/node_modules/universalify\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@electron/node-gyp/node_modules/brace-expansion\"",
-      "tar -xzf \"flatpak-node/npm/brace-expansion-26dd2f1f233e8e6501aa88c1ec4d4d21869db74bc8d10c63c5dd9312b5bde300f3f84d8b026e6f28c5d7c20e996414c73ee5250e0407297be318175f705d590d\" -C \"node_modules/@electron/node-gyp/node_modules/brace-expansion\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@electron/notarize\"",
+      "tar -xzf \"flatpak-node/npm/notarize-8cd4fc9f01f57fd5f91842135da43c205fca76c92f2243857c1d82bf0ba6b2f79589dce949cfa6be185331d0064981773be36ae3d949ef2facb0e0d15eed3af8\" -C \"node_modules/@electron/notarize\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@electron/notarize/node_modules/fs-extra\"",
+      "tar -xzf \"flatpak-node/npm/fs-extra-85c8376667a94b7d3fec1485a91be8a370ce310bbb223ab13b99c20edfb333d5d68dbdf75a0ef388d4fe42fa9bb9cdfe816a733b4d89b9b5729361b866fa3539\" -C \"node_modules/@electron/notarize/node_modules/fs-extra\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@malept/flatpak-bundler/node_modules/fs-extra\"",
+      "tar -xzf \"flatpak-node/npm/fs-extra-85c8376667a94b7d3fec1485a91be8a370ce310bbb223ab13b99c20edfb333d5d68dbdf75a0ef388d4fe42fa9bb9cdfe816a733b4d89b9b5729361b866fa3539\" -C \"node_modules/@malept/flatpak-bundler/node_modules/fs-extra\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/app-builder-lib/node_modules/@electron/fuses/node_modules/fs-extra\"",
+      "tar -xzf \"flatpak-node/npm/fs-extra-85c8376667a94b7d3fec1485a91be8a370ce310bbb223ab13b99c20edfb333d5d68dbdf75a0ef388d4fe42fa9bb9cdfe816a733b4d89b9b5729361b866fa3539\" -C \"node_modules/app-builder-lib/node_modules/@electron/fuses/node_modules/fs-extra\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@electron/osx-sign\"",
+      "tar -xzf \"flatpak-node/npm/osx-sign-299f26857bd6bf6ac812031b599e32df76c31f250a3179f1e0cd2c4f23cd2bfbdc07cd4899d798f4681dab2d1259b3038266eac90fa98607a387a57747642e4a\" -C \"node_modules/@electron/osx-sign\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@electron/osx-sign/node_modules/isbinaryfile\"",
+      "tar -xzf \"flatpak-node/npm/isbinaryfile-887aea7b9b21bc151c15b999abdcce40706878e85926ee91406ac3a4181e9d49bf026f85dc9336320423fab2b767ad357f3acbe602d95ad00f1f638169255ccb\" -C \"node_modules/@electron/osx-sign/node_modules/isbinaryfile\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@electron/rebuild\"",
+      "tar -xzf \"flatpak-node/npm/rebuild-88c1976fa21bec7fd0deff81299268113805f60e8a30d6556ec3b86fb0e6a606f9a9316ac854f3a96f45dd33921ddc9bbf6bca60acd24bd3a264bf9d7096fed5\" -C \"node_modules/@electron/rebuild\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@electron/universal\"",
+      "tar -xzf \"flatpak-node/npm/universal-5a7f6c3d8215151165e479b030990044209feeba8afc4bab91f43fac9675e261cfde26138d94883925689c40278567805f0b70ef339e90646573ac93b59d2dfa\" -C \"node_modules/@electron/universal\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@electron/universal/node_modules/brace-expansion\"",
       "tar -xzf \"flatpak-node/npm/brace-expansion-26dd2f1f233e8e6501aa88c1ec4d4d21869db74bc8d10c63c5dd9312b5bde300f3f84d8b026e6f28c5d7c20e996414c73ee5250e0407297be318175f705d590d\" -C \"node_modules/@electron/universal/node_modules/brace-expansion\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/config-file-ts/node_modules/brace-expansion\"",
-      "tar -xzf \"flatpak-node/npm/brace-expansion-26dd2f1f233e8e6501aa88c1ec4d4d21869db74bc8d10c63c5dd9312b5bde300f3f84d8b026e6f28c5d7c20e996414c73ee5250e0407297be318175f705d590d\" -C \"node_modules/config-file-ts/node_modules/brace-expansion\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/filelist/node_modules/brace-expansion\"",
+      "tar -xzf \"flatpak-node/npm/brace-expansion-26dd2f1f233e8e6501aa88c1ec4d4d21869db74bc8d10c63c5dd9312b5bde300f3f84d8b026e6f28c5d7c20e996414c73ee5250e0407297be318175f705d590d\" -C \"node_modules/@turbowarp/extensions/node_modules/filelist/node_modules/brace-expansion\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/filelist/node_modules/brace-expansion\"",
       "tar -xzf \"flatpak-node/npm/brace-expansion-26dd2f1f233e8e6501aa88c1ec4d4d21869db74bc8d10c63c5dd9312b5bde300f3f84d8b026e6f28c5d7c20e996414c73ee5250e0407297be318175f705d590d\" -C \"node_modules/filelist/node_modules/brace-expansion\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/make-fetch-happen/node_modules/brace-expansion\"",
       "tar -xzf \"flatpak-node/npm/brace-expansion-26dd2f1f233e8e6501aa88c1ec4d4d21869db74bc8d10c63c5dd9312b5bde300f3f84d8b026e6f28c5d7c20e996414c73ee5250e0407297be318175f705d590d\" -C \"node_modules/make-fetch-happen/node_modules/brace-expansion\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@electron/node-gyp/node_modules/glob\"",
-      "tar -xzf \"flatpak-node/npm/glob-afc869123890118945d9053475fddd4be9f1c5222b797412d6a461309334439343751dfce82ee36fb1f0c2877c1608ae7b1fa4d0616381fb75f32bf19b95e809\" -C \"node_modules/@electron/node-gyp/node_modules/glob\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/make-fetch-happen/node_modules/glob\"",
-      "tar -xzf \"flatpak-node/npm/glob-afc869123890118945d9053475fddd4be9f1c5222b797412d6a461309334439343751dfce82ee36fb1f0c2877c1608ae7b1fa4d0616381fb75f32bf19b95e809\" -C \"node_modules/make-fetch-happen/node_modules/glob\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@electron/node-gyp/node_modules/minimatch\"",
-      "tar -xzf \"flatpak-node/npm/minimatch-94ac15ff56eba46ea6054147b5becd526b400426f65996669b6c0d88e0398406fc55d092e01dddb4c5b2bdca1589c730016fc23844635cbb74ccfd735d4376ea\" -C \"node_modules/@electron/node-gyp/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/filelist/node_modules/minimatch\"",
-      "tar -xzf \"flatpak-node/npm/minimatch-94ac15ff56eba46ea6054147b5becd526b400426f65996669b6c0d88e0398406fc55d092e01dddb4c5b2bdca1589c730016fc23844635cbb74ccfd735d4376ea\" -C \"node_modules/@turbowarp/extensions/node_modules/filelist/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/filelist/node_modules/minimatch\"",
-      "tar -xzf \"flatpak-node/npm/minimatch-94ac15ff56eba46ea6054147b5becd526b400426f65996669b6c0d88e0398406fc55d092e01dddb4c5b2bdca1589c730016fc23844635cbb74ccfd735d4376ea\" -C \"node_modules/filelist/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/make-fetch-happen/node_modules/minimatch\"",
-      "tar -xzf \"flatpak-node/npm/minimatch-94ac15ff56eba46ea6054147b5becd526b400426f65996669b6c0d88e0398406fc55d092e01dddb4c5b2bdca1589c730016fc23844635cbb74ccfd735d4376ea\" -C \"node_modules/make-fetch-happen/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@electron/notarize\"",
-      "tar -xzf \"flatpak-node/npm/notarize-8cd4fc9f01f57fd5f91842135da43c205fca76c92f2243857c1d82bf0ba6b2f79589dce949cfa6be185331d0064981773be36ae3d949ef2facb0e0d15eed3af8\" -C \"node_modules/@electron/notarize\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@electron/osx-sign\"",
-      "tar -xzf \"flatpak-node/npm/osx-sign-0407ef89444c1e999bd586f9d186c2c67398d307f068b5c7e4a278fbcd334b48149330d7dde736de7693944a8ab0df8fc189fe6b5702cccec127859c777b06cf\" -C \"node_modules/@electron/osx-sign\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@electron/osx-sign/node_modules/fs-extra\"",
-      "tar -xzf \"flatpak-node/npm/fs-extra-a115c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d\" -C \"node_modules/@electron/osx-sign/node_modules/fs-extra\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@electron/rebuild/node_modules/fs-extra\"",
-      "tar -xzf \"flatpak-node/npm/fs-extra-a115c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d\" -C \"node_modules/@electron/rebuild/node_modules/fs-extra\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/app-builder-lib/node_modules/fs-extra\"",
-      "tar -xzf \"flatpak-node/npm/fs-extra-a115c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d\" -C \"node_modules/app-builder-lib/node_modules/fs-extra\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/builder-util/node_modules/fs-extra\"",
-      "tar -xzf \"flatpak-node/npm/fs-extra-a115c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d\" -C \"node_modules/builder-util/node_modules/fs-extra\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/dmg-builder/node_modules/fs-extra\"",
-      "tar -xzf \"flatpak-node/npm/fs-extra-a115c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d\" -C \"node_modules/dmg-builder/node_modules/fs-extra\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/electron-builder/node_modules/fs-extra\"",
-      "tar -xzf \"flatpak-node/npm/fs-extra-a115c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d\" -C \"node_modules/electron-builder/node_modules/fs-extra\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/electron-publish/node_modules/fs-extra\"",
-      "tar -xzf \"flatpak-node/npm/fs-extra-a115c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d\" -C \"node_modules/electron-publish/node_modules/fs-extra\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/temp-file/node_modules/fs-extra\"",
-      "tar -xzf \"flatpak-node/npm/fs-extra-a115c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d\" -C \"node_modules/temp-file/node_modules/fs-extra\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@electron/osx-sign/node_modules/isbinaryfile\"",
-      "tar -xzf \"flatpak-node/npm/isbinaryfile-887aea7b9b21bc151c15b999abdcce40706878e85926ee91406ac3a4181e9d49bf026f85dc9336320423fab2b767ad357f3acbe602d95ad00f1f638169255ccb\" -C \"node_modules/@electron/osx-sign/node_modules/isbinaryfile\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@electron/rebuild\"",
-      "tar -xzf \"flatpak-node/npm/rebuild-556fbe08d4a56703183fb3325c46eb2a3a73130841e640cd6f31ad88f123c18cacab24c217e61b349db5d038f70235ac19257888413036498937dc8666656f9b\" -C \"node_modules/@electron/rebuild\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@electron/universal\"",
-      "tar -xzf \"flatpak-node/npm/universal-7caa6ff6483848f9adfa163b49506721850b13d40997c2f7b027dc06c9ea6c9c3007001e4cba2427d4d1b7dcbb6cad09033216db2efc4d5563be74049acff2c8\" -C \"node_modules/@electron/universal\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@electron/universal/node_modules/fs-extra\"",
-      "tar -xzf \"flatpak-node/npm/fs-extra-6785da08be9d5031df3ff8d3db98c928c9adc6fbb06e4ac3d6f352305968f6534b6367391476124201cf459523001dba4e90c4a16f4708e82996b75b68f57f7b\" -C \"node_modules/@electron/universal/node_modules/fs-extra\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@electron/windows-sign/node_modules/fs-extra\"",
-      "tar -xzf \"flatpak-node/npm/fs-extra-6785da08be9d5031df3ff8d3db98c928c9adc6fbb06e4ac3d6f352305968f6534b6367391476124201cf459523001dba4e90c4a16f4708e82996b75b68f57f7b\" -C \"node_modules/@electron/windows-sign/node_modules/fs-extra\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/fs-extra-5ebf45eb3eaea7a5acf8d8f330265ce965e0d9815196b2cff4d4033b7550ad6adf8a88dd852e7a4f3b9e4fcf337b4b817424f0108850de9b6798a79618501ed0\" -C \"node_modules/@electron/universal/node_modules/fs-extra\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@electron/universal/node_modules/minimatch\"",
       "tar -xzf \"flatpak-node/npm/minimatch-1ba4f4657e3cc60a33c7be7cee4a1e5fd62cd8d632e869affff3fcf6c12d7bd57dc2121aa4c345e2274ac675b642d09c2e24d695bff07c269b02d0055a1841a3\" -C \"node_modules/@electron/universal/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/config-file-ts/node_modules/minimatch\"",
-      "tar -xzf \"flatpak-node/npm/minimatch-1ba4f4657e3cc60a33c7be7cee4a1e5fd62cd8d632e869affff3fcf6c12d7bd57dc2121aa4c345e2274ac675b642d09c2e24d695bff07c269b02d0055a1841a3\" -C \"node_modules/config-file-ts/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@electron/windows-sign\"",
-      "tar -xzf \"flatpak-node/npm/windows-sign-75f65ea31eba02f74fb5bda50fc3ac208421d764e9d063424540df04720a1a96e6a2966da36fc0f274a96182e879d3c81e9aa479b959fe4f0e5741b2ecf62ec9\" -C \"node_modules/@electron/windows-sign\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/make-fetch-happen/node_modules/minimatch\"",
+      "tar -xzf \"flatpak-node/npm/minimatch-1ba4f4657e3cc60a33c7be7cee4a1e5fd62cd8d632e869affff3fcf6c12d7bd57dc2121aa4c345e2274ac675b642d09c2e24d695bff07c269b02d0055a1841a3\" -C \"node_modules/make-fetch-happen/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@epic-web/invariant\"",
+      "tar -xzf \"flatpak-node/npm/invariant-96b4cfaa0bdf150b51fde63faa4233a7df0e19d349bb49b98e2deafe7248f2fdd25e444a1275a23b13266ef712a00233bff7068aebd1cb9ee4e2cb8a41201dc0\" -C \"node_modules/@epic-web/invariant\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@eslint-community/eslint-utils\"",
+      "tar -xzf \"flatpak-node/npm/eslint-utils-6b25451ddb59fa1b2ad6dd83cb6e300a619719ee2af46bb7b2684b6002c9aebe3bdd91f6eccb2748bf8b2949629a9e01589a8c0cc2e63e9c7f43d47738094be2\" -C \"node_modules/@eslint-community/eslint-utils\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@eslint-community/eslint-utils\"",
+      "tar -xzf \"flatpak-node/npm/eslint-utils-6b25451ddb59fa1b2ad6dd83cb6e300a619719ee2af46bb7b2684b6002c9aebe3bdd91f6eccb2748bf8b2949629a9e01589a8c0cc2e63e9c7f43d47738094be2\" -C \"node_modules/@turbowarp/extensions/node_modules/@eslint-community/eslint-utils\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys\"",
+      "tar -xzf \"flatpak-node/npm/eslint-visitor-keys-c2973e2d77a2ca28acc4f944914cd4eacbf24b57eb20edcc8318f57ddcbb3e6f1883382e6b1d8ddc56bf0ff6a0d56a9b3a9add23eb98eb031497cfdad86fa26a\" -C \"node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys\"",
+      "tar -xzf \"flatpak-node/npm/eslint-visitor-keys-c2973e2d77a2ca28acc4f944914cd4eacbf24b57eb20edcc8318f57ddcbb3e6f1883382e6b1d8ddc56bf0ff6a0d56a9b3a9add23eb98eb031497cfdad86fa26a\" -C \"node_modules/@turbowarp/extensions/node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/espree/node_modules/eslint-visitor-keys\"",
+      "tar -xzf \"flatpak-node/npm/eslint-visitor-keys-c2973e2d77a2ca28acc4f944914cd4eacbf24b57eb20edcc8318f57ddcbb3e6f1883382e6b1d8ddc56bf0ff6a0d56a9b3a9add23eb98eb031497cfdad86fa26a\" -C \"node_modules/@turbowarp/extensions/node_modules/espree/node_modules/eslint-visitor-keys\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/espree/node_modules/eslint-visitor-keys\"",
+      "tar -xzf \"flatpak-node/npm/eslint-visitor-keys-c2973e2d77a2ca28acc4f944914cd4eacbf24b57eb20edcc8318f57ddcbb3e6f1883382e6b1d8ddc56bf0ff6a0d56a9b3a9add23eb98eb031497cfdad86fa26a\" -C \"node_modules/espree/node_modules/eslint-visitor-keys\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@eslint-community/regexpp\"",
+      "tar -xzf \"flatpak-node/npm/regexpp-0826420c9b9db81f4e524164636220a69359322da5050803daacf05e41226b5e9c81eda98a363f6978bde8224caae0cc9f79c97653d5d40e4aac9117c1f2cdcd\" -C \"node_modules/@eslint-community/regexpp\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@eslint-community/regexpp\"",
+      "tar -xzf \"flatpak-node/npm/regexpp-0826420c9b9db81f4e524164636220a69359322da5050803daacf05e41226b5e9c81eda98a363f6978bde8224caae0cc9f79c97653d5d40e4aac9117c1f2cdcd\" -C \"node_modules/@turbowarp/extensions/node_modules/@eslint-community/regexpp\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@eslint/config-array\"",
+      "tar -xzf \"flatpak-node/npm/config-array-6b0d6035ac96a5d23f8d2615833379a4bd1c7f3534d864f7341a5e4ff0d76f1d7fd71ed92b114f77d6f0af3ca0c7faa2c08422275b30ff30fca98fe446f9461c\" -C \"node_modules/@eslint/config-array\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@eslint/config-array\"",
+      "tar -xzf \"flatpak-node/npm/config-array-6b0d6035ac96a5d23f8d2615833379a4bd1c7f3534d864f7341a5e4ff0d76f1d7fd71ed92b114f77d6f0af3ca0c7faa2c08422275b30ff30fca98fe446f9461c\" -C \"node_modules/@turbowarp/extensions/node_modules/@eslint/config-array\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@eslint/config-helpers\"",
+      "tar -xzf \"flatpak-node/npm/config-helpers-72c640ce4361b20c1bd08fd4015ebf4461536e26a43c27f466b1a6ac8c50a58bc6674d0f8539129f228da25a61808be69c9786c3aadc1951177d3cd49c5b84bf\" -C \"node_modules/@eslint/config-helpers\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@eslint/config-helpers\"",
+      "tar -xzf \"flatpak-node/npm/config-helpers-72c640ce4361b20c1bd08fd4015ebf4461536e26a43c27f466b1a6ac8c50a58bc6674d0f8539129f228da25a61808be69c9786c3aadc1951177d3cd49c5b84bf\" -C \"node_modules/@turbowarp/extensions/node_modules/@eslint/config-helpers\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@eslint/core\"",
+      "tar -xzf \"flatpak-node/npm/core-9e60bcfeda2dc286c8885706903cdadc620a7c0c35fa12e2615ae1dc8d67228990f0f12be5cc60df88e792619ac2e97f7a9e76c0644073278308db562923a3e1\" -C \"node_modules/@eslint/core\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@eslint/core\"",
+      "tar -xzf \"flatpak-node/npm/core-9e60bcfeda2dc286c8885706903cdadc620a7c0c35fa12e2615ae1dc8d67228990f0f12be5cc60df88e792619ac2e97f7a9e76c0644073278308db562923a3e1\" -C \"node_modules/@turbowarp/extensions/node_modules/@eslint/core\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@eslint/eslintrc\"",
+      "tar -xzf \"flatpak-node/npm/eslintrc-82d175f3a097848975a78a49346670f1873a465b21a1e3d1bc4d17f75a0f19bdef67ca4cdea392f56f4d18f6adf4bce268157b5eb2561b294d41790672733721\" -C \"node_modules/@eslint/eslintrc\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@eslint/eslintrc\"",
+      "tar -xzf \"flatpak-node/npm/eslintrc-82d175f3a097848975a78a49346670f1873a465b21a1e3d1bc4d17f75a0f19bdef67ca4cdea392f56f4d18f6adf4bce268157b5eb2561b294d41790672733721\" -C \"node_modules/@turbowarp/extensions/node_modules/@eslint/eslintrc\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@eslint/eslintrc/node_modules/acorn\"",
+      "tar -xzf \"flatpak-node/npm/acorn-359c896ab05f2fb9d6c08abe1432fa669ff21c485e3cc3679c9d32dea7e2782ae636f61cb7cbafb62578d54be549ee9aa407e4d1f63515b5b1f8dc1f9a9bed4e\" -C \"node_modules/@eslint/eslintrc/node_modules/acorn\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/acorn\"",
+      "tar -xzf \"flatpak-node/npm/acorn-359c896ab05f2fb9d6c08abe1432fa669ff21c485e3cc3679c9d32dea7e2782ae636f61cb7cbafb62578d54be549ee9aa407e4d1f63515b5b1f8dc1f9a9bed4e\" -C \"node_modules/@turbowarp/extensions/node_modules/acorn\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/eslint/node_modules/acorn\"",
+      "tar -xzf \"flatpak-node/npm/acorn-359c896ab05f2fb9d6c08abe1432fa669ff21c485e3cc3679c9d32dea7e2782ae636f61cb7cbafb62578d54be549ee9aa407e4d1f63515b5b1f8dc1f9a9bed4e\" -C \"node_modules/eslint/node_modules/acorn\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/espree/node_modules/acorn\"",
+      "tar -xzf \"flatpak-node/npm/acorn-359c896ab05f2fb9d6c08abe1432fa669ff21c485e3cc3679c9d32dea7e2782ae636f61cb7cbafb62578d54be549ee9aa407e4d1f63515b5b1f8dc1f9a9bed4e\" -C \"node_modules/espree/node_modules/acorn\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/acorn\"",
+      "tar -xzf \"flatpak-node/npm/acorn-359c896ab05f2fb9d6c08abe1432fa669ff21c485e3cc3679c9d32dea7e2782ae636f61cb7cbafb62578d54be549ee9aa407e4d1f63515b5b1f8dc1f9a9bed4e\" -C \"node_modules/scratch-gui/node_modules/acorn\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/terser/node_modules/acorn\"",
+      "tar -xzf \"flatpak-node/npm/acorn-359c896ab05f2fb9d6c08abe1432fa669ff21c485e3cc3679c9d32dea7e2782ae636f61cb7cbafb62578d54be549ee9aa407e4d1f63515b5b1f8dc1f9a9bed4e\" -C \"node_modules/terser/node_modules/acorn\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@eslint/eslintrc/node_modules/espree\"",
+      "tar -xzf \"flatpak-node/npm/espree-8fa3c0436b94afbf4f6610633f90b97e197c7b7f459919ce8ec0f99469d6ac553c8b61bbefab412bbfa73fc2ae4144d3c80654c1f42a5c082b547e4c6c7f4261\" -C \"node_modules/@eslint/eslintrc/node_modules/espree\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@eslint/eslintrc/node_modules/espree\"",
+      "tar -xzf \"flatpak-node/npm/espree-8fa3c0436b94afbf4f6610633f90b97e197c7b7f459919ce8ec0f99469d6ac553c8b61bbefab412bbfa73fc2ae4144d3c80654c1f42a5c082b547e4c6c7f4261\" -C \"node_modules/@turbowarp/extensions/node_modules/@eslint/eslintrc/node_modules/espree\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/eslint/node_modules/espree\"",
+      "tar -xzf \"flatpak-node/npm/espree-8fa3c0436b94afbf4f6610633f90b97e197c7b7f459919ce8ec0f99469d6ac553c8b61bbefab412bbfa73fc2ae4144d3c80654c1f42a5c082b547e4c6c7f4261\" -C \"node_modules/@turbowarp/extensions/node_modules/eslint/node_modules/espree\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/eslint/node_modules/espree\"",
+      "tar -xzf \"flatpak-node/npm/espree-8fa3c0436b94afbf4f6610633f90b97e197c7b7f459919ce8ec0f99469d6ac553c8b61bbefab412bbfa73fc2ae4144d3c80654c1f42a5c082b547e4c6c7f4261\" -C \"node_modules/eslint/node_modules/espree\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@eslint/js\"",
+      "tar -xzf \"flatpak-node/npm/js-519d55a45bd77fd274e981bdc5005d9f353e92d868aece8a8e130097a7f8807e2eb07ca1df5ad47f60cb1889d3f111582117985cd4b27603d8d15d8bb96825ec\" -C \"node_modules/@eslint/js\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@eslint/js\"",
+      "tar -xzf \"flatpak-node/npm/js-519d55a45bd77fd274e981bdc5005d9f353e92d868aece8a8e130097a7f8807e2eb07ca1df5ad47f60cb1889d3f111582117985cd4b27603d8d15d8bb96825ec\" -C \"node_modules/@turbowarp/extensions/node_modules/@eslint/js\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@eslint/object-schema\"",
+      "tar -xzf \"flatpak-node/npm/object-schema-56d00e6b299655f65c9996e9e84da6ca6a43207bf28d7b3fd762ea5988d5c3aaa3adf17e54af9fc86df7902873de79caf92539fcd7873aaad31074bcb173b738\" -C \"node_modules/@eslint/object-schema\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@eslint/object-schema\"",
+      "tar -xzf \"flatpak-node/npm/object-schema-56d00e6b299655f65c9996e9e84da6ca6a43207bf28d7b3fd762ea5988d5c3aaa3adf17e54af9fc86df7902873de79caf92539fcd7873aaad31074bcb173b738\" -C \"node_modules/@turbowarp/extensions/node_modules/@eslint/object-schema\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@eslint/plugin-kit\"",
+      "tar -xzf \"flatpak-node/npm/plugin-kit-b01e6ec9eabe770096c8f8b7d41da0425565a3e8f96eb3e55b1e32641ac4691a3f9e174313c5e47b582c1a0b6205d6814f1b9391c78b56e56dfe9725adab1bd0\" -C \"node_modules/@eslint/plugin-kit\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@eslint/plugin-kit\"",
+      "tar -xzf \"flatpak-node/npm/plugin-kit-b01e6ec9eabe770096c8f8b7d41da0425565a3e8f96eb3e55b1e32641ac4691a3f9e174313c5e47b582c1a0b6205d6814f1b9391c78b56e56dfe9725adab1bd0\" -C \"node_modules/@turbowarp/extensions/node_modules/@eslint/plugin-kit\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@eslint/plugin-kit/node_modules/levn\"",
+      "tar -xzf \"flatpak-node/npm/levn-f9b4f6b87e04e4b184ee1fe7ddebdc4bfb109495c2a48a7aca6f0e589e5e57afbaec3b2a97f2da693eea24102ddabcdfa1aff94011818710e2c7574cb7691029\" -C \"node_modules/@eslint/plugin-kit/node_modules/levn\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/levn\"",
+      "tar -xzf \"flatpak-node/npm/levn-f9b4f6b87e04e4b184ee1fe7ddebdc4bfb109495c2a48a7aca6f0e589e5e57afbaec3b2a97f2da693eea24102ddabcdfa1aff94011818710e2c7574cb7691029\" -C \"node_modules/@turbowarp/extensions/node_modules/levn\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/eslint/node_modules/levn\"",
+      "tar -xzf \"flatpak-node/npm/levn-f9b4f6b87e04e4b184ee1fe7ddebdc4bfb109495c2a48a7aca6f0e589e5e57afbaec3b2a97f2da693eea24102ddabcdfa1aff94011818710e2c7574cb7691029\" -C \"node_modules/eslint/node_modules/levn\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@eslint/plugin-kit/node_modules/prelude-ls\"",
+      "tar -xzf \"flatpak-node/npm/prelude-ls-be47033eb459a354192db9f944b18fa60fd698843ae6aa165a170629ffdbe5ea659246ab5f49bdcfca6909ab789a53aa52c5a9c8db9880edd5472ad81d2cd7e6\" -C \"node_modules/@eslint/plugin-kit/node_modules/prelude-ls\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/prelude-ls\"",
+      "tar -xzf \"flatpak-node/npm/prelude-ls-be47033eb459a354192db9f944b18fa60fd698843ae6aa165a170629ffdbe5ea659246ab5f49bdcfca6909ab789a53aa52c5a9c8db9880edd5472ad81d2cd7e6\" -C \"node_modules/@turbowarp/extensions/node_modules/prelude-ls\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/eslint/node_modules/prelude-ls\"",
+      "tar -xzf \"flatpak-node/npm/prelude-ls-be47033eb459a354192db9f944b18fa60fd698843ae6aa165a170629ffdbe5ea659246ab5f49bdcfca6909ab789a53aa52c5a9c8db9880edd5472ad81d2cd7e6\" -C \"node_modules/eslint/node_modules/prelude-ls\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@eslint/plugin-kit/node_modules/type-check\"",
+      "tar -xzf \"flatpak-node/npm/type-check-5e5794a1cf6ec065ea8d6c176944d9026ccc705679f39f10036befc7552be7121c8b15c83fef0b9c50e0469954df4bacead7aa765b2415fbbe69ee0aefd3a87b\" -C \"node_modules/@eslint/plugin-kit/node_modules/type-check\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/type-check\"",
+      "tar -xzf \"flatpak-node/npm/type-check-5e5794a1cf6ec065ea8d6c176944d9026ccc705679f39f10036befc7552be7121c8b15c83fef0b9c50e0469954df4bacead7aa765b2415fbbe69ee0aefd3a87b\" -C \"node_modules/@turbowarp/extensions/node_modules/type-check\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/eslint/node_modules/type-check\"",
+      "tar -xzf \"flatpak-node/npm/type-check-5e5794a1cf6ec065ea8d6c176944d9026ccc705679f39f10036befc7552be7121c8b15c83fef0b9c50e0469954df4bacead7aa765b2415fbbe69ee0aefd3a87b\" -C \"node_modules/eslint/node_modules/type-check\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@gar/promisify\"",
       "tar -xzf \"flatpak-node/npm/promisify-9364f2d49715a238c9170ae0fd384a8b6ba327b5cd2d868518d07f6d64fdc0647ea123091cc6b9c3e094abaa7fa55aca78d36003ba42a847234a71d5a2a25017\" -C \"node_modules/@gar/promisify\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/@gar/promisify\"",
       "tar -xzf \"flatpak-node/npm/promisify-9364f2d49715a238c9170ae0fd384a8b6ba327b5cd2d868518d07f6d64fdc0647ea123091cc6b9c3e094abaa7fa55aca78d36003ba42a847234a71d5a2a25017\" -C \"node_modules/scratch-gui/node_modules/@gar/promisify\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@humanfs/core\"",
+      "tar -xzf \"flatpak-node/npm/core-e43c90e3ed49114cde8de2b524620272275ec9f51b1a2c604bd8cd81ec799ea916f9c63b59987106282689e379427c3d668b123550bd2902b26fe194686c8a50\" -C \"node_modules/@humanfs/core\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@humanfs/core\"",
+      "tar -xzf \"flatpak-node/npm/core-e43c90e3ed49114cde8de2b524620272275ec9f51b1a2c604bd8cd81ec799ea916f9c63b59987106282689e379427c3d668b123550bd2902b26fe194686c8a50\" -C \"node_modules/@turbowarp/extensions/node_modules/@humanfs/core\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@humanfs/node\"",
+      "tar -xzf \"flatpak-node/npm/node-ff3531fb23ac22b1b8638dc4876a5e0de282c6546dfe0113e9a1df68aa6eab6ebba977580c55625477cc68bcb28193a79749065b114882c072f1016e4cb51711\" -C \"node_modules/@humanfs/node\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@humanfs/node\"",
+      "tar -xzf \"flatpak-node/npm/node-ff3531fb23ac22b1b8638dc4876a5e0de282c6546dfe0113e9a1df68aa6eab6ebba977580c55625477cc68bcb28193a79749065b114882c072f1016e4cb51711\" -C \"node_modules/@turbowarp/extensions/node_modules/@humanfs/node\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@humanwhocodes/module-importer\"",
+      "tar -xzf \"flatpak-node/npm/module-importer-6f1bde57857cbf961be277054d3deb3d281904ea429237cad32e28555549c08b8354144c0d7acfc9744bf7cf22e5aa7d9bd6e7c8412359f9b95a4066b5f7cb7c\" -C \"node_modules/@humanwhocodes/module-importer\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@humanwhocodes/module-importer\"",
+      "tar -xzf \"flatpak-node/npm/module-importer-6f1bde57857cbf961be277054d3deb3d281904ea429237cad32e28555549c08b8354144c0d7acfc9744bf7cf22e5aa7d9bd6e7c8412359f9b95a4066b5f7cb7c\" -C \"node_modules/@turbowarp/extensions/node_modules/@humanwhocodes/module-importer\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@humanwhocodes/retry\"",
+      "tar -xzf \"flatpak-node/npm/retry-6d5d13828f4ae217cf09e93e68c027f35469a452afdb248341e328499baf4c04b2c0d4e7549080ac2644d855aaa6f21ab4abbb54c44b5a547511acef5610f285\" -C \"node_modules/@humanwhocodes/retry\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@humanwhocodes/retry\"",
+      "tar -xzf \"flatpak-node/npm/retry-6d5d13828f4ae217cf09e93e68c027f35469a452afdb248341e328499baf4c04b2c0d4e7549080ac2644d855aaa6f21ab4abbb54c44b5a547511acef5610f285\" -C \"node_modules/@turbowarp/extensions/node_modules/@humanwhocodes/retry\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@isaacs/balanced-match\"",
       "tar -xzf \"flatpak-node/npm/balanced-match-cb3313b7d9446fc1afef3462a148a54a0948d1cd2c999f64e43eb9ebbec32d62ed589697212dc2a9c1b250507260a967523e939232d5b39e1f065ebe4e21900d\" -C \"node_modules/@isaacs/balanced-match\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@isaacs/brace-expansion\"",
@@ -9589,41 +10171,43 @@
       "mkdir -p \"node_modules/@isaacs/cliui\"",
       "tar -xzf \"flatpak-node/npm/cliui-3bc8dc8da6d76a578e1bd0d0d3e0115d66414df9cfe16340ab3ba224aee5978e009b118abff2763384cf8f18d8df39c109fbc15c5cee726d6dc1dc85c9b16a10\" -C \"node_modules/@isaacs/cliui\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@isaacs/cliui/node_modules/ansi-regex\"",
-      "tar -xzf \"flatpak-node/npm/ansi-regex-ec7497e1041be02b297222e9545c3245eefd3b7c6c2190c32c4476d6411143bd6868fa1d17c8cbef6e408093050186e8a08aa8949a112ee33cd52a5e524a64bc\" -C \"node_modules/@isaacs/cliui/node_modules/ansi-regex\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/ansi-regex-06add2992a721476968cf93c21ff7273ab2f33c739e9d079040b56e106f0e631d3c305d77132e844c9290c9a7a54bd17ce559a0874d7ae415444c6260f4b0baa\" -C \"node_modules/@isaacs/cliui/node_modules/ansi-regex\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@isaacs/cliui/node_modules/ansi-styles\"",
-      "tar -xzf \"flatpak-node/npm/ansi-styles-6cdefdf2015f417faf8b0dd1ef2ac6591aa7acdda84641245238e5e09367e04f06c716e3b46dc56eb108218de5f3f86bc14c0878266f8b842e3933f8304ad5ba\" -C \"node_modules/@isaacs/cliui/node_modules/ansi-styles\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/ansi-styles-e038fa336f0907ea001fc9059132d4a3e6b68f038592ea9bdf2b9c53408035c45151bc52d1c3f49d96021a371cdc1357c1122c5159831a0cdac267bbcef247be\" -C \"node_modules/@isaacs/cliui/node_modules/ansi-styles\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@isaacs/cliui/node_modules/emoji-regex\"",
       "tar -xzf \"flatpak-node/npm/emoji-regex-2f5f03689b17494936fb8da9bfc98bb398c94f686a164144e23db5c0e9a06d4aac67684bef636c514efce60f515e0a37b3464d815978d93887a7766d3affd5ca\" -C \"node_modules/@isaacs/cliui/node_modules/emoji-regex\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@isaacs/cliui/node_modules/string-width\"",
       "tar -xzf \"flatpak-node/npm/string-width-1e72ce091def8dc63c6dea0d2ed723679fe7c67d9a7e6304ea586b0eb79ba24a8c6a9f976de5bc9fd4d7a4f0cea9d18ae6a708de84f418a4d6eb00bb10c895a8\" -C \"node_modules/@isaacs/cliui/node_modules/string-width\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@isaacs/cliui/node_modules/strip-ansi\"",
-      "tar -xzf \"flatpak-node/npm/strip-ansi-8aae9e55523ae274104d162ad8ab44836776b94ecb125853270b07e18cc81d9b21c658199acff021ce15a03413946fc8bd522b04a1b4e82ad99e9d2abfb86471\" -C \"node_modules/@isaacs/cliui/node_modules/strip-ansi\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/strip-ansi-826046b25a68409b609cc02f395a86669133f5dca82930b3cb69dfcff9fc68816137f8c213fac299cc5a6c1ea338e1d5fb458d9f294ec5ac4140f4af71692584\" -C \"node_modules/@isaacs/cliui/node_modules/strip-ansi\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@isaacs/cliui/node_modules/wrap-ansi\"",
       "tar -xzf \"flatpak-node/npm/wrap-ansi-b22ed0588eb350cab9e9b11216f6a0b66ccc7463ada317d1f927b3d753286df73bb66f9591472493d6d6d9479f7d319551b3a4b31992c34000da0b3c83bd4d09\" -C \"node_modules/@isaacs/cliui/node_modules/wrap-ansi\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@isaacs/fs-minipass\"",
+      "tar -xzf \"flatpak-node/npm/fs-minipass-c209bd1219768e97aa3f7cf0ffb9a8de4447169e4c10386a01dc32d5f4c69070309e418e56c829bd084bf01e67d6a95bd358d5de7fdb23465f669e65580d64e3\" -C \"node_modules/@isaacs/fs-minipass\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@isaacs/fs-minipass/node_modules/minipass\"",
+      "tar -xzf \"flatpak-node/npm/minipass-a8e3b34b57014d6605e011fc7d578f0c138ef62a6d327194119c0d73f70c5a74d5da754b67b56835610f1e461ccd9034a5da00edd97a7bb14beb9f675fd4b66b\" -C \"node_modules/@isaacs/fs-minipass/node_modules/minipass\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/make-fetch-happen/node_modules/minipass\"",
+      "tar -xzf \"flatpak-node/npm/minipass-a8e3b34b57014d6605e011fc7d578f0c138ef62a6d327194119c0d73f70c5a74d5da754b67b56835610f1e461ccd9034a5da00edd97a7bb14beb9f675fd4b66b\" -C \"node_modules/make-fetch-happen/node_modules/minipass\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/minipass-fetch/node_modules/minipass\"",
+      "tar -xzf \"flatpak-node/npm/minipass-a8e3b34b57014d6605e011fc7d578f0c138ef62a6d327194119c0d73f70c5a74d5da754b67b56835610f1e461ccd9034a5da00edd97a7bb14beb9f675fd4b66b\" -C \"node_modules/minipass-fetch/node_modules/minipass\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/node-gyp/node_modules/minipass\"",
+      "tar -xzf \"flatpak-node/npm/minipass-a8e3b34b57014d6605e011fc7d578f0c138ef62a6d327194119c0d73f70c5a74d5da754b67b56835610f1e461ccd9034a5da00edd97a7bb14beb9f675fd4b66b\" -C \"node_modules/node-gyp/node_modules/minipass\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/path-scurry/node_modules/minipass\"",
+      "tar -xzf \"flatpak-node/npm/minipass-a8e3b34b57014d6605e011fc7d578f0c138ef62a6d327194119c0d73f70c5a74d5da754b67b56835610f1e461ccd9034a5da00edd97a7bb14beb9f675fd4b66b\" -C \"node_modules/path-scurry/node_modules/minipass\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@jridgewell/gen-mapping\"",
-      "tar -xzf \"flatpak-node/npm/gen-mapping-8a601b04691bf9e6d0cb12a0cefe47bb69e644ec680ce5c787cd1ebf17685cd3abbc09d5c7bce29b37353a8e61f5195f578bcf5da13688ce693856ef3820a558\" -C \"node_modules/@jridgewell/gen-mapping\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@jridgewell/gen-mapping\"",
-      "tar -xzf \"flatpak-node/npm/gen-mapping-8a601b04691bf9e6d0cb12a0cefe47bb69e644ec680ce5c787cd1ebf17685cd3abbc09d5c7bce29b37353a8e61f5195f578bcf5da13688ce693856ef3820a558\" -C \"node_modules/scratch-gui/node_modules/@jridgewell/gen-mapping\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/gen-mapping-da492dffb9e227a32010fc45d1b61d43a7ad65a03e7d0bc370b29c921cb5c8840ecdaa0a8c10634a3eb7fda2d58d8137aa146de5dbccfae5327c283a50a0816c\" -C \"node_modules/@jridgewell/gen-mapping\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@jridgewell/remapping\"",
+      "tar -xzf \"flatpak-node/npm/remapping-2c8f6effe95a606e03b354c3292256d983eb22571560ec22d9f502eb1078de5b9e0a383157895f7ce0990ad605887e9334e5feb50297c7ded3e082876e1c8711\" -C \"node_modules/@jridgewell/remapping\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@jridgewell/resolve-uri\"",
       "tar -xzf \"flatpak-node/npm/resolve-uri-6d12128022233f6d3fb5b5923d63048b9e1054f45913192e0fd9492fe508c542adc15240f305b54eb6f58ccb354455e8d42053359ff98690bd42f98a59da292b\" -C \"node_modules/@jridgewell/resolve-uri\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/@jridgewell/resolve-uri\"",
       "tar -xzf \"flatpak-node/npm/resolve-uri-6d12128022233f6d3fb5b5923d63048b9e1054f45913192e0fd9492fe508c542adc15240f305b54eb6f58ccb354455e8d42053359ff98690bd42f98a59da292b\" -C \"node_modules/scratch-gui/node_modules/@jridgewell/resolve-uri\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@jridgewell/set-array\"",
-      "tar -xzf \"flatpak-node/npm/set-array-47c80b45365eca9d37ca6ccfffa2e297fdbcb46786133871d6ada4ef4dca19644023555dbcf217746ef4549736a40330dcd03a24a2f986116ed6c257d0c9e7fc\" -C \"node_modules/@jridgewell/set-array\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@jridgewell/set-array\"",
-      "tar -xzf \"flatpak-node/npm/set-array-47c80b45365eca9d37ca6ccfffa2e297fdbcb46786133871d6ada4ef4dca19644023555dbcf217746ef4549736a40330dcd03a24a2f986116ed6c257d0c9e7fc\" -C \"node_modules/scratch-gui/node_modules/@jridgewell/set-array\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@jridgewell/source-map\"",
-      "tar -xzf \"flatpak-node/npm/source-map-d5925365e6e0aa594eefdb9ed9b9b7ac81ae77f6ce7b4a4fe418d2442471c58904652f124d5ef337ce1405b898bbb8f2f9e08a4a7548520a16584fedb7eb2131\" -C \"node_modules/@jridgewell/source-map\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@jridgewell/source-map\"",
-      "tar -xzf \"flatpak-node/npm/source-map-d5925365e6e0aa594eefdb9ed9b9b7ac81ae77f6ce7b4a4fe418d2442471c58904652f124d5ef337ce1405b898bbb8f2f9e08a4a7548520a16584fedb7eb2131\" -C \"node_modules/scratch-gui/node_modules/@jridgewell/source-map\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/source-map-64ca7557c64570f1b97485a740baf7352235322094ed4113752fc0d06f15fd7587bc9bf766c16abad267d58e513e600f5fa177062137f7b3aabde53ff4d0ae20\" -C \"node_modules/@jridgewell/source-map\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@jridgewell/sourcemap-codec\"",
-      "tar -xzf \"flatpak-node/npm/sourcemap-codec-82fdd945a2125377e33c080db2b88146a19640beaab85c74e1830f5bfcc3f1730bb14df69a10826df6cee8a6452e3bd8a4267ccf20c482ab207fe3f03da33b19\" -C \"node_modules/@jridgewell/sourcemap-codec\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@jridgewell/sourcemap-codec\"",
-      "tar -xzf \"flatpak-node/npm/sourcemap-codec-82fdd945a2125377e33c080db2b88146a19640beaab85c74e1830f5bfcc3f1730bb14df69a10826df6cee8a6452e3bd8a4267ccf20c482ab207fe3f03da33b19\" -C \"node_modules/scratch-gui/node_modules/@jridgewell/sourcemap-codec\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/sourcemap-codec-71843ddf5d20aeac6e7966e5f96b885086a251a0dc8fb58eab97d58449633558117ce52163d7f2db34ef7e8a96b2779b87c4a5ef45527056c80af2672ca0743a\" -C \"node_modules/@jridgewell/sourcemap-codec\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@jridgewell/trace-mapping\"",
-      "tar -xzf \"flatpak-node/npm/trace-mapping-bcd93a684c326c6b5ac169b2fcfcf09c60ce8c290b5920f6c2abe3186020380c02196c926177d8a31b74d082644c5fbc2dbe7b0f039bdc06b4a3d080a5ea6261\" -C \"node_modules/@jridgewell/trace-mapping\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@jridgewell/trace-mapping\"",
-      "tar -xzf \"flatpak-node/npm/trace-mapping-bcd93a684c326c6b5ac169b2fcfcf09c60ce8c290b5920f6c2abe3186020380c02196c926177d8a31b74d082644c5fbc2dbe7b0f039bdc06b4a3d080a5ea6261\" -C \"node_modules/scratch-gui/node_modules/@jridgewell/trace-mapping\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/trace-mapping-190ecdc391b6953bbf06d1d329f5e1287a24d9619eb5de1761c54a1b1d344a3024f06330809337cebeb339188f1ae384fbfbe473dd0ab53a2c492bda0a329bd9\" -C \"node_modules/@jridgewell/trace-mapping\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@malept/cross-spawn-promise\"",
       "tar -xzf \"flatpak-node/npm/cross-spawn-promise-d43a4a5346794e196d0708cdc92302d788340a46f28426b3f45921c6a36c648eae00f257152f1c3179412a8dba149f19b96e92f4608c711f483b99365f9ffd16\" -C \"node_modules/@malept/cross-spawn-promise\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@malept/flatpak-bundler\"",
@@ -9648,6 +10232,14 @@
       "tar -xzf \"flatpak-node/npm/fs.walk-a0607e53196059c810920c28f067041b07a6a1316ddc520ef5a6da6c199a1b05c8a01299f864f2d293f5f396de1a0ecb96287f3521d25765c0b35967ce7a1c4a\" -C \"node_modules/@nodelib/fs.walk\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/@nodelib/fs.walk\"",
       "tar -xzf \"flatpak-node/npm/fs.walk-a0607e53196059c810920c28f067041b07a6a1316ddc520ef5a6da6c199a1b05c8a01299f864f2d293f5f396de1a0ecb96287f3521d25765c0b35967ce7a1c4a\" -C \"node_modules/scratch-gui/node_modules/@nodelib/fs.walk\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@npmcli/agent\"",
+      "tar -xzf \"flatpak-node/npm/agent-4bbf4d74480341dfcd1826b2e930a85735d28fbe2c9116482897292630b994eab7e12673c88e8caad8a25a88955a856b4dc1a335e0b88a96e1d552079697c5e5\" -C \"node_modules/@npmcli/agent\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@npmcli/agent/node_modules/lru-cache\"",
+      "tar -xzf \"flatpak-node/npm/lru-cache-24d03365c5eb0ade365462ee633d337c0cc37c0bc9596e807d8943050c835790c2948da6e6c0262be3883bbb39f577ec46c587a74da3009ad169d3d1193b7a49\" -C \"node_modules/@npmcli/agent/node_modules/lru-cache\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/make-fetch-happen/node_modules/lru-cache\"",
+      "tar -xzf \"flatpak-node/npm/lru-cache-24d03365c5eb0ade365462ee633d337c0cc37c0bc9596e807d8943050c835790c2948da6e6c0262be3883bbb39f577ec46c587a74da3009ad169d3d1193b7a49\" -C \"node_modules/make-fetch-happen/node_modules/lru-cache\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/path-scurry/node_modules/lru-cache\"",
+      "tar -xzf \"flatpak-node/npm/lru-cache-24d03365c5eb0ade365462ee633d337c0cc37c0bc9596e807d8943050c835790c2948da6e6c0262be3883bbb39f577ec46c587a74da3009ad169d3d1193b7a49\" -C \"node_modules/path-scurry/node_modules/lru-cache\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@npmcli/fs\"",
       "tar -xzf \"flatpak-node/npm/fs-f0a1b9443d0654fe32744cd19ff23804d0eec43b6a55b39d9bcebbe53e3d3881bf34685a2b4a633d7ed970396f2986c0fae96f54adf3b5f705e2e05d3b1b896d\" -C \"node_modules/@npmcli/fs\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/@npmcli/fs\"",
@@ -9662,16 +10254,18 @@
       "tar -xzf \"flatpak-node/npm/is-b74f6f48ddcc75fb32087a057134421ff894b46ece2740ac8f307c72302629cfef6bf90881e0c8fd3c6c8a0767704ff86deef7e26d1cbc863035a5788b65ea03\" -C \"node_modules/@sindresorhus/is\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@szmarczak/http-timer\"",
       "tar -xzf \"flatpak-node/npm/http-timer-e0101f7f29183a03bee67cc1598c04dd6f74b0180b26850f45659c2fcc25ca233c201f22a49cf750c27d29741dd512905e92a9f13bad9fcd0766d5acbb6bbbeb\" -C \"node_modules/@szmarczak/http-timer\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@tootallnate/once\"",
-      "tar -xzf \"flatpak-node/npm/once-5c2b8a14fe4f4b9e609cc56edddb72f0a3dab4ba94a32fd96330f3006090f093450a42d7ce623bbcd1c247e5e96d968c5902bfbd0b9bafb3e462af20e3bd09fc\" -C \"node_modules/@tootallnate/once\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@transifex/api\"",
       "tar -xzf \"flatpak-node/npm/api-442a6a02ac5996b1c3a3badf6a6f2d2d2a13d36c2f17c2d078d442d15646e481ab1fec2ff86e9f07c3d62cb1ebbd4b9aa8ee970b090c998949fd7f54f532d31f\" -C \"node_modules/@transifex/api\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/@transifex/api\"",
       "tar -xzf \"flatpak-node/npm/api-442a6a02ac5996b1c3a3badf6a6f2d2d2a13d36c2f17c2d078d442d15646e481ab1fec2ff86e9f07c3d62cb1ebbd4b9aa8ee970b090c998949fd7f54f532d31f\" -C \"node_modules/scratch-gui/node_modules/@transifex/api\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@transifex/api/node_modules/core-js\"",
-      "tar -xzf \"flatpak-node/npm/core-js-37ac046d34d9498398dab6009fce42baf5969022ba43078c9fbff836bdf0fa00c1781864ff1e0425e63a14fa384330e8259c554eff14ec232f81693aa4e1c7a8\" -C \"node_modules/@transifex/api/node_modules/core-js\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@transifex/api/node_modules/core-js\"",
-      "tar -xzf \"flatpak-node/npm/core-js-37ac046d34d9498398dab6009fce42baf5969022ba43078c9fbff836bdf0fa00c1781864ff1e0425e63a14fa384330e8259c554eff14ec232f81693aa4e1c7a8\" -C \"node_modules/scratch-gui/node_modules/@transifex/api/node_modules/core-js\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/core-js-7362992fd94fe038e4377864fda9f8a569f96f965e7e14499c0738da7e8b275f644a76de45b750644e5d49e1362c1a25d4ec090f75f5050bc54c0b1af1179e0c\" -C \"node_modules/@transifex/api/node_modules/core-js\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/ancient-hull.js\"",
+      "tar -xzf \"flatpak-node/npm/ancient-hull.js-969543af5f2a46338b59c3edc3d1fe9e516163b85b7604252d4d5bea725f127da9318467384b7315765ba6b1b9260994088cc6c7f1fd58f6a36e48d176f502f9\" -C \"node_modules/@turbowarp/ancient-hull.js\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@turbowarp/ancient-hull.js\"",
+      "tar -xzf \"flatpak-node/npm/ancient-hull.js-969543af5f2a46338b59c3edc3d1fe9e516163b85b7604252d4d5bea725f127da9318467384b7315765ba6b1b9260994088cc6c7f1fd58f6a36e48d176f502f9\" -C \"node_modules/scratch-gui/node_modules/@turbowarp/ancient-hull.js\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-render/node_modules/@turbowarp/ancient-hull.js\"",
+      "tar -xzf \"flatpak-node/npm/ancient-hull.js-969543af5f2a46338b59c3edc3d1fe9e516163b85b7604252d4d5bea725f127da9318467384b7315765ba6b1b9260994088cc6c7f1fd58f6a36e48d176f502f9\" -C \"node_modules/scratch-gui/node_modules/scratch-render/node_modules/@turbowarp/ancient-hull.js\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@turbowarp/json\"",
       "tar -xzf \"flatpak-node/npm/json-f675b2c29fb4487ed1395cd03d040ef6031606291a86cab2316a752aef15574abeaba6e7c7a752d1a34f4e3a93b45d861c0639e6171112ca8acdaa14756052c2\" -C \"node_modules/@turbowarp/extensions/node_modules/@turbowarp/json\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/json\"",
@@ -9688,14 +10282,36 @@
       "tar -xzf \"flatpak-node/npm/scratchblocks-592345a00fa40d458d3006e1bd57e469058e665fe72b9e4d2280c8385cb3a16a85fb7ce75051329fb0b18f2d7fe895d1431b5f45842ac3557b2687cb441f55fe\" -C \"node_modules/@turbowarp/extensions/node_modules/@turbowarp/scratchblocks\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/scratchblocks\"",
       "tar -xzf \"flatpak-node/npm/scratchblocks-592345a00fa40d458d3006e1bd57e469058e665fe72b9e4d2280c8385cb3a16a85fb7ce75051329fb0b18f2d7fe895d1431b5f45842ac3557b2687cb441f55fe\" -C \"node_modules/@turbowarp/scratchblocks\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@types/estree\"",
+      "tar -xzf \"flatpak-node/npm/estree-7561f31dad96a845c8fced44f4e8eba1c313289976992ac4a258752289abbfa53e26e3706875ec5f1f5b2eee601bb05458520dd2c90840943f2f5ac87b1e17eb\" -C \"node_modules/@turbowarp/extensions/node_modules/@types/estree\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@types/estree\"",
+      "tar -xzf \"flatpak-node/npm/estree-7561f31dad96a845c8fced44f4e8eba1c313289976992ac4a258752289abbfa53e26e3706875ec5f1f5b2eee601bb05458520dd2c90840943f2f5ac87b1e17eb\" -C \"node_modules/@types/estree\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@types/json-schema\"",
+      "tar -xzf \"flatpak-node/npm/json-schema-e7e7cff0ff0c14d0be0326420f1ac1da991914f1b3a90594ce949ebae54bbe6f1531ca2b3586af06aa057312bc6d0cf842c6e7e2850411e9b8c032df732b061c\" -C \"node_modules/@turbowarp/extensions/node_modules/@types/json-schema\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@types/json-schema\"",
+      "tar -xzf \"flatpak-node/npm/json-schema-e7e7cff0ff0c14d0be0326420f1ac1da991914f1b3a90594ce949ebae54bbe6f1531ca2b3586af06aa057312bc6d0cf842c6e7e2850411e9b8c032df732b061c\" -C \"node_modules/@types/json-schema\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@types/json-schema\"",
+      "tar -xzf \"flatpak-node/npm/json-schema-e7e7cff0ff0c14d0be0326420f1ac1da991914f1b3a90594ce949ebae54bbe6f1531ca2b3586af06aa057312bc6d0cf842c6e7e2850411e9b8c032df732b061c\" -C \"node_modules/scratch-gui/node_modules/@types/json-schema\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/accepts\"",
-      "tar -xzf \"flatpak-node/npm/accepts-3d802d8536b69b654ac6ebd20f70cf0bf1b2f94fac380d4b02e4fc9a4991bafc3e34009269e5c443e34771517bace365eaa71ac55dd4b9e9b06b093eefe4892f\" -C \"node_modules/@turbowarp/extensions/node_modules/accepts\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/accepts-e5cbe0e82b4ac1f81d995a98d562225ca7374356e446a18b8bed96ffa6a8fba63b82efd10b046e021184ce1e41e0a96ccd2b932e0658baa16aa396c89a334a9e\" -C \"node_modules/@turbowarp/extensions/node_modules/accepts\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/accepts\"",
-      "tar -xzf \"flatpak-node/npm/accepts-3d802d8536b69b654ac6ebd20f70cf0bf1b2f94fac380d4b02e4fc9a4991bafc3e34009269e5c443e34771517bace365eaa71ac55dd4b9e9b06b093eefe4892f\" -C \"node_modules/accepts\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/accepts-e5cbe0e82b4ac1f81d995a98d562225ca7374356e446a18b8bed96ffa6a8fba63b82efd10b046e021184ce1e41e0a96ccd2b932e0658baa16aa396c89a334a9e\" -C \"node_modules/accepts\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/acorn-jsx\"",
+      "tar -xzf \"flatpak-node/npm/acorn-jsx-aeaf6cf893617f4202863b435f196527b838d68664e52957b69d0b1f0c80e5c7a3c27eef2a62a9e293eb8ba60478fbf63d4eb9b00b1e81b5ed2229e60c50d781\" -C \"node_modules/@turbowarp/extensions/node_modules/acorn-jsx\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/acorn-jsx\"",
+      "tar -xzf \"flatpak-node/npm/acorn-jsx-aeaf6cf893617f4202863b435f196527b838d68664e52957b69d0b1f0c80e5c7a3c27eef2a62a9e293eb8ba60478fbf63d4eb9b00b1e81b5ed2229e60c50d781\" -C \"node_modules/acorn-jsx\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/adm-zip\"",
       "tar -xzf \"flatpak-node/npm/adm-zip-4c6c39c958b8b1a6a3b12120cf6e60ace6c61c451a0eb9e2c2f036ab0482d3ad0a7ea18f760961bcf300da53c8a31b373d0208b63da26a0df97ce35c42a81469\" -C \"node_modules/@turbowarp/extensions/node_modules/adm-zip\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/adm-zip\"",
       "tar -xzf \"flatpak-node/npm/adm-zip-4c6c39c958b8b1a6a3b12120cf6e60ace6c61c451a0eb9e2c2f036ab0482d3ad0a7ea18f760961bcf300da53c8a31b373d0208b63da26a0df97ce35c42a81469\" -C \"node_modules/adm-zip\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/ajv\"",
+      "tar -xzf \"flatpak-node/npm/ajv-8f77d52e0bd3a39dbb6a7c98c893864d825b1bebe79d062f1349b99a691cd532be9f1029a6408b3082f4699e1d6e55423681928619be933138654ca4068320e2\" -C \"node_modules/@turbowarp/extensions/node_modules/ajv\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/ajv\"",
+      "tar -xzf \"flatpak-node/npm/ajv-8f77d52e0bd3a39dbb6a7c98c893864d825b1bebe79d062f1349b99a691cd532be9f1029a6408b3082f4699e1d6e55423681928619be933138654ca4068320e2\" -C \"node_modules/ajv\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/ajv\"",
+      "tar -xzf \"flatpak-node/npm/ajv-8f77d52e0bd3a39dbb6a7c98c893864d825b1bebe79d062f1349b99a691cd532be9f1029a6408b3082f4699e1d6e55423681928619be933138654ca4068320e2\" -C \"node_modules/scratch-gui/node_modules/ajv\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/ajv\"",
+      "tar -xzf \"flatpak-node/npm/ajv-8f77d52e0bd3a39dbb6a7c98c893864d825b1bebe79d062f1349b99a691cd532be9f1029a6408b3082f4699e1d6e55423681928619be933138654ca4068320e2\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/ajv\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/ansi-styles\"",
       "tar -xzf \"flatpak-node/npm/ansi-styles-cdb07dac22404f5adb8e25436f686a2851cd60bc60b64f0d511c59dc86700f717a36dc5b5d94029e74a2d4b931f880e885d3e5169db6db05402c885e64941212\" -C \"node_modules/@turbowarp/extensions/node_modules/ansi-styles\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/ansi-styles\"",
@@ -9704,12 +10320,10 @@
       "tar -xzf \"flatpak-node/npm/argparse-f3ef56a9e6db173a57f4e47e59ae8edbd6ac22881e44ccdc1ad00835da4c1c7c80835d1fd3969215505b704a867ff3d7c35123019faadbf6c4060dc3beeacadd\" -C \"node_modules/@turbowarp/extensions/node_modules/argparse\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/argparse\"",
       "tar -xzf \"flatpak-node/npm/argparse-f3ef56a9e6db173a57f4e47e59ae8edbd6ac22881e44ccdc1ad00835da4c1c7c80835d1fd3969215505b704a867ff3d7c35123019faadbf6c4060dc3beeacadd\" -C \"node_modules/argparse\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/array-flatten\"",
-      "tar -xzf \"flatpak-node/npm/array-flatten-3c254042cc167a6bba51dc6c0c5157ffe815798a8a0287770f75159bdd631f0ca782e3b002f60f871f2736533ef8da9170ae82c71a5469f8e684874a88789baa\" -C \"node_modules/@turbowarp/extensions/node_modules/array-flatten\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/array-flatten\"",
-      "tar -xzf \"flatpak-node/npm/array-flatten-3c254042cc167a6bba51dc6c0c5157ffe815798a8a0287770f75159bdd631f0ca782e3b002f60f871f2736533ef8da9170ae82c71a5469f8e684874a88789baa\" -C \"node_modules/array-flatten\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/async\"",
-      "tar -xzf \"flatpak-node/npm/async-6da359caa69a2e1c8b54a9bf0e5bdd5b4e7531280ee9bf1e55f21ece5f44e4fa96c458332e6ff0427b445b8ccecad55bbab0c4af426500b12974e170bc4acbb2\" -C \"node_modules/@turbowarp/extensions/node_modules/async\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/async-86d0940e5c72c822cc81a337c578340b42d6db1a9fb90ea9d39a42108b17bb243e6b592860a4ee04ccd13709b26df2e0bc90cc774af52d39f8f84d138ba0b600\" -C \"node_modules/@turbowarp/extensions/node_modules/async\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/async\"",
+      "tar -xzf \"flatpak-node/npm/async-86d0940e5c72c822cc81a337c578340b42d6db1a9fb90ea9d39a42108b17bb243e6b592860a4ee04ccd13709b26df2e0bc90cc774af52d39f8f84d138ba0b600\" -C \"node_modules/async\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/balanced-match\"",
       "tar -xzf \"flatpak-node/npm/balanced-match-de849e50ed13315ebb84dd4099b5ec2b8c9aa94eed8e21e56f144364ea47d0a5bdf82797e1b440697d009f1b74b71d8cae94695b041a3f02252121098585393f\" -C \"node_modules/@turbowarp/extensions/node_modules/balanced-match\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/balanced-match\"",
@@ -9719,81 +10333,15 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/balanced-match\"",
       "tar -xzf \"flatpak-node/npm/balanced-match-de849e50ed13315ebb84dd4099b5ec2b8c9aa94eed8e21e56f144364ea47d0a5bdf82797e1b440697d009f1b74b71d8cae94695b041a3f02252121098585393f\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/balanced-match\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/body-parser\"",
-      "tar -xzf \"flatpak-node/npm/body-parser-eeb0310728d432a437fdb1c9cbb0fa3865efc7f30c73822a067fd7d1f70cd5051c008b6966b0446215867a6fadcd71fdd1cf86d35ca931c60904ef58df4db4de\" -C \"node_modules/@turbowarp/extensions/node_modules/body-parser\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/body-parser-d36aaf01ac6ff2da7b7c16bf9b0d606bdf0e1a6f9e09bab324e2a846def4b0b99f1048be8f20585530c67c22ff934ebfe04324ff3d358027bb1e8087fdfd8b4e\" -C \"node_modules/@turbowarp/extensions/node_modules/body-parser\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/body-parser\"",
-      "tar -xzf \"flatpak-node/npm/body-parser-eeb0310728d432a437fdb1c9cbb0fa3865efc7f30c73822a067fd7d1f70cd5051c008b6966b0446215867a6fadcd71fdd1cf86d35ca931c60904ef58df4db4de\" -C \"node_modules/body-parser\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/body-parser/node_modules/debug\"",
-      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/@turbowarp/extensions/node_modules/body-parser/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/express/node_modules/debug\"",
-      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/@turbowarp/extensions/node_modules/express/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/finalhandler/node_modules/debug\"",
-      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/@turbowarp/extensions/node_modules/finalhandler/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/send/node_modules/debug\"",
-      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/@turbowarp/extensions/node_modules/send/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/body-parser/node_modules/debug\"",
-      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/body-parser/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/expand-brackets/node_modules/debug\"",
-      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/expand-brackets/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/express/node_modules/debug\"",
-      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/express/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/finalhandler/node_modules/debug\"",
-      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/finalhandler/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/react-popover/node_modules/debug\"",
-      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/react-popover/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/expand-brackets/node_modules/debug\"",
-      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/scratch-gui/node_modules/expand-brackets/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/react-popover/node_modules/debug\"",
-      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/scratch-gui/node_modules/react-popover/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/expand-brackets/node_modules/debug\"",
-      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/expand-brackets/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/snapdragon/node_modules/debug\"",
-      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/snapdragon/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/snapdragon/node_modules/debug\"",
-      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/scratch-gui/node_modules/snapdragon/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/send/node_modules/debug\"",
-      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/send/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/snapdragon/node_modules/debug\"",
-      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/snapdragon/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/body-parser/node_modules/ms\"",
-      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/@turbowarp/extensions/node_modules/body-parser/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/express/node_modules/ms\"",
-      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/@turbowarp/extensions/node_modules/express/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/finalhandler/node_modules/ms\"",
-      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/@turbowarp/extensions/node_modules/finalhandler/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/send/node_modules/debug/node_modules/ms\"",
-      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/@turbowarp/extensions/node_modules/send/node_modules/debug/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/body-parser/node_modules/ms\"",
-      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/body-parser/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/expand-brackets/node_modules/ms\"",
-      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/expand-brackets/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/express/node_modules/ms\"",
-      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/express/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/finalhandler/node_modules/ms\"",
-      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/finalhandler/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/mocha/node_modules/ms\"",
-      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/mocha/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/react-popover/node_modules/ms\"",
-      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/react-popover/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/expand-brackets/node_modules/ms\"",
-      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/scratch-gui/node_modules/expand-brackets/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/mocha/node_modules/ms\"",
-      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/scratch-gui/node_modules/mocha/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/react-popover/node_modules/ms\"",
-      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/scratch-gui/node_modules/react-popover/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/expand-brackets/node_modules/ms\"",
-      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/expand-brackets/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/snapdragon/node_modules/ms\"",
-      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/snapdragon/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/snapdragon/node_modules/ms\"",
-      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/scratch-gui/node_modules/snapdragon/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/send/node_modules/debug/node_modules/ms\"",
-      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/send/node_modules/debug/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/snapdragon/node_modules/ms\"",
-      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/snapdragon/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/body-parser-d36aaf01ac6ff2da7b7c16bf9b0d606bdf0e1a6f9e09bab324e2a846def4b0b99f1048be8f20585530c67c22ff934ebfe04324ff3d358027bb1e8087fdfd8b4e\" -C \"node_modules/body-parser\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/brace-expansion\"",
-      "tar -xzf \"flatpak-node/npm/brace-expansion-882b8f1c3160ac75fb1f6bc423fe71a73d3bcd21c1d344e9ba0aa1998b5598c3bae75f260ae44ca0e60595d101974835f3bb9fa3375a1e058a71815beb5a8688\" -C \"node_modules/@turbowarp/extensions/node_modules/brace-expansion\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/brace-expansion\"",
-      "tar -xzf \"flatpak-node/npm/brace-expansion-882b8f1c3160ac75fb1f6bc423fe71a73d3bcd21c1d344e9ba0aa1998b5598c3bae75f260ae44ca0e60595d101974835f3bb9fa3375a1e058a71815beb5a8688\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/brace-expansion\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/brace-expansion-f53f548d6debd145b973543b193c25969b57c21bd8984cc587331f67d1fb1505adfae65e3e364f8c13ff5b5644c99d6dc065a89b9ff9e9317894f72a8e70c772\" -C \"node_modules/@turbowarp/extensions/node_modules/brace-expansion\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/brace-expansion\"",
+      "tar -xzf \"flatpak-node/npm/brace-expansion-f53f548d6debd145b973543b193c25969b57c21bd8984cc587331f67d1fb1505adfae65e3e364f8c13ff5b5644c99d6dc065a89b9ff9e9317894f72a8e70c772\" -C \"node_modules/brace-expansion\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/brace-expansion\"",
+      "tar -xzf \"flatpak-node/npm/brace-expansion-f53f548d6debd145b973543b193c25969b57c21bd8984cc587331f67d1fb1505adfae65e3e364f8c13ff5b5644c99d6dc065a89b9ff9e9317894f72a8e70c772\" -C \"node_modules/scratch-gui/node_modules/brace-expansion\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/bytes\"",
       "tar -xzf \"flatpak-node/npm/bytes-fcd7fb4f2cd3c7a4b7c9124e6ce015efde7aafc72bdbe3a3f000b976df3048fdc1400a1e5f9f0da07c8253c3fccc690d5d2b634d28ba7f33ba174a4175c61b12\" -C \"node_modules/@turbowarp/extensions/node_modules/bytes\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/bytes\"",
@@ -9812,6 +10360,10 @@
       "tar -xzf \"flatpak-node/npm/call-bound-fb2b3df7b53dea9a382b1fc0069042aa103d12ec49690583420ef6f791f8841a61bf72198346e804abb0629b78617a7a319e4099942753fb72313951a5a49e8e\" -C \"node_modules/call-bound\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/call-bound\"",
       "tar -xzf \"flatpak-node/npm/call-bound-fb2b3df7b53dea9a382b1fc0069042aa103d12ec49690583420ef6f791f8841a61bf72198346e804abb0629b78617a7a319e4099942753fb72313951a5a49e8e\" -C \"node_modules/scratch-gui/node_modules/call-bound\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/callsites\"",
+      "tar -xzf \"flatpak-node/npm/callsites-3fc06302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69\" -C \"node_modules/@turbowarp/extensions/node_modules/callsites\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/callsites\"",
+      "tar -xzf \"flatpak-node/npm/callsites-3fc06302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69\" -C \"node_modules/callsites\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/chalk\"",
       "tar -xzf \"flatpak-node/npm/chalk-a0a9db845c91217a54b9ecfc881326c846b89db8f820e432ba173fc32f6463bfd654f73020ef5503aebc3eef1190eefed06efa48b44e7b2c3d0a9434eb58b898\" -C \"node_modules/@turbowarp/extensions/node_modules/chalk\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/chalk\"",
@@ -9837,31 +10389,35 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/concat-map\"",
       "tar -xzf \"flatpak-node/npm/concat-map-fd2aefe1db30c903417e8846a73f68e986f71b3dd2ad40ea047e6b4ee84647b6a1b656d82a7571c366c214c4658da03b1171da5d9f30b07768745bdb9212a6aa\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/concat-map\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/content-disposition\"",
-      "tar -xzf \"flatpak-node/npm/content-disposition-16f7994cdb86c34e1cc6502259bce2eb34c02ff9617a16966d3b6096e261e3f13de43a8cc139a16b7299375680580f1c148847ccc654bcb7af930e51aa4fad49\" -C \"node_modules/@turbowarp/extensions/node_modules/content-disposition\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/content-disposition\"",
-      "tar -xzf \"flatpak-node/npm/content-disposition-16f7994cdb86c34e1cc6502259bce2eb34c02ff9617a16966d3b6096e261e3f13de43a8cc139a16b7299375680580f1c148847ccc654bcb7af930e51aa4fad49\" -C \"node_modules/content-disposition\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/content-disposition\"",
-      "tar -xzf \"flatpak-node/npm/content-disposition-16f7994cdb86c34e1cc6502259bce2eb34c02ff9617a16966d3b6096e261e3f13de43a8cc139a16b7299375680580f1c148847ccc654bcb7af930e51aa4fad49\" -C \"node_modules/scratch-gui/node_modules/content-disposition\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/content-disposition-02ef6744bf15354badfd74b36d0037f3e33bf1dccfe03f9eaa0de07c91cc2071d86b76e0d3aef18f52b13145a3f9550b6e264ca302a780515b29ccd4acd2759a\" -C \"node_modules/@turbowarp/extensions/node_modules/content-disposition\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/express/node_modules/content-disposition\"",
+      "tar -xzf \"flatpak-node/npm/content-disposition-02ef6744bf15354badfd74b36d0037f3e33bf1dccfe03f9eaa0de07c91cc2071d86b76e0d3aef18f52b13145a3f9550b6e264ca302a780515b29ccd4acd2759a\" -C \"node_modules/express/node_modules/content-disposition\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/content-type\"",
       "tar -xzf \"flatpak-node/npm/content-type-9d38ea7dc045122a4a7570afe180d05827e670b64a9bcd65745d29028a53bf2ac51956dc47a3ff54001de46ecdfb4b53afc42a894d2d15a743e852b836d27038\" -C \"node_modules/@turbowarp/extensions/node_modules/content-type\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/content-type\"",
       "tar -xzf \"flatpak-node/npm/content-type-9d38ea7dc045122a4a7570afe180d05827e670b64a9bcd65745d29028a53bf2ac51956dc47a3ff54001de46ecdfb4b53afc42a894d2d15a743e852b836d27038\" -C \"node_modules/content-type\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/cookie\"",
       "tar -xzf \"flatpak-node/npm/cookie-e839c89e9c7b489d802b7f824d413f64cd2f59351ba1909e831842db1888c9d1d1f6336e4c001206b7c4a4786218e670fe75f9d5b1ede98425f23b06a38cbfd3\" -C \"node_modules/@turbowarp/extensions/node_modules/cookie\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/cookie\"",
-      "tar -xzf \"flatpak-node/npm/cookie-e839c89e9c7b489d802b7f824d413f64cd2f59351ba1909e831842db1888c9d1d1f6336e4c001206b7c4a4786218e670fe75f9d5b1ede98425f23b06a38cbfd3\" -C \"node_modules/cookie\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/cookie-signature\"",
-      "tar -xzf \"flatpak-node/npm/cookie-signature-4000f395a1dcf22715f08eef6da257270a1df47598a7cb82a9fd716b839f36ed53ec9571408ad480e5ad1dd343b4f8b2c2615b892d76563a2d2172eb28cde8ad\" -C \"node_modules/@turbowarp/extensions/node_modules/cookie-signature\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/cookie-signature-0fbeae53bdee9525eb0f5517178284d93331555c21b270a07c0c9383d93c3fa2866639572ab38b7b874940a2370718b9c237ac6681572561253560633d931b86\" -C \"node_modules/@turbowarp/extensions/node_modules/cookie-signature\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/cookie-signature\"",
-      "tar -xzf \"flatpak-node/npm/cookie-signature-4000f395a1dcf22715f08eef6da257270a1df47598a7cb82a9fd716b839f36ed53ec9571408ad480e5ad1dd343b4f8b2c2615b892d76563a2d2172eb28cde8ad\" -C \"node_modules/cookie-signature\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/cookie-signature-0fbeae53bdee9525eb0f5517178284d93331555c21b270a07c0c9383d93c3fa2866639572ab38b7b874940a2370718b9c237ac6681572561253560633d931b86\" -C \"node_modules/cookie-signature\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/cross-spawn\"",
+      "tar -xzf \"flatpak-node/npm/cross-spawn-b95d903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc\" -C \"node_modules/@turbowarp/extensions/node_modules/cross-spawn\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/cross-spawn\"",
+      "tar -xzf \"flatpak-node/npm/cross-spawn-b95d903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc\" -C \"node_modules/cross-spawn\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/debug\"",
+      "tar -xzf \"flatpak-node/npm/debug-446c305a7c10be455f6af295b76d8518bc3ec5849dcc04709b4aeee83853540dee994e6165cdbc57790ee2cb6062bcab4e52e9baf808f468a28e5b408cd6dca8\" -C \"node_modules/@turbowarp/extensions/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/deep-is\"",
+      "tar -xzf \"flatpak-node/npm/deep-is-a083f392c993838fccae289a6063bea245c34fbced9ffc37129b6fffe81221d31d2ac268d2ee027d834524fcbee1228cb82a86c36c319c0f9444c837b7c6bf6d\" -C \"node_modules/@turbowarp/extensions/node_modules/deep-is\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/deep-is\"",
+      "tar -xzf \"flatpak-node/npm/deep-is-a083f392c993838fccae289a6063bea245c34fbced9ffc37129b6fffe81221d31d2ac268d2ee027d834524fcbee1228cb82a86c36c319c0f9444c837b7c6bf6d\" -C \"node_modules/deep-is\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/deep-is\"",
+      "tar -xzf \"flatpak-node/npm/deep-is-a083f392c993838fccae289a6063bea245c34fbced9ffc37129b6fffe81221d31d2ac268d2ee027d834524fcbee1228cb82a86c36c319c0f9444c837b7c6bf6d\" -C \"node_modules/scratch-gui/node_modules/deep-is\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/depd\"",
       "tar -xzf \"flatpak-node/npm/depd-83b9c7e8fe9dc838a8268800006a6b1a90ad5489898693e4feba02cdd6f77c887ad7fb3f9cfb1f47aa27c8cc2408047f3a50b7c810b49444af52840402cb08af\" -C \"node_modules/@turbowarp/extensions/node_modules/depd\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/depd\"",
       "tar -xzf \"flatpak-node/npm/depd-83b9c7e8fe9dc838a8268800006a6b1a90ad5489898693e4feba02cdd6f77c887ad7fb3f9cfb1f47aa27c8cc2408047f3a50b7c810b49444af52840402cb08af\" -C \"node_modules/depd\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/destroy\"",
-      "tar -xzf \"flatpak-node/npm/destroy-dac246253697208691d70e22252368374867318ec6a5cfe7f03e2a482270f10a855977fb72e0209c41f1069c1e69570f7af0b69772a98d80b1dcdca941081a26\" -C \"node_modules/@turbowarp/extensions/node_modules/destroy\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/destroy\"",
-      "tar -xzf \"flatpak-node/npm/destroy-dac246253697208691d70e22252368374867318ec6a5cfe7f03e2a482270f10a855977fb72e0209c41f1069c1e69570f7af0b69772a98d80b1dcdca941081a26\" -C \"node_modules/destroy\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/dunder-proto\"",
       "tar -xzf \"flatpak-node/npm/dunder-proto-28837f9c3241411717c3430b561644f62407986ebca80548060f42aa65188e64088608a3f54e4c16faea9142f915bb72cb366e39e3add3375e45ee1463b72df8\" -C \"node_modules/@turbowarp/extensions/node_modules/dunder-proto\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/dunder-proto\"",
@@ -9914,32 +10470,128 @@
       "tar -xzf \"flatpak-node/npm/escape-html-3624aea59e0e7ae1b0afaf251887b29bf92c219309a1d506392099fc54a74f172b7a46efaab81d53194938ca628da299563009ad6ac6b3fe89cbc38cbb28fda3\" -C \"node_modules/@turbowarp/extensions/node_modules/escape-html\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/escape-html\"",
       "tar -xzf \"flatpak-node/npm/escape-html-3624aea59e0e7ae1b0afaf251887b29bf92c219309a1d506392099fc54a74f172b7a46efaab81d53194938ca628da299563009ad6ac6b3fe89cbc38cbb28fda3\" -C \"node_modules/escape-html\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/escape-string-regexp\"",
+      "tar -xzf \"flatpak-node/npm/escape-string-regexp-4eda5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80\" -C \"node_modules/@turbowarp/extensions/node_modules/escape-string-regexp\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/escape-string-regexp\"",
+      "tar -xzf \"flatpak-node/npm/escape-string-regexp-4eda5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80\" -C \"node_modules/escape-string-regexp\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/eslint\"",
+      "tar -xzf \"flatpak-node/npm/eslint-b7968f3a99ad25c65ccf9509c98d866efa4396c2b913c26a46aa0ab5f88a13770d878dfb288a9f26bdc0dc029fe64eb834fc7a7741b7767a3a5c3634e4fa8fb7\" -C \"node_modules/@turbowarp/extensions/node_modules/eslint\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/eslint\"",
+      "tar -xzf \"flatpak-node/npm/eslint-b7968f3a99ad25c65ccf9509c98d866efa4396c2b913c26a46aa0ab5f88a13770d878dfb288a9f26bdc0dc029fe64eb834fc7a7741b7767a3a5c3634e4fa8fb7\" -C \"node_modules/eslint\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/eslint-scope\"",
+      "tar -xzf \"flatpak-node/npm/eslint-scope-b0d5ce7ca0a7ef8aedf1120228cbc94bb5ca57f5e4f6403b0f226bf262629374bb0b0832dea964926c92dae401de388983a54d75977fa43049bb49ef1b63654e\" -C \"node_modules/@turbowarp/extensions/node_modules/eslint-scope\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/eslint/node_modules/eslint-scope\"",
+      "tar -xzf \"flatpak-node/npm/eslint-scope-b0d5ce7ca0a7ef8aedf1120228cbc94bb5ca57f5e4f6403b0f226bf262629374bb0b0832dea964926c92dae401de388983a54d75977fa43049bb49ef1b63654e\" -C \"node_modules/eslint/node_modules/eslint-scope\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/eslint-visitor-keys\"",
+      "tar -xzf \"flatpak-node/npm/eslint-visitor-keys-521764e6c7ea71e7bff47feb08e262918cfaee8d1ad93c3684644f386d98d51d9d83b6eb45ed6e1b4c9a3500c7bbe4cefee40f17fe5e09aa6f612987523b7b25\" -C \"node_modules/@turbowarp/extensions/node_modules/eslint-visitor-keys\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/eslint-visitor-keys\"",
+      "tar -xzf \"flatpak-node/npm/eslint-visitor-keys-521764e6c7ea71e7bff47feb08e262918cfaee8d1ad93c3684644f386d98d51d9d83b6eb45ed6e1b4c9a3500c7bbe4cefee40f17fe5e09aa6f612987523b7b25\" -C \"node_modules/eslint-visitor-keys\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/espree\"",
+      "tar -xzf \"flatpak-node/npm/espree-a2bb99685923a2b4e9177da40d2239ffbe558b019e6608a7186cb636839283743d6e7c259e60e6e072e7925d111379fe9e30d7474dfb698d7ec79f19ff315dc1\" -C \"node_modules/@turbowarp/extensions/node_modules/espree\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/espree\"",
+      "tar -xzf \"flatpak-node/npm/espree-a2bb99685923a2b4e9177da40d2239ffbe558b019e6608a7186cb636839283743d6e7c259e60e6e072e7925d111379fe9e30d7474dfb698d7ec79f19ff315dc1\" -C \"node_modules/espree\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/esquery\"",
+      "tar -xzf \"flatpak-node/npm/esquery-71af69c3d7e898570a3ef14b5e104a50af7466f1a26e218ebd124d6e396363bb3bbaaff960ee013b3718b49a84c5dc7df6b17a6807274711e67141dccfab10b2\" -C \"node_modules/@turbowarp/extensions/node_modules/esquery\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/esquery\"",
+      "tar -xzf \"flatpak-node/npm/esquery-71af69c3d7e898570a3ef14b5e104a50af7466f1a26e218ebd124d6e396363bb3bbaaff960ee013b3718b49a84c5dc7df6b17a6807274711e67141dccfab10b2\" -C \"node_modules/esquery\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/esrecurse\"",
+      "tar -xzf \"flatpak-node/npm/esrecurse-2a67ca2f76fa1be457bcff0dd6faf74ead642ffa021609f63585c4b6a3fcfcbde929aa540381bc70555aa05dd2537db7083e17ca947f7df8a81e692d8bafd36a\" -C \"node_modules/@turbowarp/extensions/node_modules/esrecurse\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/esrecurse\"",
+      "tar -xzf \"flatpak-node/npm/esrecurse-2a67ca2f76fa1be457bcff0dd6faf74ead642ffa021609f63585c4b6a3fcfcbde929aa540381bc70555aa05dd2537db7083e17ca947f7df8a81e692d8bafd36a\" -C \"node_modules/esrecurse\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/esrecurse\"",
+      "tar -xzf \"flatpak-node/npm/esrecurse-2a67ca2f76fa1be457bcff0dd6faf74ead642ffa021609f63585c4b6a3fcfcbde929aa540381bc70555aa05dd2537db7083e17ca947f7df8a81e692d8bafd36a\" -C \"node_modules/scratch-gui/node_modules/esrecurse\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/esrecurse\"",
+      "tar -xzf \"flatpak-node/npm/esrecurse-2a67ca2f76fa1be457bcff0dd6faf74ead642ffa021609f63585c4b6a3fcfcbde929aa540381bc70555aa05dd2537db7083e17ca947f7df8a81e692d8bafd36a\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/esrecurse\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/estraverse\"",
+      "tar -xzf \"flatpak-node/npm/estraverse-30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004\" -C \"node_modules/@turbowarp/extensions/node_modules/estraverse\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/eslint/node_modules/estraverse\"",
+      "tar -xzf \"flatpak-node/npm/estraverse-30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004\" -C \"node_modules/eslint/node_modules/estraverse\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/esquery/node_modules/estraverse\"",
+      "tar -xzf \"flatpak-node/npm/estraverse-30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004\" -C \"node_modules/esquery/node_modules/estraverse\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/esrecurse/node_modules/estraverse\"",
+      "tar -xzf \"flatpak-node/npm/estraverse-30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004\" -C \"node_modules/esrecurse/node_modules/estraverse\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/estraverse\"",
+      "tar -xzf \"flatpak-node/npm/estraverse-30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004\" -C \"node_modules/scratch-gui/node_modules/estraverse\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/estraverse\"",
+      "tar -xzf \"flatpak-node/npm/estraverse-30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/estraverse\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/static-eval/node_modules/estraverse\"",
+      "tar -xzf \"flatpak-node/npm/estraverse-30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004\" -C \"node_modules/static-eval/node_modules/estraverse\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/esutils\"",
+      "tar -xzf \"flatpak-node/npm/esutils-915b1ca97938382a7af126747648042958baffc8a3df4d0a0564c9ab7d8ffdd61e5934b02b8d56c93c5a94dd5e46603967d514fcb5fd0fb1564a657d480631ea\" -C \"node_modules/@turbowarp/extensions/node_modules/esutils\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/esutils\"",
+      "tar -xzf \"flatpak-node/npm/esutils-915b1ca97938382a7af126747648042958baffc8a3df4d0a0564c9ab7d8ffdd61e5934b02b8d56c93c5a94dd5e46603967d514fcb5fd0fb1564a657d480631ea\" -C \"node_modules/esutils\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/esutils\"",
+      "tar -xzf \"flatpak-node/npm/esutils-915b1ca97938382a7af126747648042958baffc8a3df4d0a0564c9ab7d8ffdd61e5934b02b8d56c93c5a94dd5e46603967d514fcb5fd0fb1564a657d480631ea\" -C \"node_modules/scratch-gui/node_modules/esutils\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/etag\"",
       "tar -xzf \"flatpak-node/npm/etag-6882f9171ee66b055adf4d1a976067104e2236fa35a844f12eb3c8fe8d392fbcfa828edf0b0d49e844266cae05989d804bb920545fca1195ae7c17dd0a531c3e\" -C \"node_modules/@turbowarp/extensions/node_modules/etag\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/etag\"",
       "tar -xzf \"flatpak-node/npm/etag-6882f9171ee66b055adf4d1a976067104e2236fa35a844f12eb3c8fe8d392fbcfa828edf0b0d49e844266cae05989d804bb920545fca1195ae7c17dd0a531c3e\" -C \"node_modules/etag\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/express\"",
-      "tar -xzf \"flatpak-node/npm/express-dbc1ea80c6409a28750b3b7d9f2eeaafa7a4daa75d17815c95b333c21091101e8e15f1fead7027b8d0b0a35ff016faed6e0b100dbe2449b5fd75ef6515bad79c\" -C \"node_modules/@turbowarp/extensions/node_modules/express\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/express-0d3f5c939608454fbc198cf3539913dde1c603988bfb565dd04bad3a64c4f43b64f93beecdddb754153e79cec73cd493c5760ee7980f57f86ae294812438c5a4\" -C \"node_modules/@turbowarp/extensions/node_modules/express\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/express\"",
-      "tar -xzf \"flatpak-node/npm/express-dbc1ea80c6409a28750b3b7d9f2eeaafa7a4daa75d17815c95b333c21091101e8e15f1fead7027b8d0b0a35ff016faed6e0b100dbe2449b5fd75ef6515bad79c\" -C \"node_modules/express\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/express-0d3f5c939608454fbc198cf3539913dde1c603988bfb565dd04bad3a64c4f43b64f93beecdddb754153e79cec73cd493c5760ee7980f57f86ae294812438c5a4\" -C \"node_modules/express\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/fast-deep-equal\"",
+      "tar -xzf \"flatpak-node/npm/fast-deep-equal-7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1\" -C \"node_modules/@turbowarp/extensions/node_modules/fast-deep-equal\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/fast-deep-equal\"",
+      "tar -xzf \"flatpak-node/npm/fast-deep-equal-7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1\" -C \"node_modules/fast-deep-equal\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/fast-deep-equal\"",
+      "tar -xzf \"flatpak-node/npm/fast-deep-equal-7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1\" -C \"node_modules/scratch-gui/node_modules/fast-deep-equal\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/fast-deep-equal\"",
+      "tar -xzf \"flatpak-node/npm/fast-deep-equal-7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/fast-deep-equal\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/fast-json-stable-stringify\"",
+      "tar -xzf \"flatpak-node/npm/fast-json-stable-stringify-96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f\" -C \"node_modules/@turbowarp/extensions/node_modules/fast-json-stable-stringify\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/fast-json-stable-stringify\"",
+      "tar -xzf \"flatpak-node/npm/fast-json-stable-stringify-96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f\" -C \"node_modules/fast-json-stable-stringify\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/fast-json-stable-stringify\"",
+      "tar -xzf \"flatpak-node/npm/fast-json-stable-stringify-96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f\" -C \"node_modules/scratch-gui/node_modules/fast-json-stable-stringify\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-parser/node_modules/fast-json-stable-stringify\"",
+      "tar -xzf \"flatpak-node/npm/fast-json-stable-stringify-96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f\" -C \"node_modules/scratch-gui/node_modules/scratch-parser/node_modules/fast-json-stable-stringify\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/fast-json-stable-stringify\"",
+      "tar -xzf \"flatpak-node/npm/fast-json-stable-stringify-96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/fast-json-stable-stringify\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/scratch-parser/node_modules/fast-json-stable-stringify\"",
+      "tar -xzf \"flatpak-node/npm/fast-json-stable-stringify-96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/scratch-parser/node_modules/fast-json-stable-stringify\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/fast-levenshtein\"",
+      "tar -xzf \"flatpak-node/npm/fast-levenshtein-0c25eee887e1a9c92ced364a6371f1a77cbaaa9858e522599ab58c0eb29c11148e5d641d32153d220fcf62bcf2c3fba5f63388ca1d0de0cd2d6c2e61a1d83c77\" -C \"node_modules/@turbowarp/extensions/node_modules/fast-levenshtein\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/fast-levenshtein\"",
+      "tar -xzf \"flatpak-node/npm/fast-levenshtein-0c25eee887e1a9c92ced364a6371f1a77cbaaa9858e522599ab58c0eb29c11148e5d641d32153d220fcf62bcf2c3fba5f63388ca1d0de0cd2d6c2e61a1d83c77\" -C \"node_modules/fast-levenshtein\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/fast-levenshtein\"",
+      "tar -xzf \"flatpak-node/npm/fast-levenshtein-0c25eee887e1a9c92ced364a6371f1a77cbaaa9858e522599ab58c0eb29c11148e5d641d32153d220fcf62bcf2c3fba5f63388ca1d0de0cd2d6c2e61a1d83c77\" -C \"node_modules/scratch-gui/node_modules/fast-levenshtein\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/file-entry-cache\"",
+      "tar -xzf \"flatpak-node/npm/file-entry-cache-5d74d4c02be2b1ae6869c34644ff527cdb5804d00c8be44fc011666e564417b37bb301d8412ebf65f93b491c31e03e63dc21f6d7560d45ca350c430d55f6429d\" -C \"node_modules/@turbowarp/extensions/node_modules/file-entry-cache\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/file-entry-cache\"",
+      "tar -xzf \"flatpak-node/npm/file-entry-cache-5d74d4c02be2b1ae6869c34644ff527cdb5804d00c8be44fc011666e564417b37bb301d8412ebf65f93b491c31e03e63dc21f6d7560d45ca350c430d55f6429d\" -C \"node_modules/file-entry-cache\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/filelist\"",
       "tar -xzf \"flatpak-node/npm/filelist-c35704b9fdd2f83acb0902fb113ea4cfe82694975babd27bc970928cafce6423c0faa10dd56c85e1901fd186096b8fec84726b6b6b7f77fafc495e098bec7ef1\" -C \"node_modules/@turbowarp/extensions/node_modules/filelist\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/filelist\"",
       "tar -xzf \"flatpak-node/npm/filelist-c35704b9fdd2f83acb0902fb113ea4cfe82694975babd27bc970928cafce6423c0faa10dd56c85e1901fd186096b8fec84726b6b6b7f77fafc495e098bec7ef1\" -C \"node_modules/filelist\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/filelist/node_modules/brace-expansion\"",
-      "tar -xzf \"flatpak-node/npm/brace-expansion-5e7008bd0f1e33e902e9a50bc7ac2e422c15b27cec8bd7775b1cd5dc5a564c6035f45eb6d64c1d6ec01c14a5e02941d95accbe998ea22f5b074f1584142cad0c\" -C \"node_modules/@turbowarp/extensions/node_modules/filelist/node_modules/brace-expansion\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/filelist/node_modules/minimatch\"",
+      "tar -xzf \"flatpak-node/npm/minimatch-94ac15ff56eba46ea6054147b5becd526b400426f65996669b6c0d88e0398406fc55d092e01dddb4c5b2bdca1589c730016fc23844635cbb74ccfd735d4376ea\" -C \"node_modules/@turbowarp/extensions/node_modules/filelist/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/filelist/node_modules/minimatch\"",
+      "tar -xzf \"flatpak-node/npm/minimatch-94ac15ff56eba46ea6054147b5becd526b400426f65996669b6c0d88e0398406fc55d092e01dddb4c5b2bdca1589c730016fc23844635cbb74ccfd735d4376ea\" -C \"node_modules/filelist/node_modules/minimatch\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/finalhandler\"",
-      "tar -xzf \"flatpak-node/npm/finalhandler-e8137db6b1fb6e9deabe7ad1cb3b01cfe837959c533594db54ed84575092d1621c0db6b0615758bc67e5304ffd40fd21d296250830424e361af67673303a72c5\" -C \"node_modules/@turbowarp/extensions/node_modules/finalhandler\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/finalhandler-fedf3c4f2ddde495906d662068e1820987d7470575f9b7b4d96a986252fa87494489400c3ccf28f2a2863b4d58224387ce46b6ba9d3cc2f8180f4983888faadd\" -C \"node_modules/@turbowarp/extensions/node_modules/finalhandler\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/finalhandler\"",
-      "tar -xzf \"flatpak-node/npm/finalhandler-e8137db6b1fb6e9deabe7ad1cb3b01cfe837959c533594db54ed84575092d1621c0db6b0615758bc67e5304ffd40fd21d296250830424e361af67673303a72c5\" -C \"node_modules/finalhandler\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/finalhandler-fedf3c4f2ddde495906d662068e1820987d7470575f9b7b4d96a986252fa87494489400c3ccf28f2a2863b4d58224387ce46b6ba9d3cc2f8180f4983888faadd\" -C \"node_modules/finalhandler\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/find-up\"",
+      "tar -xzf \"flatpak-node/npm/find-up-efcfcf5d3d7094b2c3813cc3b3bb23abd873cf4bd70fece7fbbc32a447b87d74310a6766a9f1ac10f4319a2092408dda8c557dd5b552b2f36dac94625ba9c69e\" -C \"node_modules/@turbowarp/extensions/node_modules/find-up\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/eslint/node_modules/find-up\"",
+      "tar -xzf \"flatpak-node/npm/find-up-efcfcf5d3d7094b2c3813cc3b3bb23abd873cf4bd70fece7fbbc32a447b87d74310a6766a9f1ac10f4319a2092408dda8c557dd5b552b2f36dac94625ba9c69e\" -C \"node_modules/eslint/node_modules/find-up\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/flat-cache\"",
+      "tar -xzf \"flatpak-node/npm/flat-cache-7fb71c14f2b7497147a71d795081b2449fc525072db8a674cd5b8dddfac1a381e72b771acbd5445b447ac8f6051c2d0082a86e90fcca8eadb6b790e6032a86cb\" -C \"node_modules/@turbowarp/extensions/node_modules/flat-cache\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/flat-cache\"",
+      "tar -xzf \"flatpak-node/npm/flat-cache-7fb71c14f2b7497147a71d795081b2449fc525072db8a674cd5b8dddfac1a381e72b771acbd5445b447ac8f6051c2d0082a86e90fcca8eadb6b790e6032a86cb\" -C \"node_modules/flat-cache\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/flatted\"",
+      "tar -xzf \"flatpak-node/npm/flatted-197fb2b30e0f042cf43f3a2c1c37a964600d12e14230bae7453884cbd31c1a39a409063046ae00fd7efce86fdf8ccffe3a3b16494d59ad8e6ac8045998efeec2\" -C \"node_modules/@turbowarp/extensions/node_modules/flatted\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/flatted\"",
+      "tar -xzf \"flatpak-node/npm/flatted-197fb2b30e0f042cf43f3a2c1c37a964600d12e14230bae7453884cbd31c1a39a409063046ae00fd7efce86fdf8ccffe3a3b16494d59ad8e6ac8045998efeec2\" -C \"node_modules/flatted\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/forwarded\"",
       "tar -xzf \"flatpak-node/npm/forwarded-6ee446d1fa41b511d24c238049eea10f6e7cb44b9b16844b6f864d03a3713151cdc3680e7301e8f70c9a6e5ccccce039cfdc40f4bd4a36393f36de8c4fd698a3\" -C \"node_modules/@turbowarp/extensions/node_modules/forwarded\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/forwarded\"",
       "tar -xzf \"flatpak-node/npm/forwarded-6ee446d1fa41b511d24c238049eea10f6e7cb44b9b16844b6f864d03a3713151cdc3680e7301e8f70c9a6e5ccccce039cfdc40f4bd4a36393f36de8c4fd698a3\" -C \"node_modules/forwarded\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/fresh\"",
-      "tar -xzf \"flatpak-node/npm/fresh-cc9da6418335f2b1053ae75e57819285318843b45bcc0ee8cdb53d23f5c1a66ee4aa0332c209b294cc171f16499a45686249daf5dda95575573dd6133fd7a3f1\" -C \"node_modules/@turbowarp/extensions/node_modules/fresh\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/fresh-471fd6c9c67ad0739aa8b2808ba70744a288ef3c566c9df53219ed9adc0ca1a4de17b5c51fd861069f2f21368c89d7e58d143a7985822a46932beca45491cfd8\" -C \"node_modules/@turbowarp/extensions/node_modules/fresh\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/fresh\"",
-      "tar -xzf \"flatpak-node/npm/fresh-cc9da6418335f2b1053ae75e57819285318843b45bcc0ee8cdb53d23f5c1a66ee4aa0332c209b294cc171f16499a45686249daf5dda95575573dd6133fd7a3f1\" -C \"node_modules/fresh\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/fresh-471fd6c9c67ad0739aa8b2808ba70744a288ef3c566c9df53219ed9adc0ca1a4de17b5c51fd861069f2f21368c89d7e58d143a7985822a46932beca45491cfd8\" -C \"node_modules/fresh\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/function-bind\"",
       "tar -xzf \"flatpak-node/npm/function-bind-ed71cdc47eea5fdc46e66230c6486e993a31fcc21135c3a00ebc56b0cb76a40af6dd61e9e8cad194dec50521690a9afea153b417be38894811f369c931f1b648\" -C \"node_modules/@turbowarp/extensions/node_modules/function-bind\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/function-bind\"",
@@ -9964,6 +10616,14 @@
       "tar -xzf \"flatpak-node/npm/get-proto-b1349f063a17069f3d26f20a21e7eac3b53608279bb1cef892263a6b0886a202ada1219b823604fc6ffe97db05dcc5853cd73d21ca0e0b83837ca1dfc459a9d2\" -C \"node_modules/scratch-gui/node_modules/get-proto\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/get-proto\"",
       "tar -xzf \"flatpak-node/npm/get-proto-b1349f063a17069f3d26f20a21e7eac3b53608279bb1cef892263a6b0886a202ada1219b823604fc6ffe97db05dcc5853cd73d21ca0e0b83837ca1dfc459a9d2\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/get-proto\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/glob-parent\"",
+      "tar -xzf \"flatpak-node/npm/glob-parent-5f1c08f043a1550816a7a8832feddbd2bf3a7f877a017eb3494e791df078c9d084b972d773915c61e3aefa79c67ed4b84c48eeff5d6bb782893d33206df9afe0\" -C \"node_modules/@turbowarp/extensions/node_modules/glob-parent\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/eslint/node_modules/glob-parent\"",
+      "tar -xzf \"flatpak-node/npm/glob-parent-5f1c08f043a1550816a7a8832feddbd2bf3a7f877a017eb3494e791df078c9d084b972d773915c61e3aefa79c67ed4b84c48eeff5d6bb782893d33206df9afe0\" -C \"node_modules/eslint/node_modules/glob-parent\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/globals\"",
+      "tar -xzf \"flatpak-node/npm/globals-a1a846bee3064253f0fe2bc86018d54ab5807d62c17a4bb9b693c4d9f38f2e2f961df7c859bba1dad0a38724214c13cc7f913d8c3107e053a64d8818c1b2b0b5\" -C \"node_modules/@turbowarp/extensions/node_modules/globals\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/globals\"",
+      "tar -xzf \"flatpak-node/npm/globals-a1a846bee3064253f0fe2bc86018d54ab5807d62c17a4bb9b693c4d9f38f2e2f961df7c859bba1dad0a38724214c13cc7f913d8c3107e053a64d8818c1b2b0b5\" -C \"node_modules/globals\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/gopd\"",
       "tar -xzf \"flatpak-node/npm/gopd-65429187afe4505a0089302d4d83d9277870f70371c7e04804e8a39e51bd3e7ac9b027128ecd70cb20fabc9a5a62d827cc3aca6114aa7f738ee917daf77c6c46\" -C \"node_modules/@turbowarp/extensions/node_modules/gopd\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/gopd\"",
@@ -10000,16 +10660,36 @@
       "tar -xzf \"flatpak-node/npm/http-errors-16dc2b1bf7ae0736848d8791a8e825cbb1b4aaf8a25e82569ef107d99d6994175781bca3bf7e291d349bf73a1e1ccc83cb7dfe0d6cb95adf56a3e4d446d39849\" -C \"node_modules/@turbowarp/extensions/node_modules/http-errors\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/http-errors\"",
       "tar -xzf \"flatpak-node/npm/http-errors-16dc2b1bf7ae0736848d8791a8e825cbb1b4aaf8a25e82569ef107d99d6994175781bca3bf7e291d349bf73a1e1ccc83cb7dfe0d6cb95adf56a3e4d446d39849\" -C \"node_modules/http-errors\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/http-errors/node_modules/statuses\"",
+      "tar -xzf \"flatpak-node/npm/statuses-470340f59ffb3eb2b4eab60b23314c95a17e97bde2c29ceca9120581b30b6d370b0fa70e6a8f364da59e7cf5d0bc1d9f382e008ee612127752ecdfe64c26e475\" -C \"node_modules/@turbowarp/extensions/node_modules/http-errors/node_modules/statuses\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/http-errors/node_modules/statuses\"",
+      "tar -xzf \"flatpak-node/npm/statuses-470340f59ffb3eb2b4eab60b23314c95a17e97bde2c29ceca9120581b30b6d370b0fa70e6a8f364da59e7cf5d0bc1d9f382e008ee612127752ecdfe64c26e475\" -C \"node_modules/http-errors/node_modules/statuses\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/iconv-lite\"",
-      "tar -xzf \"flatpak-node/npm/iconv-lite-bf73179d901cbe7cb091350466898801cb657bb4575de79d391df5c3097b565ca85cee108bd6abbd27a73505a77b54dc4708422f51f02c8db56c4a9da63f3fac\" -C \"node_modules/@turbowarp/extensions/node_modules/iconv-lite\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/body-parser/node_modules/iconv-lite\"",
-      "tar -xzf \"flatpak-node/npm/iconv-lite-bf73179d901cbe7cb091350466898801cb657bb4575de79d391df5c3097b565ca85cee108bd6abbd27a73505a77b54dc4708422f51f02c8db56c4a9da63f3fac\" -C \"node_modules/body-parser/node_modules/iconv-lite\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/raw-body/node_modules/iconv-lite\"",
-      "tar -xzf \"flatpak-node/npm/iconv-lite-bf73179d901cbe7cb091350466898801cb657bb4575de79d391df5c3097b565ca85cee108bd6abbd27a73505a77b54dc4708422f51f02c8db56c4a9da63f3fac\" -C \"node_modules/raw-body/node_modules/iconv-lite\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/iconv-lite-e1f0a4efdc2c84c773329dab1f4eaa5ab244e22a25a8b842507f8e8ae22053ef91074fbde0d9432fcd5ab4eec65f9e6e50ab9ea34b711cdb6f13223a0fb59d33\" -C \"node_modules/@turbowarp/extensions/node_modules/iconv-lite\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/iconv-lite\"",
+      "tar -xzf \"flatpak-node/npm/iconv-lite-e1f0a4efdc2c84c773329dab1f4eaa5ab244e22a25a8b842507f8e8ae22053ef91074fbde0d9432fcd5ab4eec65f9e6e50ab9ea34b711cdb6f13223a0fb59d33\" -C \"node_modules/iconv-lite\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/ignore\"",
+      "tar -xzf \"flatpak-node/npm/ignore-86c053354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa\" -C \"node_modules/@turbowarp/extensions/node_modules/ignore\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/ignore\"",
+      "tar -xzf \"flatpak-node/npm/ignore-86c053354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa\" -C \"node_modules/ignore\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/ignore\"",
+      "tar -xzf \"flatpak-node/npm/ignore-86c053354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa\" -C \"node_modules/scratch-gui/node_modules/ignore\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/image-size\"",
       "tar -xzf \"flatpak-node/npm/image-size-211a972a5697c2048c00cb6937365ad5901ef26f926b5efbd03864f15912b0ff4b4be8870fad9977c1502acf1f6cf89a80113b073a055f6ddcc459f0b21a55eb\" -C \"node_modules/@turbowarp/extensions/node_modules/image-size\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/image-size\"",
       "tar -xzf \"flatpak-node/npm/image-size-211a972a5697c2048c00cb6937365ad5901ef26f926b5efbd03864f15912b0ff4b4be8870fad9977c1502acf1f6cf89a80113b073a055f6ddcc459f0b21a55eb\" -C \"node_modules/image-size\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/import-fresh\"",
+      "tar -xzf \"flatpak-node/npm/import-fresh-4d1dca7eb4d94d82cf07a8d48dfc7a305f56716ac72fdb2ee5339b2b866462005d58a3ce1684a8408744b93b91f36a66b711f6b29586f61e9eb707ebd692c1a9\" -C \"node_modules/@turbowarp/extensions/node_modules/import-fresh\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/import-fresh\"",
+      "tar -xzf \"flatpak-node/npm/import-fresh-4d1dca7eb4d94d82cf07a8d48dfc7a305f56716ac72fdb2ee5339b2b866462005d58a3ce1684a8408744b93b91f36a66b711f6b29586f61e9eb707ebd692c1a9\" -C \"node_modules/import-fresh\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/imurmurhash\"",
+      "tar -xzf \"flatpak-node/npm/imurmurhash-2665cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c\" -C \"node_modules/@turbowarp/extensions/node_modules/imurmurhash\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/imurmurhash\"",
+      "tar -xzf \"flatpak-node/npm/imurmurhash-2665cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c\" -C \"node_modules/imurmurhash\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/imurmurhash\"",
+      "tar -xzf \"flatpak-node/npm/imurmurhash-2665cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c\" -C \"node_modules/scratch-gui/node_modules/imurmurhash\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/imurmurhash\"",
+      "tar -xzf \"flatpak-node/npm/imurmurhash-2665cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/imurmurhash\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/inherits\"",
       "tar -xzf \"flatpak-node/npm/inherits-93fbc6697e3f6256b75b3c8c0af4d039761e207bea38ab67a8176ecd31e9ce9419cc0b2428c859d8af849c189233dcc64a820578ca572b16b8758799210a9ec1\" -C \"node_modules/@turbowarp/extensions/node_modules/inherits\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/inherits\"",
@@ -10026,12 +10706,70 @@
       "tar -xzf \"flatpak-node/npm/ipaddr.js-d0a23feb4ef1a31493a07ec68cdd457d26cba14d3e6ed4e2723b1049642587f859ca437c2a998c7fbb98c0f5b747e6a467a47fc35f199574870585e26143cede\" -C \"node_modules/@turbowarp/extensions/node_modules/ipaddr.js\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/ipaddr.js\"",
       "tar -xzf \"flatpak-node/npm/ipaddr.js-d0a23feb4ef1a31493a07ec68cdd457d26cba14d3e6ed4e2723b1049642587f859ca437c2a998c7fbb98c0f5b747e6a467a47fc35f199574870585e26143cede\" -C \"node_modules/ipaddr.js\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/is-extglob\"",
+      "tar -xzf \"flatpak-node/npm/is-extglob-49b29b00d90deb4dd58b88c466fe3d2de549327e321b0b1bcd9c28ac4a32122badb0dde725875b3b7eb37e1189e90103a4e6481640ed9eae494719af9778eca1\" -C \"node_modules/@turbowarp/extensions/node_modules/is-extglob\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/is-extglob\"",
+      "tar -xzf \"flatpak-node/npm/is-extglob-49b29b00d90deb4dd58b88c466fe3d2de549327e321b0b1bcd9c28ac4a32122badb0dde725875b3b7eb37e1189e90103a4e6481640ed9eae494719af9778eca1\" -C \"node_modules/is-extglob\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/is-extglob\"",
+      "tar -xzf \"flatpak-node/npm/is-extglob-49b29b00d90deb4dd58b88c466fe3d2de549327e321b0b1bcd9c28ac4a32122badb0dde725875b3b7eb37e1189e90103a4e6481640ed9eae494719af9778eca1\" -C \"node_modules/scratch-gui/node_modules/is-extglob\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/is-extglob\"",
+      "tar -xzf \"flatpak-node/npm/is-extglob-49b29b00d90deb4dd58b88c466fe3d2de549327e321b0b1bcd9c28ac4a32122badb0dde725875b3b7eb37e1189e90103a4e6481640ed9eae494719af9778eca1\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/is-extglob\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/is-glob\"",
+      "tar -xzf \"flatpak-node/npm/is-glob-c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a\" -C \"node_modules/@turbowarp/extensions/node_modules/is-glob\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/is-glob\"",
+      "tar -xzf \"flatpak-node/npm/is-glob-c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a\" -C \"node_modules/is-glob\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/is-glob\"",
+      "tar -xzf \"flatpak-node/npm/is-glob-c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a\" -C \"node_modules/scratch-gui/node_modules/is-glob\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/is-glob\"",
+      "tar -xzf \"flatpak-node/npm/is-glob-c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/is-glob\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/is-promise\"",
+      "tar -xzf \"flatpak-node/npm/is-promise-86fa6823a928ae124c9de8f6f3975283a9eed7e7babb1b3bcc6dc16009b96f2a83b2024d5b0c7333acfa8998808104784c9df42660533b0a99530dd69721f701\" -C \"node_modules/@turbowarp/extensions/node_modules/is-promise\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/is-promise\"",
+      "tar -xzf \"flatpak-node/npm/is-promise-86fa6823a928ae124c9de8f6f3975283a9eed7e7babb1b3bcc6dc16009b96f2a83b2024d5b0c7333acfa8998808104784c9df42660533b0a99530dd69721f701\" -C \"node_modules/is-promise\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/isexe\"",
+      "tar -xzf \"flatpak-node/npm/isexe-447c4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23\" -C \"node_modules/@turbowarp/extensions/node_modules/isexe\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/isexe\"",
+      "tar -xzf \"flatpak-node/npm/isexe-447c4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23\" -C \"node_modules/isexe\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/jake\"",
-      "tar -xzf \"flatpak-node/npm/jake-6438b768ff9f1bf2dc87207350cf34e158dd767c1f49fb1d798930b7c35c6ca46fa38ac592386ce39ea22c59f79366545af35ee22e3c5800836f36bc7e1ab6fb\" -C \"node_modules/@turbowarp/extensions/node_modules/jake\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/jake-c291d8ce1c625502fe215d3904b1365e7df8cd6d52db6de1be3b6a934fa0b0faf077ff0934b5c981964cfe23c5b18735c72a6117ee8ce84bdd13913d3011a40c\" -C \"node_modules/@turbowarp/extensions/node_modules/jake\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/jake\"",
+      "tar -xzf \"flatpak-node/npm/jake-c291d8ce1c625502fe215d3904b1365e7df8cd6d52db6de1be3b6a934fa0b0faf077ff0934b5c981964cfe23c5b18735c72a6117ee8ce84bdd13913d3011a40c\" -C \"node_modules/jake\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/js-yaml\"",
+      "tar -xzf \"flatpak-node/npm/js-yaml-c29c59b3d368c596891122462194f20c4698a65d0529203e141f5a262c9e98a84cc24c5083ade1e13d4a2605061e94ea3c33517269982ee82b46326506d5af44\" -C \"node_modules/@turbowarp/extensions/node_modules/js-yaml\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/js-yaml\"",
+      "tar -xzf \"flatpak-node/npm/js-yaml-c29c59b3d368c596891122462194f20c4698a65d0529203e141f5a262c9e98a84cc24c5083ade1e13d4a2605061e94ea3c33517269982ee82b46326506d5af44\" -C \"node_modules/js-yaml\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/json-buffer\"",
+      "tar -xzf \"flatpak-node/npm/json-buffer-e1b57905f4769aa7d04c99be579b4f3dd7fe669ba1888bd3b8007983c91cad7399a534ff430c15456072c17d68cebea512e3dd6c7c70689966f46ea6236b1f49\" -C \"node_modules/@turbowarp/extensions/node_modules/json-buffer\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/json-buffer\"",
+      "tar -xzf \"flatpak-node/npm/json-buffer-e1b57905f4769aa7d04c99be579b4f3dd7fe669ba1888bd3b8007983c91cad7399a534ff430c15456072c17d68cebea512e3dd6c7c70689966f46ea6236b1f49\" -C \"node_modules/json-buffer\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/json-schema-traverse\"",
+      "tar -xzf \"flatpak-node/npm/json-schema-traverse-c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756\" -C \"node_modules/@turbowarp/extensions/node_modules/json-schema-traverse\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/json-schema-traverse\"",
+      "tar -xzf \"flatpak-node/npm/json-schema-traverse-c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756\" -C \"node_modules/json-schema-traverse\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/json-schema-traverse\"",
+      "tar -xzf \"flatpak-node/npm/json-schema-traverse-c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756\" -C \"node_modules/scratch-gui/node_modules/json-schema-traverse\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/json-schema-traverse\"",
+      "tar -xzf \"flatpak-node/npm/json-schema-traverse-c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/json-schema-traverse\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/json-stable-stringify-without-jsonify\"",
+      "tar -xzf \"flatpak-node/npm/json-stable-stringify-without-jsonify-05d6e8cbe97bb40dce196e858f21475a43f92ee0728f54e4df72e3caad1ac72cdd93dfff2528b6bb77cfd504a677528dc2ae9538a606940bbcec28ac562afa3f\" -C \"node_modules/@turbowarp/extensions/node_modules/json-stable-stringify-without-jsonify\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/json-stable-stringify-without-jsonify\"",
+      "tar -xzf \"flatpak-node/npm/json-stable-stringify-without-jsonify-05d6e8cbe97bb40dce196e858f21475a43f92ee0728f54e4df72e3caad1ac72cdd93dfff2528b6bb77cfd504a677528dc2ae9538a606940bbcec28ac562afa3f\" -C \"node_modules/json-stable-stringify-without-jsonify\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/keyv\"",
+      "tar -xzf \"flatpak-node/npm/keyv-a3154790747f1097f608d5e75b144b5ba9a0ec9c82094706d03b441a62f672d528d4f3538a7d4f52297eafffb8af93295600bf7e7d648ecc7b9a34ae8caa88a7\" -C \"node_modules/@turbowarp/extensions/node_modules/keyv\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/keyv\"",
+      "tar -xzf \"flatpak-node/npm/keyv-a3154790747f1097f608d5e75b144b5ba9a0ec9c82094706d03b441a62f672d528d4f3538a7d4f52297eafffb8af93295600bf7e7d648ecc7b9a34ae8caa88a7\" -C \"node_modules/keyv\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/linkify-it\"",
       "tar -xzf \"flatpak-node/npm/linkify-it-e5a1c26f341100371d3fe013aa70ee86127f31122a0e4657e69ca3147451cac4bcbd9e406ea184a0521bea96073d9f8bfce0b62dcfb14fcb875554790802bfc1\" -C \"node_modules/@turbowarp/extensions/node_modules/linkify-it\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/linkify-it\"",
       "tar -xzf \"flatpak-node/npm/linkify-it-e5a1c26f341100371d3fe013aa70ee86127f31122a0e4657e69ca3147451cac4bcbd9e406ea184a0521bea96073d9f8bfce0b62dcfb14fcb875554790802bfc1\" -C \"node_modules/linkify-it\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/locate-path\"",
+      "tar -xzf \"flatpak-node/npm/locate-path-88f64ae9e6236f146edee078fd667712c10830914ca80a28a65dd1fb3baad148dc026fcc3ba282c1e0e03df3f77a54f3b6828fdcab67547c539f63470520d553\" -C \"node_modules/@turbowarp/extensions/node_modules/locate-path\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/eslint/node_modules/locate-path\"",
+      "tar -xzf \"flatpak-node/npm/locate-path-88f64ae9e6236f146edee078fd667712c10830914ca80a28a65dd1fb3baad148dc026fcc3ba282c1e0e03df3f77a54f3b6828fdcab67547c539f63470520d553\" -C \"node_modules/eslint/node_modules/locate-path\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/lodash.merge\"",
+      "tar -xzf \"flatpak-node/npm/lodash.merge-d0aa63a97455beb6320ac5f5b3047f5d32b4bdae9542440ce8c368ecfa96efb0728c086801103c11facfd4de3e2a52a3f184b46540ad453fd852e872603ba321\" -C \"node_modules/@turbowarp/extensions/node_modules/lodash.merge\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/lodash.merge\"",
+      "tar -xzf \"flatpak-node/npm/lodash.merge-d0aa63a97455beb6320ac5f5b3047f5d32b4bdae9542440ce8c368ecfa96efb0728c086801103c11facfd4de3e2a52a3f184b46540ad453fd852e872603ba321\" -C \"node_modules/lodash.merge\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/markdown-it\"",
       "tar -xzf \"flatpak-node/npm/markdown-it-6b9e08c2058f69e042000b2fd776209802ce1757a5001074f05c4ef62fabe15164e55978a4aa2444f797f2ee530a04ac3e2e9e735a2d7cb8dd3a955c81ba6c86\" -C \"node_modules/@turbowarp/extensions/node_modules/markdown-it\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/markdown-it\"",
@@ -10049,43 +10787,49 @@
       "mkdir -p \"node_modules/mdurl\"",
       "tar -xzf \"flatpak-node/npm/mdurl-2dffbdfb6afe4dda79c170d70b83dc2018d30edab850a8c23cc421288bb3a49356d1bf7a915a92c16d1b4fb1614527e602215880ff92091bddac3a337e1d14e7\" -C \"node_modules/mdurl\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/media-typer\"",
-      "tar -xzf \"flatpak-node/npm/media-typer-76afaa7a543d6a41e970e97f8145514f15483a4009d70477400bdbe11b158d2f285681630c64dcebbf702589949a49d41791f030b3a06f93be6b72b17d66a93d\" -C \"node_modules/@turbowarp/extensions/node_modules/media-typer\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/media-typer-6a2b27ac33f818d7b4e9470a1675796df30d3c1530e23b0b19a5b059f9c7defd361a706e5d7d8c0959f945bad6a348f7a5ccd48a561b96aedf43b370dade572b\" -C \"node_modules/@turbowarp/extensions/node_modules/media-typer\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/media-typer\"",
-      "tar -xzf \"flatpak-node/npm/media-typer-76afaa7a543d6a41e970e97f8145514f15483a4009d70477400bdbe11b158d2f285681630c64dcebbf702589949a49d41791f030b3a06f93be6b72b17d66a93d\" -C \"node_modules/media-typer\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/media-typer-6a2b27ac33f818d7b4e9470a1675796df30d3c1530e23b0b19a5b059f9c7defd361a706e5d7d8c0959f945bad6a348f7a5ccd48a561b96aedf43b370dade572b\" -C \"node_modules/media-typer\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/merge-descriptors\"",
-      "tar -xzf \"flatpak-node/npm/merge-descriptors-81a36f012ed367cf7bfeb55a6749ccb40cb13728bfa5d6e36c0c14a4542937bd06aa755f3a25e979450c291066cd769243c0dd4d7e3fd26b3adabd8afa113a99\" -C \"node_modules/@turbowarp/extensions/node_modules/merge-descriptors\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/merge-descriptors-4a7937d785796b214b869ddf914444b9be96b6305f3dd08f6352e7f3ff26ba7b8bba2621b000600555aca33006f8c58c6d512f71d7296e2f51ef0c36da5f50de\" -C \"node_modules/@turbowarp/extensions/node_modules/merge-descriptors\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/merge-descriptors\"",
-      "tar -xzf \"flatpak-node/npm/merge-descriptors-81a36f012ed367cf7bfeb55a6749ccb40cb13728bfa5d6e36c0c14a4542937bd06aa755f3a25e979450c291066cd769243c0dd4d7e3fd26b3adabd8afa113a99\" -C \"node_modules/merge-descriptors\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/methods\"",
-      "tar -xzf \"flatpak-node/npm/methods-89c9401de36a366ebccc5b676747bed4bdb250876fccda1ab8a53858103756f1ffbcf162785eea7d197051953e0c0f4ff5b3d7212f74ba5c68528087db7b15db\" -C \"node_modules/@turbowarp/extensions/node_modules/methods\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/methods\"",
-      "tar -xzf \"flatpak-node/npm/methods-89c9401de36a366ebccc5b676747bed4bdb250876fccda1ab8a53858103756f1ffbcf162785eea7d197051953e0c0f4ff5b3d7212f74ba5c68528087db7b15db\" -C \"node_modules/methods\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/mime\"",
-      "tar -xzf \"flatpak-node/npm/mime-c74567f2ca48fb0b89d4ee92ee09db69083c3f187834d1dbeca4883661162a23c4e1128ea65be28e7f8d92662699180febc99cef48f611b793151b2bb306907a\" -C \"node_modules/@turbowarp/extensions/node_modules/mime\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/send/node_modules/mime\"",
-      "tar -xzf \"flatpak-node/npm/mime-c74567f2ca48fb0b89d4ee92ee09db69083c3f187834d1dbeca4883661162a23c4e1128ea65be28e7f8d92662699180febc99cef48f611b793151b2bb306907a\" -C \"node_modules/send/node_modules/mime\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/merge-descriptors-4a7937d785796b214b869ddf914444b9be96b6305f3dd08f6352e7f3ff26ba7b8bba2621b000600555aca33006f8c58c6d512f71d7296e2f51ef0c36da5f50de\" -C \"node_modules/merge-descriptors\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/mime-db\"",
-      "tar -xzf \"flatpak-node/npm/mime-db-b0f538b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be\" -C \"node_modules/@turbowarp/extensions/node_modules/mime-db\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/mime-db\"",
-      "tar -xzf \"flatpak-node/npm/mime-db-b0f538b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be\" -C \"node_modules/mime-db\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/mime-types/node_modules/mime-db\"",
-      "tar -xzf \"flatpak-node/npm/mime-db-b0f538b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be\" -C \"node_modules/scratch-gui/node_modules/mime-types/node_modules/mime-db\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/mime-db-694e4426e20dd960de982700a76bc505fa7f9b810085626750d492c348b1b3bfe45db77a3e0eb8126c0990d745841f1a5add6c1f60935eb2f1a3f880195de83d\" -C \"node_modules/@turbowarp/extensions/node_modules/mime-db\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/accepts/node_modules/mime-db\"",
+      "tar -xzf \"flatpak-node/npm/mime-db-694e4426e20dd960de982700a76bc505fa7f9b810085626750d492c348b1b3bfe45db77a3e0eb8126c0990d745841f1a5add6c1f60935eb2f1a3f880195de83d\" -C \"node_modules/accepts/node_modules/mime-db\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/express/node_modules/mime-db\"",
+      "tar -xzf \"flatpak-node/npm/mime-db-694e4426e20dd960de982700a76bc505fa7f9b810085626750d492c348b1b3bfe45db77a3e0eb8126c0990d745841f1a5add6c1f60935eb2f1a3f880195de83d\" -C \"node_modules/express/node_modules/mime-db\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/mime-db\"",
+      "tar -xzf \"flatpak-node/npm/mime-db-694e4426e20dd960de982700a76bc505fa7f9b810085626750d492c348b1b3bfe45db77a3e0eb8126c0990d745841f1a5add6c1f60935eb2f1a3f880195de83d\" -C \"node_modules/scratch-gui/node_modules/mime-db\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/send/node_modules/mime-db\"",
+      "tar -xzf \"flatpak-node/npm/mime-db-694e4426e20dd960de982700a76bc505fa7f9b810085626750d492c348b1b3bfe45db77a3e0eb8126c0990d745841f1a5add6c1f60935eb2f1a3f880195de83d\" -C \"node_modules/send/node_modules/mime-db\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/type-is/node_modules/mime-db\"",
+      "tar -xzf \"flatpak-node/npm/mime-db-694e4426e20dd960de982700a76bc505fa7f9b810085626750d492c348b1b3bfe45db77a3e0eb8126c0990d745841f1a5add6c1f60935eb2f1a3f880195de83d\" -C \"node_modules/type-is/node_modules/mime-db\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/mime-types\"",
-      "tar -xzf \"flatpak-node/npm/mime-types-64363e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b\" -C \"node_modules/@turbowarp/extensions/node_modules/mime-types\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/mime-types\"",
-      "tar -xzf \"flatpak-node/npm/mime-types-64363e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b\" -C \"node_modules/mime-types\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/mime-types\"",
-      "tar -xzf \"flatpak-node/npm/mime-types-64363e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b\" -C \"node_modules/scratch-gui/node_modules/mime-types\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/mime-types-c51738a04853e9e681a54d5717b023a4e143fb14265cd0793952b0a78b6a0ae0691cb4bf65b043adcd3b9984c3a95320e8f7f15238cda7ce4ee8277667fe4758\" -C \"node_modules/@turbowarp/extensions/node_modules/mime-types\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/accepts/node_modules/mime-types\"",
+      "tar -xzf \"flatpak-node/npm/mime-types-c51738a04853e9e681a54d5717b023a4e143fb14265cd0793952b0a78b6a0ae0691cb4bf65b043adcd3b9984c3a95320e8f7f15238cda7ce4ee8277667fe4758\" -C \"node_modules/accepts/node_modules/mime-types\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/express/node_modules/mime-types\"",
+      "tar -xzf \"flatpak-node/npm/mime-types-c51738a04853e9e681a54d5717b023a4e143fb14265cd0793952b0a78b6a0ae0691cb4bf65b043adcd3b9984c3a95320e8f7f15238cda7ce4ee8277667fe4758\" -C \"node_modules/express/node_modules/mime-types\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/send/node_modules/mime-types\"",
+      "tar -xzf \"flatpak-node/npm/mime-types-c51738a04853e9e681a54d5717b023a4e143fb14265cd0793952b0a78b6a0ae0691cb4bf65b043adcd3b9984c3a95320e8f7f15238cda7ce4ee8277667fe4758\" -C \"node_modules/send/node_modules/mime-types\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/type-is/node_modules/mime-types\"",
+      "tar -xzf \"flatpak-node/npm/mime-types-c51738a04853e9e681a54d5717b023a4e143fb14265cd0793952b0a78b6a0ae0691cb4bf65b043adcd3b9984c3a95320e8f7f15238cda7ce4ee8277667fe4758\" -C \"node_modules/type-is/node_modules/mime-types\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/ms\"",
       "tar -xzf \"flatpak-node/npm/ms-e85973b9b4cb646dc9d9afcd542025784863ceae68c601f268253dc985ef70bb2fa1568726afece715c8ebf5d73fab73ed1f7100eb479d23bfb57b45dd645394\" -C \"node_modules/@turbowarp/extensions/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/ms\"",
       "tar -xzf \"flatpak-node/npm/ms-e85973b9b4cb646dc9d9afcd542025784863ceae68c601f268253dc985ef70bb2fa1568726afece715c8ebf5d73fab73ed1f7100eb479d23bfb57b45dd645394\" -C \"node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/ms\"",
       "tar -xzf \"flatpak-node/npm/ms-e85973b9b4cb646dc9d9afcd542025784863ceae68c601f268253dc985ef70bb2fa1568726afece715c8ebf5d73fab73ed1f7100eb479d23bfb57b45dd645394\" -C \"node_modules/scratch-gui/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/natural-compare\"",
+      "tar -xzf \"flatpak-node/npm/natural-compare-396343f1e8b756d342f61ed5eb4a9f7f7495a1b1ebf7de824f0831b9b832418129836f7487d2746eec8408d3497b19059b9b0e6a38791b5d7a45803573c64c4b\" -C \"node_modules/@turbowarp/extensions/node_modules/natural-compare\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/natural-compare\"",
+      "tar -xzf \"flatpak-node/npm/natural-compare-396343f1e8b756d342f61ed5eb4a9f7f7495a1b1ebf7de824f0831b9b832418129836f7487d2746eec8408d3497b19059b9b0e6a38791b5d7a45803573c64c4b\" -C \"node_modules/natural-compare\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/negotiator\"",
-      "tar -xzf \"flatpak-node/npm/negotiator-f8452ca863cbb0cfa3ff37428598ec9d7e758385eb1c53885f07e70953c695093f9398226a470ab2ec4239b051bba0d29bda29c3f3bab2559b25d82140ce1b06\" -C \"node_modules/@turbowarp/extensions/node_modules/negotiator\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/negotiator-f0e7ecfc051087c31a11cae5ab9c4e5f4090f72a53179765efc9a394c35f38ad3c7f3a604c741140f07170f944b48c34c91a70b3e668ff7afee5645bcbbbb71a\" -C \"node_modules/@turbowarp/extensions/node_modules/negotiator\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/negotiator\"",
-      "tar -xzf \"flatpak-node/npm/negotiator-f8452ca863cbb0cfa3ff37428598ec9d7e758385eb1c53885f07e70953c695093f9398226a470ab2ec4239b051bba0d29bda29c3f3bab2559b25d82140ce1b06\" -C \"node_modules/negotiator\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/negotiator-f0e7ecfc051087c31a11cae5ab9c4e5f4090f72a53179765efc9a394c35f38ad3c7f3a604c741140f07170f944b48c34c91a70b3e668ff7afee5645bcbbbb71a\" -C \"node_modules/negotiator\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/object-inspect\"",
       "tar -xzf \"flatpak-node/npm/object-inspect-5baee22e5e09d845c41936df78709f7eb8c37e2b6f2c0360d14957df01545124f1f762974457a0307515812a84fb0be101b8b85aa8c683d733cac4d5d84a5b7b\" -C \"node_modules/@turbowarp/extensions/node_modules/object-inspect\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/object-inspect\"",
@@ -10098,36 +10842,108 @@
       "tar -xzf \"flatpak-node/npm/on-finished-a15973920dc4340842936cddbfb209c1dfd0503e33d91c51c2991c198f29b0255c09864dab8c189d55802c733e6ebb6e26378f5a2605fc2966b83afc0a1e7e92\" -C \"node_modules/@turbowarp/extensions/node_modules/on-finished\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/on-finished\"",
       "tar -xzf \"flatpak-node/npm/on-finished-a15973920dc4340842936cddbfb209c1dfd0503e33d91c51c2991c198f29b0255c09864dab8c189d55802c733e6ebb6e26378f5a2605fc2966b83afc0a1e7e92\" -C \"node_modules/on-finished\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/once\"",
+      "tar -xzf \"flatpak-node/npm/once-94d689808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb\" -C \"node_modules/@turbowarp/extensions/node_modules/once\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/once\"",
+      "tar -xzf \"flatpak-node/npm/once-94d689808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb\" -C \"node_modules/once\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/once\"",
+      "tar -xzf \"flatpak-node/npm/once-94d689808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb\" -C \"node_modules/scratch-gui/node_modules/once\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/once\"",
+      "tar -xzf \"flatpak-node/npm/once-94d689808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/once\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/optionator\"",
+      "tar -xzf \"flatpak-node/npm/optionator-e88a50ee6294c5171934b20e6d1d21cfb971b1aa5248860d649c173c6785d264d5a862852178f50d070ca13db64b744e70bc98febcf43d669667d6b25a669df6\" -C \"node_modules/@turbowarp/extensions/node_modules/optionator\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/eslint/node_modules/optionator\"",
+      "tar -xzf \"flatpak-node/npm/optionator-e88a50ee6294c5171934b20e6d1d21cfb971b1aa5248860d649c173c6785d264d5a862852178f50d070ca13db64b744e70bc98febcf43d669667d6b25a669df6\" -C \"node_modules/eslint/node_modules/optionator\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/p-limit\"",
+      "tar -xzf \"flatpak-node/npm/p-limit-4d839a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945\" -C \"node_modules/@turbowarp/extensions/node_modules/p-limit\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/p-limit\"",
+      "tar -xzf \"flatpak-node/npm/p-limit-4d839a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945\" -C \"node_modules/p-limit\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/p-limit\"",
+      "tar -xzf \"flatpak-node/npm/p-limit-4d839a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945\" -C \"node_modules/scratch-gui/node_modules/p-limit\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/p-locate\"",
+      "tar -xzf \"flatpak-node/npm/p-locate-2da363b51594058fbecc1e6713f37071aa0cca548f93e4be647341d53cdd6cc24c9f2e9dca7a401aded7fed97f418ab74c8784ea7c47a696e8d8b1b29ab1b93f\" -C \"node_modules/@turbowarp/extensions/node_modules/p-locate\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/eslint/node_modules/p-locate\"",
+      "tar -xzf \"flatpak-node/npm/p-locate-2da363b51594058fbecc1e6713f37071aa0cca548f93e4be647341d53cdd6cc24c9f2e9dca7a401aded7fed97f418ab74c8784ea7c47a696e8d8b1b29ab1b93f\" -C \"node_modules/eslint/node_modules/p-locate\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/parent-module\"",
+      "tar -xzf \"flatpak-node/npm/parent-module-190d84591a5057cfe8f80c3c62ab5f6593df3515996246e2744f64e6ba65fe10b7bed1c705f1a6d887e2eaa595f9ca031a4ad42990311372e8b7991cb11961fa\" -C \"node_modules/@turbowarp/extensions/node_modules/parent-module\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/parent-module\"",
+      "tar -xzf \"flatpak-node/npm/parent-module-190d84591a5057cfe8f80c3c62ab5f6593df3515996246e2744f64e6ba65fe10b7bed1c705f1a6d887e2eaa595f9ca031a4ad42990311372e8b7991cb11961fa\" -C \"node_modules/parent-module\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/parseurl\"",
       "tar -xzf \"flatpak-node/npm/parseurl-0a2c9e3b1153fc96723799b4cfd3df5f0e1208127a4b2833d43a65d30aa39610c418604fd469ec51510bd29eb78681b57dc8f77c7ca75e2f4d60ee2758e2fea9\" -C \"node_modules/@turbowarp/extensions/node_modules/parseurl\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/parseurl\"",
       "tar -xzf \"flatpak-node/npm/parseurl-0a2c9e3b1153fc96723799b4cfd3df5f0e1208127a4b2833d43a65d30aa39610c418604fd469ec51510bd29eb78681b57dc8f77c7ca75e2f4d60ee2758e2fea9\" -C \"node_modules/parseurl\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/path-exists\"",
+      "tar -xzf \"flatpak-node/npm/path-exists-6a4f50cb943b8d86f65b071ecb9169be0d8aa0073f64884b48b392066466ca03ec1b091556dd1f65ad2aaed333fa6ead2530077d943c167981e0c1b82d6cbbff\" -C \"node_modules/@turbowarp/extensions/node_modules/path-exists\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/path-exists\"",
+      "tar -xzf \"flatpak-node/npm/path-exists-6a4f50cb943b8d86f65b071ecb9169be0d8aa0073f64884b48b392066466ca03ec1b091556dd1f65ad2aaed333fa6ead2530077d943c167981e0c1b82d6cbbff\" -C \"node_modules/path-exists\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/path-exists\"",
+      "tar -xzf \"flatpak-node/npm/path-exists-6a4f50cb943b8d86f65b071ecb9169be0d8aa0073f64884b48b392066466ca03ec1b091556dd1f65ad2aaed333fa6ead2530077d943c167981e0c1b82d6cbbff\" -C \"node_modules/scratch-gui/node_modules/path-exists\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/path-key\"",
+      "tar -xzf \"flatpak-node/npm/path-key-a2399e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9\" -C \"node_modules/@turbowarp/extensions/node_modules/path-key\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/path-key\"",
+      "tar -xzf \"flatpak-node/npm/path-key-a2399e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9\" -C \"node_modules/path-key\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/path-to-regexp\"",
-      "tar -xzf \"flatpak-node/npm/path-to-regexp-440d468d454c9ef605c6eaa8beb12a668c715b935466a6f02ad633fd3b7b9d77ab9342db2db9509abb2075e3b15794851dfd140e08234bf6d278e670b75a6611\" -C \"node_modules/@turbowarp/extensions/node_modules/path-to-regexp\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/path-to-regexp-ee377054846db0ff0c6297574b0392d18743d03bbea8ea05fc010f22df3c3dc085ad90b3c78d68c64bb58c3f3c8590706cd50811fa6abee86315a300a8c4d69c\" -C \"node_modules/@turbowarp/extensions/node_modules/path-to-regexp\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/path-to-regexp\"",
-      "tar -xzf \"flatpak-node/npm/path-to-regexp-440d468d454c9ef605c6eaa8beb12a668c715b935466a6f02ad633fd3b7b9d77ab9342db2db9509abb2075e3b15794851dfd140e08234bf6d278e670b75a6611\" -C \"node_modules/path-to-regexp\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/path-to-regexp-ee377054846db0ff0c6297574b0392d18743d03bbea8ea05fc010f22df3c3dc085ad90b3c78d68c64bb58c3f3c8590706cd50811fa6abee86315a300a8c4d69c\" -C \"node_modules/path-to-regexp\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/picocolors\"",
+      "tar -xzf \"flatpak-node/npm/picocolors-c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454\" -C \"node_modules/@turbowarp/extensions/node_modules/picocolors\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/picocolors\"",
+      "tar -xzf \"flatpak-node/npm/picocolors-c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454\" -C \"node_modules/picocolors\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/picocolors\"",
+      "tar -xzf \"flatpak-node/npm/picocolors-c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454\" -C \"node_modules/scratch-gui/node_modules/picocolors\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/proxy-addr\"",
       "tar -xzf \"flatpak-node/npm/proxy-addr-96542c30b4940d43d3e388ddad4fcedfbaa59e27e2b433fe670ae699972848ac8b2afb59c69c95d27dbf6c3fcde2d040019fe024475953b28cadaa0ad7e5d802\" -C \"node_modules/@turbowarp/extensions/node_modules/proxy-addr\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/proxy-addr\"",
       "tar -xzf \"flatpak-node/npm/proxy-addr-96542c30b4940d43d3e388ddad4fcedfbaa59e27e2b433fe670ae699972848ac8b2afb59c69c95d27dbf6c3fcde2d040019fe024475953b28cadaa0ad7e5d802\" -C \"node_modules/proxy-addr\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/punycode\"",
+      "tar -xzf \"flatpak-node/npm/punycode-bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16\" -C \"node_modules/@turbowarp/extensions/node_modules/punycode\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/punycode\"",
+      "tar -xzf \"flatpak-node/npm/punycode-bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16\" -C \"node_modules/punycode\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/psl/node_modules/punycode\"",
+      "tar -xzf \"flatpak-node/npm/punycode-bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16\" -C \"node_modules/scratch-gui/node_modules/psl/node_modules/punycode\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/punycode\"",
+      "tar -xzf \"flatpak-node/npm/punycode-bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/punycode\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/tough-cookie/node_modules/punycode\"",
+      "tar -xzf \"flatpak-node/npm/punycode-bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16\" -C \"node_modules/scratch-gui/node_modules/tough-cookie/node_modules/punycode\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/uri-js/node_modules/punycode\"",
+      "tar -xzf \"flatpak-node/npm/punycode-bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16\" -C \"node_modules/scratch-gui/node_modules/uri-js/node_modules/punycode\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/punycode.js\"",
       "tar -xzf \"flatpak-node/npm/punycode.js-bb11481d4d189476210d0b55e11f49e9ae7648bc76f010a34fee227a1ec819b83054958efa49b8df5738c9195111402c026b7fb8c8d05324073443dfd0cdfd08\" -C \"node_modules/@turbowarp/extensions/node_modules/punycode.js\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/punycode.js\"",
       "tar -xzf \"flatpak-node/npm/punycode.js-bb11481d4d189476210d0b55e11f49e9ae7648bc76f010a34fee227a1ec819b83054958efa49b8df5738c9195111402c026b7fb8c8d05324073443dfd0cdfd08\" -C \"node_modules/punycode.js\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/qs\"",
-      "tar -xzf \"flatpak-node/npm/qs-fb7f2a23d48eafcb5f67842624da65314c6a8db7bb2cabef66059d13104e99df9e8194ed8cb07aec6bb41d15f7bbf5ceabb514d8dc7a9ec8ef4b5e99f6ec1fa6\" -C \"node_modules/@turbowarp/extensions/node_modules/qs\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/qs\"",
-      "tar -xzf \"flatpak-node/npm/qs-fb7f2a23d48eafcb5f67842624da65314c6a8db7bb2cabef66059d13104e99df9e8194ed8cb07aec6bb41d15f7bbf5ceabb514d8dc7a9ec8ef4b5e99f6ec1fa6\" -C \"node_modules/qs\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/qs-6165938e000148a72fb3f9d6062f4fc9c63f2623c9a8e0f8240ea8f527a3d80b6f4866ab5f1282dce412938a406ab6dd4252808790f814242424d916f86027df\" -C \"node_modules/@turbowarp/extensions/node_modules/qs\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/body-parser/node_modules/qs\"",
+      "tar -xzf \"flatpak-node/npm/qs-6165938e000148a72fb3f9d6062f4fc9c63f2623c9a8e0f8240ea8f527a3d80b6f4866ab5f1282dce412938a406ab6dd4252808790f814242424d916f86027df\" -C \"node_modules/body-parser/node_modules/qs\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/express/node_modules/qs\"",
+      "tar -xzf \"flatpak-node/npm/qs-6165938e000148a72fb3f9d6062f4fc9c63f2623c9a8e0f8240ea8f527a3d80b6f4866ab5f1282dce412938a406ab6dd4252808790f814242424d916f86027df\" -C \"node_modules/express/node_modules/qs\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/url/node_modules/qs\"",
+      "tar -xzf \"flatpak-node/npm/qs-6165938e000148a72fb3f9d6062f4fc9c63f2623c9a8e0f8240ea8f527a3d80b6f4866ab5f1282dce412938a406ab6dd4252808790f814242424d916f86027df\" -C \"node_modules/scratch-gui/node_modules/url/node_modules/qs\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/range-parser\"",
       "tar -xzf \"flatpak-node/npm/range-parser-1eb82cc7ea2baa8ca09e68456ca68713a736f7a27e1d30105e8c4417a80dba944e9a6189468cb37c6ddc700bdea8206bc2bff6cb143905577f1939796a03b04a\" -C \"node_modules/@turbowarp/extensions/node_modules/range-parser\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/range-parser\"",
       "tar -xzf \"flatpak-node/npm/range-parser-1eb82cc7ea2baa8ca09e68456ca68713a736f7a27e1d30105e8c4417a80dba944e9a6189468cb37c6ddc700bdea8206bc2bff6cb143905577f1939796a03b04a\" -C \"node_modules/range-parser\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/raw-body\"",
-      "tar -xzf \"flatpak-node/npm/raw-body-f331aaca97c4363088a868605d3a02f1a076afb62b057f804007c83ecfcc964f81b4f4f3b4ebd34b4d4d456ff7121eb427e6b8f25b7caac0b38ab43a9680957c\" -C \"node_modules/@turbowarp/extensions/node_modules/raw-body\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/raw-body-f46f1c03eb6e312ef9fba1bf4f35bc3ad2f39810cca3ca75251c4de4067e2c0a7cbb1180f15f06666e06438fcde503501272e683a492ef0cae4a66ca7a988aa8\" -C \"node_modules/@turbowarp/extensions/node_modules/raw-body\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/raw-body\"",
-      "tar -xzf \"flatpak-node/npm/raw-body-f331aaca97c4363088a868605d3a02f1a076afb62b057f804007c83ecfcc964f81b4f4f3b4ebd34b4d4d456ff7121eb427e6b8f25b7caac0b38ab43a9680957c\" -C \"node_modules/raw-body\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/raw-body-f46f1c03eb6e312ef9fba1bf4f35bc3ad2f39810cca3ca75251c4de4067e2c0a7cbb1180f15f06666e06438fcde503501272e683a492ef0cae4a66ca7a988aa8\" -C \"node_modules/raw-body\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/raw-body/node_modules/iconv-lite\"",
+      "tar -xzf \"flatpak-node/npm/iconv-lite-71fe8bd83b37879ed55669197be3e7fb900fb13ec5a6a26d1218627830afac4d8c2b9424f4cc9f7e0432bb14139ba04285f79936d70e2c7a7d21c59155c21c05\" -C \"node_modules/@turbowarp/extensions/node_modules/raw-body/node_modules/iconv-lite\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/raw-body/node_modules/iconv-lite\"",
+      "tar -xzf \"flatpak-node/npm/iconv-lite-71fe8bd83b37879ed55669197be3e7fb900fb13ec5a6a26d1218627830afac4d8c2b9424f4cc9f7e0432bb14139ba04285f79936d70e2c7a7d21c59155c21c05\" -C \"node_modules/raw-body/node_modules/iconv-lite\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/readdirp\"",
-      "tar -xzf \"flatpak-node/npm/readdirp-c83333f60f9569992a0584bfa33a012706818536d9a3750d6101cd470d43dd415007ca07078b92fed00e0cef992e31969946ca9c894e58ef9a688880c6b5161c\" -C \"node_modules/@turbowarp/extensions/node_modules/readdirp\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/readdirp-18387090b7f2c162f6b3abc48f286b8be79799f1fa8f52fb244dbb5a1a8b798ce887f0370c16981848f61ff1c56429ff90c7e29bbdc55f11094f0d3a5adc50c2\" -C \"node_modules/@turbowarp/extensions/node_modules/readdirp\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/readdirp\"",
+      "tar -xzf \"flatpak-node/npm/readdirp-18387090b7f2c162f6b3abc48f286b8be79799f1fa8f52fb244dbb5a1a8b798ce887f0370c16981848f61ff1c56429ff90c7e29bbdc55f11094f0d3a5adc50c2\" -C \"node_modules/readdirp\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/resolve-from\"",
+      "tar -xzf \"flatpak-node/npm/resolve-from-a5bfcc6265ecb40932b11171f2988d235b4614d408140def904dc6ab812e035745ea01e9ffebe066ab021896a9bf2f0ddd0fb8a3b170beab8f25c9d9ed1632e2\" -C \"node_modules/@turbowarp/extensions/node_modules/resolve-from\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/resolve-from\"",
+      "tar -xzf \"flatpak-node/npm/resolve-from-a5bfcc6265ecb40932b11171f2988d235b4614d408140def904dc6ab812e035745ea01e9ffebe066ab021896a9bf2f0ddd0fb8a3b170beab8f25c9d9ed1632e2\" -C \"node_modules/resolve-from\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/router\"",
+      "tar -xzf \"flatpak-node/npm/router-9cb4eb50a9b653288beeb9616a9bbf665e3917036091919a0a965b2076a30d883094908eccb4a4f9c20f027b04a95f79e468c82c99ca6dd402d6754fcfe80061\" -C \"node_modules/@turbowarp/extensions/node_modules/router\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/router\"",
+      "tar -xzf \"flatpak-node/npm/router-9cb4eb50a9b653288beeb9616a9bbf665e3917036091919a0a965b2076a30d883094908eccb4a4f9c20f027b04a95f79e468c82c99ca6dd402d6754fcfe80061\" -C \"node_modules/router\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/safe-buffer\"",
       "tar -xzf \"flatpak-node/npm/safe-buffer-ae9dd2a34eca71d9a629b1af81a37141226bedb1954959394bd12ad45fa9a5b468ef4f9879a0f1930e4377c34f37e183e9b8e7626d95b8fb825e6a6e62f9825d\" -C \"node_modules/@turbowarp/extensions/node_modules/safe-buffer\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/safe-buffer\"",
@@ -10147,21 +10963,25 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/safer-buffer\"",
       "tar -xzf \"flatpak-node/npm/safer-buffer-619a372bcd920fb462ca2d04d4440fa232f3ee4a5ea6749023d2323db1c78355d75debdbe5d248eeda72376003c467106c71bbbdcc911e4d1c6f0a9c42b894b6\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/safer-buffer\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/send\"",
-      "tar -xzf \"flatpak-node/npm/send-756e35bb955f2d7bbc4898796f0466c9851b028481ddcf6e421e8bf21fcab6c15110f5a96d7d65ae58c9a35f3a25ce2799c8bfb06519f5ad1ad09db381fab687\" -C \"node_modules/@turbowarp/extensions/node_modules/send\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/send-b9a5b45b05caa4bf5b957136a346d18682f61065c8ad9c50d994389a071fa01c5d16642895dfaa5ac0f68cbadf674b6b8ca2fabcec348fffde0307002c58ca4b\" -C \"node_modules/@turbowarp/extensions/node_modules/send\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/send\"",
-      "tar -xzf \"flatpak-node/npm/send-756e35bb955f2d7bbc4898796f0466c9851b028481ddcf6e421e8bf21fcab6c15110f5a96d7d65ae58c9a35f3a25ce2799c8bfb06519f5ad1ad09db381fab687\" -C \"node_modules/send\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/send/node_modules/encodeurl\"",
-      "tar -xzf \"flatpak-node/npm/encodeurl-4cf257abc26a15a5589b609698fbe73f6232a3865233bfd029c4a6b8c2c339b7e91f97e2ed150699dfeb4c37feaeeb7fb1a88389011e5533600262447403b1d3\" -C \"node_modules/@turbowarp/extensions/node_modules/send/node_modules/encodeurl\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/send/node_modules/encodeurl\"",
-      "tar -xzf \"flatpak-node/npm/encodeurl-4cf257abc26a15a5589b609698fbe73f6232a3865233bfd029c4a6b8c2c339b7e91f97e2ed150699dfeb4c37feaeeb7fb1a88389011e5533600262447403b1d3\" -C \"node_modules/send/node_modules/encodeurl\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/send-b9a5b45b05caa4bf5b957136a346d18682f61065c8ad9c50d994389a071fa01c5d16642895dfaa5ac0f68cbadf674b6b8ca2fabcec348fffde0307002c58ca4b\" -C \"node_modules/send\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/serve-static\"",
-      "tar -xzf \"flatpak-node/npm/serve-static-56aa6325929a75007f3c46c4c2f15d3b8dc0c79745059d94102b33cfc6d0ee98bbc2dfff3d67b53fa30dede0a78ec6ad62d053e84ba20a56e34963f65ab2284f\" -C \"node_modules/@turbowarp/extensions/node_modules/serve-static\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/serve-static-eb583da4287456787b22eb598ed2c61a94c0df9e7e38f9f64f20efffa8af3f687f01d0155fd6b3b28c66836fccea765e419358044c0872c9ded6625df68408b5\" -C \"node_modules/@turbowarp/extensions/node_modules/serve-static\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/serve-static\"",
-      "tar -xzf \"flatpak-node/npm/serve-static-56aa6325929a75007f3c46c4c2f15d3b8dc0c79745059d94102b33cfc6d0ee98bbc2dfff3d67b53fa30dede0a78ec6ad62d053e84ba20a56e34963f65ab2284f\" -C \"node_modules/serve-static\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/serve-static-eb583da4287456787b22eb598ed2c61a94c0df9e7e38f9f64f20efffa8af3f687f01d0155fd6b3b28c66836fccea765e419358044c0872c9ded6625df68408b5\" -C \"node_modules/serve-static\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/setprototypeof\"",
       "tar -xzf \"flatpak-node/npm/setprototypeof-1392c35fb5aba7ce4a8a5e5b859bf8ea3f2339e6e82aae4932660cde05467461fcc45a4f59750cb0dae53830ab928c4c11e362fd7648c2e46f6385cdc18309a7\" -C \"node_modules/@turbowarp/extensions/node_modules/setprototypeof\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/setprototypeof\"",
       "tar -xzf \"flatpak-node/npm/setprototypeof-1392c35fb5aba7ce4a8a5e5b859bf8ea3f2339e6e82aae4932660cde05467461fcc45a4f59750cb0dae53830ab928c4c11e362fd7648c2e46f6385cdc18309a7\" -C \"node_modules/setprototypeof\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/shebang-command\"",
+      "tar -xzf \"flatpak-node/npm/shebang-command-907c6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c\" -C \"node_modules/@turbowarp/extensions/node_modules/shebang-command\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/shebang-command\"",
+      "tar -xzf \"flatpak-node/npm/shebang-command-907c6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c\" -C \"node_modules/shebang-command\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/shebang-regex\"",
+      "tar -xzf \"flatpak-node/npm/shebang-regex-efef9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4\" -C \"node_modules/@turbowarp/extensions/node_modules/shebang-regex\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/shebang-regex\"",
+      "tar -xzf \"flatpak-node/npm/shebang-regex-efef9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4\" -C \"node_modules/shebang-regex\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/side-channel\"",
       "tar -xzf \"flatpak-node/npm/side-channel-657f7d7bab51c1ea145ea47e541aec96175ae75361e4c4d0c28bb9b6750381bb723347418268440ed5863ffc5b2a7ea1a9f3d11ee8d4370cf97f2ff06db867a7\" -C \"node_modules/@turbowarp/extensions/node_modules/side-channel\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/side-channel\"",
@@ -10195,9 +11015,13 @@
       "mkdir -p \"node_modules/side-channel-weakmap\"",
       "tar -xzf \"flatpak-node/npm/side-channel-weakmap-58f4bf1ef1d04d89c78ac2e8f4c72a0473899361641cefed969be5772ae77a6e1a790a7885a8b7832b61b3083aa74d684a84e5e7cadca621408c5d9baf6024d8\" -C \"node_modules/side-channel-weakmap\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/statuses\"",
-      "tar -xzf \"flatpak-node/npm/statuses-470340f59ffb3eb2b4eab60b23314c95a17e97bde2c29ceca9120581b30b6d370b0fa70e6a8f364da59e7cf5d0bc1d9f382e008ee612127752ecdfe64c26e475\" -C \"node_modules/@turbowarp/extensions/node_modules/statuses\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/statuses-0ef132e795770c1eee927468fb888e193e5f3f5b2547cc10a2155d9278a064f32932cb5a289416870898040089137525da94e70138a18416274616501c606247\" -C \"node_modules/@turbowarp/extensions/node_modules/statuses\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/statuses\"",
-      "tar -xzf \"flatpak-node/npm/statuses-470340f59ffb3eb2b4eab60b23314c95a17e97bde2c29ceca9120581b30b6d370b0fa70e6a8f364da59e7cf5d0bc1d9f382e008ee612127752ecdfe64c26e475\" -C \"node_modules/statuses\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/statuses-0ef132e795770c1eee927468fb888e193e5f3f5b2547cc10a2155d9278a064f32932cb5a289416870898040089137525da94e70138a18416274616501c606247\" -C \"node_modules/statuses\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/strip-json-comments\"",
+      "tar -xzf \"flatpak-node/npm/strip-json-comments-e9f3dcf91e22870a8fe8dfda22fd9fd60307f25395b56407a2a0b8c8aea8483555a1cba602c7c2aa39179ea89832198cc12fe61072e9ed57a196ddea97a9448a\" -C \"node_modules/@turbowarp/extensions/node_modules/strip-json-comments\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/strip-json-comments\"",
+      "tar -xzf \"flatpak-node/npm/strip-json-comments-e9f3dcf91e22870a8fe8dfda22fd9fd60307f25395b56407a2a0b8c8aea8483555a1cba602c7c2aa39179ea89832198cc12fe61072e9ed57a196ddea97a9448a\" -C \"node_modules/strip-json-comments\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/supports-color\"",
       "tar -xzf \"flatpak-node/npm/supports-color-aa9080bd197db2db8e1ef78ab27ec79dc251befe74d6a21a70acd094effe2f0c5cf7ed2adb02f2bf80dfbedf34fc33e7da9a8e06c25d0e2a205c647df8ebf047\" -C \"node_modules/@turbowarp/extensions/node_modules/supports-color\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/terser-webpack-plugin/node_modules/supports-color\"",
@@ -10209,9 +11033,9 @@
       "mkdir -p \"node_modules/toidentifier\"",
       "tar -xzf \"flatpak-node/npm/toidentifier-a39b123ca12483f0c840d987e37574fee7ab2eba7355e764521f2d18dbda797a5fa6ec2329e9e54a8c7fd8efc14e5654b447be246eece58844cfad3c3e500744\" -C \"node_modules/toidentifier\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/type-is\"",
-      "tar -xzf \"flatpak-node/npm/type-is-4e444aafdb144f1107f0c75fb8248fed58b3272cd134c8e3d89d9da3626bdcaca6e7df0955d124b2eccf4029e514f5b8932f50fa203e99af411a6d3a5d0072f2\" -C \"node_modules/@turbowarp/extensions/node_modules/type-is\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/type-is-399b3a82c8c5e2f329df6aab09b8954a4ac5997b46fc0661637b7488032b30188067257da002ed5cef21b2b1db31717dc7a2f782b945bb05b6a00cfb71abfe1b\" -C \"node_modules/@turbowarp/extensions/node_modules/type-is\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/type-is\"",
-      "tar -xzf \"flatpak-node/npm/type-is-4e444aafdb144f1107f0c75fb8248fed58b3272cd134c8e3d89d9da3626bdcaca6e7df0955d124b2eccf4029e514f5b8932f50fa203e99af411a6d3a5d0072f2\" -C \"node_modules/type-is\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/type-is-399b3a82c8c5e2f329df6aab09b8954a4ac5997b46fc0661637b7488032b30188067257da002ed5cef21b2b1db31717dc7a2f782b945bb05b6a00cfb71abfe1b\" -C \"node_modules/type-is\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/uc.micro\"",
       "tar -xzf \"flatpak-node/npm/uc.micro-0110c99a986676f524e86970ef2f434366c590a047c101cb8b696c687e8f3e6cff29af6c14e06c065ba8ce10e5b569a7bfdbbf705e91b7cef39d14cf57eca9fc\" -C \"node_modules/@turbowarp/extensions/node_modules/uc.micro\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/uc.micro\"",
@@ -10220,14 +11044,44 @@
       "tar -xzf \"flatpak-node/npm/unpipe-a63cb66d8852b2e7f05a52b03dcfa5ddc37bfb0b8994aeaecf461d2443a54036e5ea3a3f6253e2e266fc6a0524542f0117b57c36ecdec8f36a464b00de1ced29\" -C \"node_modules/@turbowarp/extensions/node_modules/unpipe\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/unpipe\"",
       "tar -xzf \"flatpak-node/npm/unpipe-a63cb66d8852b2e7f05a52b03dcfa5ddc37bfb0b8994aeaecf461d2443a54036e5ea3a3f6253e2e266fc6a0524542f0117b57c36ecdec8f36a464b00de1ced29\" -C \"node_modules/unpipe\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/utils-merge\"",
-      "tar -xzf \"flatpak-node/npm/utils-merge-a4c653bc8913d5df93146bc33aaa1d39c971d105a49208ba4dda1af200bc7df18002acfda733d36560326dbb071e8103ff3b4cb64bff5686136324a1527f3584\" -C \"node_modules/@turbowarp/extensions/node_modules/utils-merge\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/utils-merge\"",
-      "tar -xzf \"flatpak-node/npm/utils-merge-a4c653bc8913d5df93146bc33aaa1d39c971d105a49208ba4dda1af200bc7df18002acfda733d36560326dbb071e8103ff3b4cb64bff5686136324a1527f3584\" -C \"node_modules/utils-merge\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/uri-js\"",
+      "tar -xzf \"flatpak-node/npm/uri-js-eeb294cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06\" -C \"node_modules/@turbowarp/extensions/node_modules/uri-js\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/uri-js\"",
+      "tar -xzf \"flatpak-node/npm/uri-js-eeb294cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/uri-js\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/uri-js\"",
+      "tar -xzf \"flatpak-node/npm/uri-js-eeb294cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06\" -C \"node_modules/scratch-gui/node_modules/uri-js\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/uri-js\"",
+      "tar -xzf \"flatpak-node/npm/uri-js-eeb294cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06\" -C \"node_modules/uri-js\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/vary\"",
       "tar -xzf \"flatpak-node/npm/vary-04d19b58b7ddd1e50f69b8645d4566d23f2ebaf444c93879a2f45afddca8c3f06a01b649c82fb97d4f88cd03b39802b362a6110084a8461750af778867f3d7aa\" -C \"node_modules/@turbowarp/extensions/node_modules/vary\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/vary\"",
       "tar -xzf \"flatpak-node/npm/vary-04d19b58b7ddd1e50f69b8645d4566d23f2ebaf444c93879a2f45afddca8c3f06a01b649c82fb97d4f88cd03b39802b362a6110084a8461750af778867f3d7aa\" -C \"node_modules/vary\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/which\"",
+      "tar -xzf \"flatpak-node/npm/which-04b2374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c\" -C \"node_modules/@turbowarp/extensions/node_modules/which\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/which\"",
+      "tar -xzf \"flatpak-node/npm/which-04b2374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c\" -C \"node_modules/which\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/word-wrap\"",
+      "tar -xzf \"flatpak-node/npm/word-wrap-04ddb607979a30c23d50cb63ac677983978260fa423c3532d052576d8b1a4f9cd8c6314e7244b9dd2403137a56915a16a475d56f706b61c10de13c1ae7907970\" -C \"node_modules/@turbowarp/extensions/node_modules/word-wrap\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-render/node_modules/word-wrap\"",
+      "tar -xzf \"flatpak-node/npm/word-wrap-04ddb607979a30c23d50cb63ac677983978260fa423c3532d052576d8b1a4f9cd8c6314e7244b9dd2403137a56915a16a475d56f706b61c10de13c1ae7907970\" -C \"node_modules/scratch-gui/node_modules/scratch-render/node_modules/word-wrap\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/word-wrap\"",
+      "tar -xzf \"flatpak-node/npm/word-wrap-04ddb607979a30c23d50cb63ac677983978260fa423c3532d052576d8b1a4f9cd8c6314e7244b9dd2403137a56915a16a475d56f706b61c10de13c1ae7907970\" -C \"node_modules/scratch-gui/node_modules/word-wrap\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/word-wrap\"",
+      "tar -xzf \"flatpak-node/npm/word-wrap-04ddb607979a30c23d50cb63ac677983978260fa423c3532d052576d8b1a4f9cd8c6314e7244b9dd2403137a56915a16a475d56f706b61c10de13c1ae7907970\" -C \"node_modules/word-wrap\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/wrappy\"",
+      "tar -xzf \"flatpak-node/npm/wrappy-9784a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71\" -C \"node_modules/@turbowarp/extensions/node_modules/wrappy\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/wrappy\"",
+      "tar -xzf \"flatpak-node/npm/wrappy-9784a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/wrappy\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/wrappy\"",
+      "tar -xzf \"flatpak-node/npm/wrappy-9784a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71\" -C \"node_modules/scratch-gui/node_modules/wrappy\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/wrappy\"",
+      "tar -xzf \"flatpak-node/npm/wrappy-9784a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71\" -C \"node_modules/wrappy\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/yocto-queue\"",
+      "tar -xzf \"flatpak-node/npm/yocto-queue-ad592cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9\" -C \"node_modules/@turbowarp/extensions/node_modules/yocto-queue\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/yocto-queue\"",
+      "tar -xzf \"flatpak-node/npm/yocto-queue-ad592cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9\" -C \"node_modules/scratch-gui/node_modules/yocto-queue\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/yocto-queue\"",
+      "tar -xzf \"flatpak-node/npm/yocto-queue-ad592cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9\" -C \"node_modules/yocto-queue\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/jszip\"",
       "tar -xzf \"flatpak-node/npm/jszip-d6d5974f101a7354ff8345470bd948634223ed0cadeec39121a013e0bd3f63ea6353566d5c3f6d8bff919d7cd35475e9e8033c7ccd8ede6176dbf6921153d789\" -C \"node_modules/@turbowarp/jszip\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/@turbowarp/jszip\"",
@@ -10571,9 +11425,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/@types/babel__template\"",
       "tar -xzf \"flatpak-node/npm/babel__template-87f354692c86e44cb1048a7c611c68e1131edbfa9082fca8c11c1533385884108e35b5bc3d4b20e2590532b86066151ee73dcbdcc88b0eebf227f09a3dad80f0\" -C \"node_modules/scratch-gui/node_modules/@types/babel__template\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@types/babel__traverse\"",
-      "tar -xzf \"flatpak-node/npm/babel__traverse-7643b97e14bbfbfa28b387225b1c84ca359ee3cce61bac1b0a17a8fc6d999c7c787ecdc453a602e9433cae4e7a8008cd27d3f73131f68e8e636fddbf2bac1b9e\" -C \"node_modules/@types/babel__traverse\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@types/babel__traverse\"",
-      "tar -xzf \"flatpak-node/npm/babel__traverse-7643b97e14bbfbfa28b387225b1c84ca359ee3cce61bac1b0a17a8fc6d999c7c787ecdc453a602e9433cae4e7a8008cd27d3f73131f68e8e636fddbf2bac1b9e\" -C \"node_modules/scratch-gui/node_modules/@types/babel__traverse\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/babel__traverse-f0fbdc5dfef48130d9060b7da6dc49f1e9417818dc2ce01c3ada0efe63c98ed8e2d7e09d19b1e09bbee89b51abb0fc6c884fae5c8a4d48aeb8518688c105dde1\" -C \"node_modules/@types/babel__traverse\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@types/cacheable-request\"",
       "tar -xzf \"flatpak-node/npm/cacheable-request-210dc46d3cc6c488a06f5237a8f65cd6b5899c7d019922afe506136a5130c1e16fc810cb4807b6e333f495efe1ca2ede7067d9565215020e0166a6fc581c0aab\" -C \"node_modules/@types/cacheable-request\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@types/debug\"",
@@ -10582,16 +11434,12 @@
       "tar -xzf \"flatpak-node/npm/fs-extra-9c49f007efb5bb99550ccd94238735fb947e15868a7da0334b83a87287229a3566de7430dd3bb31f950db2872b71305b8677ab6e5c878f8038f6a5db22265da4\" -C \"node_modules/@types/fs-extra\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@types/http-cache-semantics\"",
       "tar -xzf \"flatpak-node/npm/http-cache-semantics-d66d1b20555cede256caf7bd4b4467b9181c42a17f5dde50b1464065e405af5437fe9f495a841012a995cbe0cf4cda465f086021eb40a1817c252737deadbd40\" -C \"node_modules/@types/http-cache-semantics\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/@types/json-schema\"",
-      "tar -xzf \"flatpak-node/npm/json-schema-e7e7cff0ff0c14d0be0326420f1ac1da991914f1b3a90594ce949ebae54bbe6f1531ca2b3586af06aa057312bc6d0cf842c6e7e2850411e9b8c032df732b061c\" -C \"node_modules/@types/json-schema\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@types/json-schema\"",
-      "tar -xzf \"flatpak-node/npm/json-schema-e7e7cff0ff0c14d0be0326420f1ac1da991914f1b3a90594ce949ebae54bbe6f1531ca2b3586af06aa057312bc6d0cf842c6e7e2850411e9b8c032df732b061c\" -C \"node_modules/scratch-gui/node_modules/@types/json-schema\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@types/keyv\"",
       "tar -xzf \"flatpak-node/npm/keyv-050e5a64d482a63ec3e8ada4b2b4424e62912c4a673ef58388b3dfa06ca167efbc62d88af5dff70c128f260af2df9f57fcfd4f7ebbb2630be7bf0163b8488422\" -C \"node_modules/@types/keyv\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@types/ms\"",
       "tar -xzf \"flatpak-node/npm/ms-1ac0822190c4fe9de2f7abed12ac7eedd054197adcef37922b7c303c721a453852fbd3a15885d1ab3b3877a93549553c83dd43acd456c56506869e4a5d06f654\" -C \"node_modules/@types/ms\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@types/node\"",
-      "tar -xzf \"flatpak-node/npm/node-8e755ee542ca97ab628f1521bd078d6d01bff387c77e0fb231a934d9c4fc415841c7f174e6b015c421816184e1d842b3db60fa245e64b57b8dc1dc7b6fd8841b\" -C \"node_modules/@types/node\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/node-cb7b416b3fab8eca434f294d8c05f7ee3102dd311310518d24beae403c7017dffc18b2c88d6d6bbd51e5ca7cae50a32732bd51a2af233afdef928a418c2e3f54\" -C \"node_modules/@types/node\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@types/node-hid\"",
       "tar -xzf \"flatpak-node/npm/node-hid-d28a2da6c61eb4df6f8ea9034b09bf700e1f93ff7218cfcf3b45fc48b3c4fc1cd79546817a52263163329ad17d404a04cf1634a6785c44e20933408d494a8ef3\" -C \"node_modules/@types/node-hid\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/@types/node-hid\"",
@@ -10735,7 +11583,7 @@
       "mkdir -p \"node_modules/@webpack-cli/serve\"",
       "tar -xzf \"flatpak-node/npm/serve-a319c23468fcf1f2fec7357e75a717b38e07703c1fd68becdc0b84cef3fb9aa5f0edf427b6a2214350519b29e1e2a10a412492452595c974639936d9217f55d9\" -C \"node_modules/@webpack-cli/serve\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@xmldom/xmldom\"",
-      "tar -xzf \"flatpak-node/npm/xmldom-d9600b7d3978c68d9290609846deab0d315f93d475733981bd4432d7680ad8ab91288a5612171b6f3cbc1195edcff8e446a1d7f1b14473a142d478d7e1351663\" -C \"node_modules/@xmldom/xmldom\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/xmldom-710cd60ad3ba0bc4d0898975aee28d9f653a028e28e1604171b2fad72265f38c7e8f9b0e596154f57ec3a4d0fc5d91b775a0e9a52b2280c75f008976ba940147\" -C \"node_modules/@xmldom/xmldom\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@xtuc/ieee754\"",
       "tar -xzf \"flatpak-node/npm/ieee754-0d7f272a0a9c1b0b1cd1e252a98b799703f80c7e459479e6b96581472ed7d0d71a191d19b6ec9e11280cc1361512dc66b0d198faa8ade10613fcc2184ce4cf78\" -C \"node_modules/@xtuc/ieee754\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/@xtuc/ieee754\"",
@@ -10751,25 +11599,17 @@
       "mkdir -p \"node_modules/7zip-bin\"",
       "tar -xzf \"flatpak-node/npm/7zip-bin-ba44cf561a86e2337332ba36a80f4748249254937768deed95bfa17ea602b77111d325aba1e036551dfc30dace1cb43f7158fe0da20c69dd24142b565a8c21fc\" -C \"node_modules/7zip-bin\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/abbrev\"",
-      "tar -xzf \"flatpak-node/npm/abbrev-9e77bdfc8890fe1cc8858ea97439db06dcfb0e33d32ab634d0fff3bcf4a6e69385925eb1b86ac69d79ff56d4cd35f36d01f67dff546d7a192ccd4f6a7138a2d1\" -C \"node_modules/abbrev\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/abbrev-00ed9a73aa63441dd2266189a3ebf9fda2ba3a6820a7a7ec2ebb3ac0df5b777e6e96ee1c0b068053dfbb6615e37aa1d591a1d384bbb31f49d9af462908387282\" -C \"node_modules/abbrev\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/acorn\"",
       "tar -xzf \"flatpak-node/npm/acorn-9d0ca9d28d7f98d75b4ced4f3ba9079304ab9a0674313fe3082a4d8b06d48c6a11378765061a89b6842e0a710e2b3813570834656882a10cba4b131e6d0561f0\" -C \"node_modules/acorn\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/falafel/node_modules/acorn\"",
       "tar -xzf \"flatpak-node/npm/acorn-9d0ca9d28d7f98d75b4ced4f3ba9079304ab9a0674313fe3082a4d8b06d48c6a11378765061a89b6842e0a710e2b3813570834656882a10cba4b131e6d0561f0\" -C \"node_modules/scratch-gui/node_modules/falafel/node_modules/acorn\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/agent-base\"",
-      "tar -xzf \"flatpak-node/npm/agent-base-8d1479c1dca5abc0a439eea17a2d7d186667c4ceab046c05977060d1822d1838a6be31ad02f7599383eee82978bb8220b30b386b57ddd55ab77b3ae19f82a617\" -C \"node_modules/agent-base\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/agentkeepalive\"",
-      "tar -xzf \"flatpak-node/npm/agentkeepalive-9236bc8fb3e39a770e36a693b01f1f43ec04da6494d8327d0f85caa09e4f15621d44c6ba48b48dd5f7f898eaf88c26df452b3147891e222c92254d0df53e6121\" -C \"node_modules/agentkeepalive\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/agent-base-32703e613f1fc1f24f801c779bad0c36a6a49b7d173a4c88a07d72ea1b9342f0b43f0646ee48bc35a70b05cacf6cda28f2f119cbb269ba4efe8cc3be094a2f4d\" -C \"node_modules/agent-base\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/aggregate-error\"",
       "tar -xzf \"flatpak-node/npm/aggregate-error-e08ed3774d6ab96fd1a6871f35ac85745564d6a4aea21d04ec9adb449d7a9c7d351e128543cf0836af5277e9ddef6cea4724a5afd0660c0f3194427abc932b60\" -C \"node_modules/aggregate-error\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/aggregate-error\"",
       "tar -xzf \"flatpak-node/npm/aggregate-error-e08ed3774d6ab96fd1a6871f35ac85745564d6a4aea21d04ec9adb449d7a9c7d351e128543cf0836af5277e9ddef6cea4724a5afd0660c0f3194427abc932b60\" -C \"node_modules/scratch-gui/node_modules/aggregate-error\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/ajv\"",
-      "tar -xzf \"flatpak-node/npm/ajv-8f77d52e0bd3a39dbb6a7c98c893864d825b1bebe79d062f1349b99a691cd532be9f1029a6408b3082f4699e1d6e55423681928619be933138654ca4068320e2\" -C \"node_modules/ajv\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/ajv\"",
-      "tar -xzf \"flatpak-node/npm/ajv-8f77d52e0bd3a39dbb6a7c98c893864d825b1bebe79d062f1349b99a691cd532be9f1029a6408b3082f4699e1d6e55423681928619be933138654ca4068320e2\" -C \"node_modules/scratch-gui/node_modules/ajv\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/ajv\"",
-      "tar -xzf \"flatpak-node/npm/ajv-8f77d52e0bd3a39dbb6a7c98c893864d825b1bebe79d062f1349b99a691cd532be9f1029a6408b3082f4699e1d6e55423681928619be933138654ca4068320e2\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/ajv\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/ajv-errors\"",
       "tar -xzf \"flatpak-node/npm/ajv-errors-0c245f3bfe2743ef3da7f44ae378bc133778d44a9d18853895dee7185f0e435e2873fc1ee6b127b4b0946bbfa3ae7de79fcdc1a2c7f0640d306f8a689f6a3c89\" -C \"node_modules/ajv-errors\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/ajv-errors\"",
@@ -10793,7 +11633,21 @@
       "mkdir -p \"node_modules/app-builder-bin\"",
       "tar -xzf \"flatpak-node/npm/app-builder-bin-8fcee8d23e8ba8f2f7411afcca277a73e4ede600bbc4d7d8a3ab90210928ac00ba32979ac95319ac40f32a6249fc796fec49ce4296919b9de4ea4b43619c81eb\" -C \"node_modules/app-builder-bin\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/app-builder-lib\"",
-      "tar -xzf \"flatpak-node/npm/app-builder-lib-fbf0843c7d5f54a7fa1e8c0152ce8b70022845c8deaa0bc07a8484f9c97b63b2e777243d56218f6226cd93bc2684c1f33601c8b886f0e275800cf3bee268e05b\" -C \"node_modules/app-builder-lib\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/app-builder-lib-7715841888134cf0fc3a260df17ea7dcf577d7e0c5c2f3fda725c2143b15e5fcadea0fb44cc654557ac246b48f8f4f97fe98413da779b0d3cb2ef0510d50cf69\" -C \"node_modules/app-builder-lib\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/app-builder-lib/node_modules/@electron/fuses\"",
+      "tar -xzf \"flatpak-node/npm/fuses-cf1d0422aefc5a563f9416f5b97973899983648e2e6dc09720c278b868d7cd95b49d2d7d4e348f7973c08f3cd398a425254666d126e66613ca3fbb6e4354ac13\" -C \"node_modules/app-builder-lib/node_modules/@electron/fuses\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/app-builder-lib/node_modules/isexe\"",
+      "tar -xzf \"flatpak-node/npm/isexe-2e907fe7807eff627986a43b8a66477dd537d4e96042ac7b6627159649bd93383dff0f0628b11c15f265fedec30840ee78ec81003eb3082c133ba173b3436811\" -C \"node_modules/app-builder-lib/node_modules/isexe\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/node-gyp/node_modules/isexe\"",
+      "tar -xzf \"flatpak-node/npm/isexe-2e907fe7807eff627986a43b8a66477dd537d4e96042ac7b6627159649bd93383dff0f0628b11c15f265fedec30840ee78ec81003eb3082c133ba173b3436811\" -C \"node_modules/node-gyp/node_modules/isexe\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/app-builder-lib/node_modules/semver\"",
+      "tar -xzf \"flatpak-node/npm/semver-445d05c3eacee4031ff4c0326915c8e005745258f994c1ea571c5d4a08956e2c52097a049a65ff8e4d02b89c38fb74aaae860ef55a1487e1dcb898afbed25e98\" -C \"node_modules/app-builder-lib/node_modules/semver\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@npmcli/fs/node_modules/semver\"",
+      "tar -xzf \"flatpak-node/npm/semver-445d05c3eacee4031ff4c0326915c8e005745258f994c1ea571c5d4a08956e2c52097a049a65ff8e4d02b89c38fb74aaae860ef55a1487e1dcb898afbed25e98\" -C \"node_modules/scratch-gui/node_modules/@npmcli/fs/node_modules/semver\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/app-builder-lib/node_modules/which\"",
+      "tar -xzf \"flatpak-node/npm/which-244746cc7c3092b6d6a063a5207a90e60b69aca18e7a7a431e9c44f73551d5b59b3ad611c8f3c731ef4568feb1eb50a635a4d385291bd03009b5ee630fe0e6cd\" -C \"node_modules/app-builder-lib/node_modules/which\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/node-gyp/node_modules/which\"",
+      "tar -xzf \"flatpak-node/npm/which-244746cc7c3092b6d6a063a5207a90e60b69aca18e7a7a431e9c44f73551d5b59b3ad611c8f3c731ef4568feb1eb50a635a4d385291bd03009b5ee630fe0e6cd\" -C \"node_modules/node-gyp/node_modules/which\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/archive-type\"",
       "tar -xzf \"flatpak-node/npm/archive-type-cd5e0acb4bf517c741add6049704ef421c1e4343fb2b07356a5baa26c62d3813f4d635dc582c96d8811f235622aac1be232ed947ea392c5d4df8f184081c4758\" -C \"node_modules/archive-type\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/archive-type\"",
@@ -10958,8 +11812,6 @@
       "tar -xzf \"flatpak-node/npm/assign-symbols-43e242ed686ef078664dd06987f4eae7d22846da32e8a026e73ccfbf4d1676e8d7f3695b00bf0aed65639deeef742b0099b17801868338fc8ede4d2497ca88af\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/assign-symbols\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/astral-regex\"",
       "tar -xzf \"flatpak-node/npm/astral-regex-67bb4cc35cad4d7b798ea31c38ff8e42d794d55b8d2bd634daeb89b4a4354afebd8d740a2a0e5c89b2f0189a30f32cd93fe780735f0498b18f6a5d1ba77eabbd\" -C \"node_modules/astral-regex\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/async\"",
-      "tar -xzf \"flatpak-node/npm/async-86d0940e5c72c822cc81a337c578340b42d6db1a9fb90ea9d39a42108b17bb243e6b592860a4ee04ccd13709b26df2e0bc90cc774af52d39f8f84d138ba0b600\" -C \"node_modules/async\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/async-each\"",
       "tar -xzf \"flatpak-node/npm/async-each-73ae3a8c7d5abf1afe695a6775531e01f630ef001aea276e7eb94ddcb3c0e0f98a4b44041a9e8f202f67c33d1642492f04600c1248b7a4576dc5a177f49f6fbe\" -C \"node_modules/async-each\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/async-each\"",
@@ -10968,8 +11820,6 @@
       "tar -xzf \"flatpak-node/npm/async-each-73ae3a8c7d5abf1afe695a6775531e01f630ef001aea276e7eb94ddcb3c0e0f98a4b44041a9e8f202f67c33d1642492f04600c1248b7a4576dc5a177f49f6fbe\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/async-each\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/async-exit-hook\"",
       "tar -xzf \"flatpak-node/npm/async-exit-hook-356d9c5fc9b543b28f03b6b933650b41e676c11e6a2393c06f0e4bd1438cc5d8a8564f4f319d21d539b264490f62b0af6230e51480aeb0ebb576510a00079707\" -C \"node_modules/async-exit-hook\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/async-limiter\"",
-      "tar -xzf \"flatpak-node/npm/async-limiter-9f21c5cef55a47ee267c773dd3f56a39442396793dfa2a03c507ea0eea8a9e6de6f6c213ee3a15296f1d93179a2a96a6309dcc603ef7b7a33c3cc2845a540449\" -C \"node_modules/async-limiter\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/asynckit\"",
       "tar -xzf \"flatpak-node/npm/asynckit-39e8bd387e2d461d18a94dc6c615fbf5d33f9b0560bdb64969235a464f9bb21923d12e5c7c772061a92b7818eb1f06ad5ca6f3f88a087582f1aca8a6d8c8d6d1\" -C \"node_modules/asynckit\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/asynckit\"",
@@ -11042,6 +11892,8 @@
       "tar -xzf \"flatpak-node/npm/source-map-52381aa6e99695b3219018334fb624739617513e3a17488abbc4865ead1b7303f9773fe1d0f963e9e9c9aa3cf565bab697959aa989eb55bc16396332177178ee\" -C \"node_modules/terser-webpack-plugin/node_modules/source-map\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/webpack-sources/node_modules/source-map\"",
       "tar -xzf \"flatpak-node/npm/source-map-52381aa6e99695b3219018334fb624739617513e3a17488abbc4865ead1b7303f9773fe1d0f963e9e9c9aa3cf565bab697959aa989eb55bc16396332177178ee\" -C \"node_modules/webpack-sources/node_modules/source-map\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/available-typed-arrays\"",
+      "tar -xzf \"flatpak-node/npm/available-typed-arrays-c2f52306d48637bfbb4a3369abff4cd93837e745190f7abad881592db4404756d23250a8d5969e5be049f83d3dd1ee2120864b05c4c359ee0c8788ef5036a3cd\" -C \"node_modules/available-typed-arrays\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/aws-sign2\"",
       "tar -xzf \"flatpak-node/npm/aws-sign2-d3c91c1aa9d87ff6268e84617f1caef822f106352d1cb5cb5d7fef51fc7d9762d8cc6ddcd66eb59eba72154648eb3792f8b8bfc1630c89d0fd2a0aeab46ab798\" -C \"node_modules/aws-sign2\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/aws-sign2\"",
@@ -11105,11 +11957,11 @@
       "mkdir -p \"node_modules/babel-loader\"",
       "tar -xzf \"flatpak-node/npm/babel-loader-9d7cd10a15fe6751a813ac966af05083a8c3b25c851774838e5da96800eea10b505b5d09a92849b7ad91e9e250e66fe98c91434fcc602885923fce4e63c79778\" -C \"node_modules/babel-loader\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/babel-plugin-polyfill-corejs2\"",
-      "tar -xzf \"flatpak-node/npm/babel-plugin-polyfill-corejs2-dec5ff78e9acf24777ab6299e8302128f7347609b9db91aaab936d58a67b41861912fe7b390e782ad6e5cc9cc7d65405fde4313bc2a358620af483d424dbace6\" -C \"node_modules/babel-plugin-polyfill-corejs2\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/babel-plugin-polyfill-corejs2-0a8d98f705fce78b6ce94f200003d77e7d06980c9cb47b8af27d1885f8ddeaddf483bcaf2a3b29bef3a8f721becf9d8f65180512bb7b29ada96275c28cb284a6\" -C \"node_modules/babel-plugin-polyfill-corejs2\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/babel-plugin-polyfill-corejs3\"",
-      "tar -xzf \"flatpak-node/npm/babel-plugin-polyfill-corejs3-c860aabc14f8af031cce8dbcc641ff9e8c49e8c6789c97e45587680da0bfbad2ed5ab5f1bf6ec756bcc07926ea47c4b10eca78ea7d18178ec46c7a22c72eab5d\" -C \"node_modules/babel-plugin-polyfill-corejs3\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/babel-plugin-polyfill-corejs3-53e18dc0c752160cd599f84d9bc189517f3c01a741deea3d2a926a4b715aa8d20f2a0c92baf31bf9b1cfb0e9a6b96c8872ea998ffa73b75454214667b38cb6f8\" -C \"node_modules/babel-plugin-polyfill-corejs3\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/babel-plugin-polyfill-regenerator\"",
-      "tar -xzf \"flatpak-node/npm/babel-plugin-polyfill-regenerator-ee00f7a5169d3eb6e38632f2c5e6e6c7f5ab15872e4a36745db754ba340c67f7dc13da1e7b093653fecf0af7b3f3851eb8ade84a398f6740a1d1d96ea50bc6cf\" -C \"node_modules/babel-plugin-polyfill-regenerator\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/babel-plugin-polyfill-regenerator-212a90d9fadb88d53dbc8264ce0edd94fa739cf6788ce894435b92981d1f1077a8c2d37708e611b17affc5ec67eb8369535dcfd3a8dcfcbe538222573a0adb12\" -C \"node_modules/babel-plugin-polyfill-regenerator\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/babel-plugin-react-intl\"",
       "tar -xzf \"flatpak-node/npm/babel-plugin-react-intl-d639442424a62da24ce2d8c82a9bbae1467cdf708e0879b047bedb1490cec9efb39707fcd2e4756fca78d65e2d0a5c7542cadf23ea95eb0ff90223d842068c51\" -C \"node_modules/babel-plugin-react-intl\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/babel-plugin-react-intl\"",
@@ -11220,10 +12072,6 @@
       "tar -xzf \"flatpak-node/npm/bowser-f4874c9a3d8a8e2811abaa16866c2fd56dfaa43b80e124d067caba60ef6e9bec74ef18183420f73a8bbe58fff72f51cdcfb8aacad8467addffa78c2f73c000c1\" -C \"node_modules/bowser\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/bowser\"",
       "tar -xzf \"flatpak-node/npm/bowser-f4874c9a3d8a8e2811abaa16866c2fd56dfaa43b80e124d067caba60ef6e9bec74ef18183420f73a8bbe58fff72f51cdcfb8aacad8467addffa78c2f73c000c1\" -C \"node_modules/scratch-gui/node_modules/bowser\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/brace-expansion\"",
-      "tar -xzf \"flatpak-node/npm/brace-expansion-f53f548d6debd145b973543b193c25969b57c21bd8984cc587331f67d1fb1505adfae65e3e364f8c13ff5b5644c99d6dc065a89b9ff9e9317894f72a8e70c772\" -C \"node_modules/brace-expansion\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/brace-expansion\"",
-      "tar -xzf \"flatpak-node/npm/brace-expansion-f53f548d6debd145b973543b193c25969b57c21bd8984cc587331f67d1fb1505adfae65e3e364f8c13ff5b5644c99d6dc065a89b9ff9e9317894f72a8e70c772\" -C \"node_modules/scratch-gui/node_modules/brace-expansion\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/braces\"",
       "tar -xzf \"flatpak-node/npm/braces-c906d780efce499543d88b222e5ae8fbb1dfe90d7c109aca484b1da0ccca78f29772dde0bc3f282dc390748cc6ba9af9163f840def203bf9717350737cca71bc\" -C \"node_modules/braces\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/braces\"",
@@ -11281,9 +12129,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/browserify-zlib\"",
       "tar -xzf \"flatpak-node/npm/browserify-zlib-67de36472b075e626b86a93cf0598a055abfbf9b6a992903cfba79e06fcc1b28cc9c21459c2efd5d635b83e56d6bc5ba59bdaab526534b1206909ad1a4214488\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/browserify-zlib\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/browserslist\"",
-      "tar -xzf \"flatpak-node/npm/browserslist-3c9f2060a792e5eff0847061f31af060af9d02f123ec95edcfab93b9c9cc441f0e8864ec29c7057a4a11ae36a33c11d5f28398fb6b48e2ec5e71e4a298ac0c14\" -C \"node_modules/browserslist\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/browserslist\"",
-      "tar -xzf \"flatpak-node/npm/browserslist-3c9f2060a792e5eff0847061f31af060af9d02f123ec95edcfab93b9c9cc441f0e8864ec29c7057a4a11ae36a33c11d5f28398fb6b48e2ec5e71e4a298ac0c14\" -C \"node_modules/scratch-gui/node_modules/browserslist\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/browserslist-d2c8b64892b7a281b321ac11bbad5974f08ed489dc6704bc233b97ef7b0f66c5d6e8443fc3f0c07cfc8a23c9751134c2af6327bea5a2b6694253181dba5e398c\" -C \"node_modules/browserslist\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/btoa\"",
       "tar -xzf \"flatpak-node/npm/btoa-481e3f3081a5b2256431c1e64fea529883e8343a0783eedc3339addd4c6deb6f0c4f3db8f3b0ca4aa2bf7ee84506b92eaab62fe540849c00a917875314d29cfe\" -C \"node_modules/btoa\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/btoa\"",
@@ -11327,9 +12173,9 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/buffer-xor\"",
       "tar -xzf \"flatpak-node/npm/buffer-xor-e7bd6cd13ee76562babc1ebb1c8e5dc9417bc1788d71f68f3cf4e5eb3602340a4036322f6094e0ee196e77ff9c269740852edd573a8c2e67e17c7477ac070e8d\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/buffer-xor\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/builder-util\"",
-      "tar -xzf \"flatpak-node/npm/builder-util-c4d8d77ec95d5047b5e778750eb683d17bc33a9a864742f978a164751781ede156e47ab2b036457e5cb8adc91d6bacbd745dfd377a643e539b95c7c7286c3eb8\" -C \"node_modules/builder-util\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/builder-util-0535219a9902b8400052673c1099093a0edf306b0349244c3e7d504e9a14a58a46a774a3c89575f0b9423d3bb7f9405fb90ff9b9aecaa832ebb0af4d0173bb7e\" -C \"node_modules/builder-util\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/builder-util-runtime\"",
-      "tar -xzf \"flatpak-node/npm/builder-util-runtime-dbf7a0acd0c39d16b15702b703e709aba50e96a39d79d180ec93ea09e263376663935fd007fe90522ddbef5e12708192ec769f1574f2cc910eaf96f8e08de4bd\" -C \"node_modules/builder-util-runtime\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/builder-util-runtime-eea991307f17fc8cc333ed53cac28d168e5c35605b7da71d2d7e04aa4b84e5a8914c408095888a1d2a8473a71cddce0bae6a60934bad6f138f923d2261a58059\" -C \"node_modules/builder-util-runtime\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/builtin-status-codes\"",
       "tar -xzf \"flatpak-node/npm/builtin-status-codes-1e9185c35f038055a59dc0df8d36b6adc4385bcf0ed660bc7bcc99d80bd06392836a4b524f0a3e2917fa9c72ba1512391724726ffe53ebe4d2c5f3fb4321ac99\" -C \"node_modules/builtin-status-codes\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/builtin-status-codes\"",
@@ -11390,12 +12236,8 @@
       "tar -xzf \"flatpak-node/npm/caller-path-3022f7b1fea70925cec024f3bcf2a1375f1353b0074ef76d6a6f0302883172b27c4637db6e0ecb82783ae07f48cbebd457a54614294dfd3cb106401e6cb451e0\" -C \"node_modules/caller-path\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/caller-path\"",
       "tar -xzf \"flatpak-node/npm/caller-path-3022f7b1fea70925cec024f3bcf2a1375f1353b0074ef76d6a6f0302883172b27c4637db6e0ecb82783ae07f48cbebd457a54614294dfd3cb106401e6cb451e0\" -C \"node_modules/scratch-gui/node_modules/caller-path\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/callsites\"",
-      "tar -xzf \"flatpak-node/npm/callsites-3fc06302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69\" -C \"node_modules/callsites\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/caniuse-lite\"",
-      "tar -xzf \"flatpak-node/npm/caniuse-lite-0c240704166d88ae89564006c3b76bbc030ad10d0f383ff166f1260e9e9b6a230c3fa4175e4f47a43ea63580595a138f1ba2ef2036fcd884eab568e10dc90708\" -C \"node_modules/caniuse-lite\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/caniuse-lite\"",
-      "tar -xzf \"flatpak-node/npm/caniuse-lite-0c240704166d88ae89564006c3b76bbc030ad10d0f383ff166f1260e9e9b6a230c3fa4175e4f47a43ea63580595a138f1ba2ef2036fcd884eab568e10dc90708\" -C \"node_modules/scratch-gui/node_modules/caniuse-lite\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/caniuse-lite-ba113561ee6f82a8eee8e23bd474d0a9c04266bbc7ba09343232da93b43e1dfa01828ab9062fb9627c233f87e30e0aed62bfe5f0c55106fcf3f5d3c3e0ac8ad0\" -C \"node_modules/caniuse-lite\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/canvas-toBlob\"",
       "tar -xzf \"flatpak-node/npm/canvas-toBlob-a14e5b6b0ca0b7f35e7fd17e0b8f5e4c59b35f3cfac8a746aa7e89d709ff2d9405e6e9679d9566d0a219ce293ce48ead8c26d9147e9a6b8ee3e1b536b641f147\" -C \"node_modules/canvas-toBlob\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/canvas-toBlob\"",
@@ -11417,7 +12259,7 @@
       "mkdir -p \"node_modules/chromium-pickle-js\"",
       "tar -xzf \"flatpak-node/npm/chromium-pickle-js-d51e45868fa306ad030f276dfbfbc75a3e4a24d24229d01128e0b06547a7f3823906b796a0ba912c0347d54f3b789cb5b620123ed3271aa249ab466c2e844f3b\" -C \"node_modules/chromium-pickle-js\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/ci-info\"",
-      "tar -xzf \"flatpak-node/npm/ci-info-348c45e7986fe274aa42cc2401e88e8b5afcdf1cbc26574e1434d68ae839e4a06ef499db96771dd94e958879988077f4d533d94bbecd24184130a7568fd1d031\" -C \"node_modules/ci-info\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/ci-info-59dcb6220bbc39c069236a5978f679a168cf0b7f2d983571e562945cac252d8900d28ce8f39b0bb0bbe405b067fec65a482305386649d787ef5bdb79fddee474\" -C \"node_modules/ci-info\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/cipher-base\"",
       "tar -xzf \"flatpak-node/npm/cipher-base-dc493d1f75faa63e5381e9d762d35675a0689f5b6060269e6ddf973e0d247b28c46c47e40f82a4980c6443f8b5bd8bf175c4f99ec70b05fabd5494660817054b\" -C \"node_modules/cipher-base\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/cipher-base\"",
@@ -11492,14 +12334,6 @@
       "tar -xzf \"flatpak-node/npm/concat-stream-dbb1c18212718e266d224dd872f9ffe246c993fd6e66e2457ee3c49ece8b684be9bc6d5fd214de6bc96296ba2eca8f6655cd8659d70467c38ba0699200396b0b\" -C \"node_modules/scratch-gui/node_modules/concat-stream\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/concat-stream\"",
       "tar -xzf \"flatpak-node/npm/concat-stream-dbb1c18212718e266d224dd872f9ffe246c993fd6e66e2457ee3c49ece8b684be9bc6d5fd214de6bc96296ba2eca8f6655cd8659d70467c38ba0699200396b0b\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/concat-stream\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/config-file-ts\"",
-      "tar -xzf \"flatpak-node/npm/config-file-ts-1ad34409b548f366d3e1188323305256e4caa121ee7e753b09eeffe366e459925914b8e60c5d9606956cbd19212827ca0674c16f7a99ac1c0fa45054fcccaf86\" -C \"node_modules/config-file-ts\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/config-file-ts/node_modules/glob\"",
-      "tar -xzf \"flatpak-node/npm/glob-ec1bfc445d24eb18e8edde00fcfc582db5027dbe9cf95a5ddbf981db244395ec3b25be611178820fd89b7ceef0a64f22e2c7af2ba0c59f2f61ec461b337fec1e\" -C \"node_modules/config-file-ts/node_modules/glob\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/config-file-ts/node_modules/minipass\"",
-      "tar -xzf \"flatpak-node/npm/minipass-a8e3b34b57014d6605e011fc7d578f0c138ef62a6d327194119c0d73f70c5a74d5da754b67b56835610f1e461ccd9034a5da00edd97a7bb14beb9f675fd4b66b\" -C \"node_modules/config-file-ts/node_modules/minipass\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/path-scurry/node_modules/minipass\"",
-      "tar -xzf \"flatpak-node/npm/minipass-a8e3b34b57014d6605e011fc7d578f0c138ef62a6d327194119c0d73f70c5a74d5da754b67b56835610f1e461ccd9034a5da00edd97a7bb14beb9f675fd4b66b\" -C \"node_modules/path-scurry/node_modules/minipass\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/console-browserify\"",
       "tar -xzf \"flatpak-node/npm/console-browserify-64c9183bf2e4175ed0bc23ea334831c3cc94ce28003993925921e0f75147ea8ad2eef7048f975565389d3767d0d78c8149d83ded1aa148dc0b517227779d8e4c\" -C \"node_modules/console-browserify\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/console-browserify\"",
@@ -11512,10 +12346,16 @@
       "tar -xzf \"flatpak-node/npm/constants-browserify-c45c4ec2a23347f7b593580b896128a6148232a5dcc151c81fb6a47fb6ffbf1714786ba7963de1bd969aab1c07b13827f889ddb64409812ced20359eba65890d\" -C \"node_modules/scratch-gui/node_modules/constants-browserify\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/constants-browserify\"",
       "tar -xzf \"flatpak-node/npm/constants-browserify-c45c4ec2a23347f7b593580b896128a6148232a5dcc151c81fb6a47fb6ffbf1714786ba7963de1bd969aab1c07b13827f889ddb64409812ced20359eba65890d\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/constants-browserify\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/content-disposition\"",
+      "tar -xzf \"flatpak-node/npm/content-disposition-16f7994cdb86c34e1cc6502259bce2eb34c02ff9617a16966d3b6096e261e3f13de43a8cc139a16b7299375680580f1c148847ccc654bcb7af930e51aa4fad49\" -C \"node_modules/content-disposition\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/content-disposition\"",
+      "tar -xzf \"flatpak-node/npm/content-disposition-16f7994cdb86c34e1cc6502259bce2eb34c02ff9617a16966d3b6096e261e3f13de43a8cc139a16b7299375680580f1c148847ccc654bcb7af930e51aa4fad49\" -C \"node_modules/scratch-gui/node_modules/content-disposition\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/convert-source-map\"",
       "tar -xzf \"flatpak-node/npm/convert-source-map-2afa78e7d1eb576144275080b22d4abbe318de46ac1f5f53172913cf6c5698c7aae9b936354dd75ef7c9f90eb59b4c64b56c2dfb51d261fdc966c4e6b3769126\" -C \"node_modules/convert-source-map\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/convert-source-map\"",
       "tar -xzf \"flatpak-node/npm/convert-source-map-2afa78e7d1eb576144275080b22d4abbe318de46ac1f5f53172913cf6c5698c7aae9b936354dd75ef7c9f90eb59b4c64b56c2dfb51d261fdc966c4e6b3769126\" -C \"node_modules/scratch-gui/node_modules/convert-source-map\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/cookie\"",
+      "tar -xzf \"flatpak-node/npm/cookie-ca48b95e72ae7fbe74979d2e193965b7a90a20b6389d0d5e34841ab685c40726797568272aa6e7aa64eb044e41e0dee5acc24a436cad58c8933b6a34bfa130ff\" -C \"node_modules/cookie\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/copy-descriptor\"",
       "tar -xzf \"flatpak-node/npm/copy-descriptor-5e0674a4571a9045256f040454d837f90022b351724cbdd07a5f45632f294a442aa06dcf3684f46ce090b4e5dc3a4babdb5af612ada423e204fa0b2600456563\" -C \"node_modules/copy-descriptor\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/copy-descriptor\"",
@@ -11545,7 +12385,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/core-js\"",
       "tar -xzf \"flatpak-node/npm/core-js-46ccc9080c60fcf3fabb35d55cbe81b31497c7f074e68240436be42518f28eb11c355c9c6aa3a635be4e4f164f137c5ae60c1976eab36ba2fd24e09e9e1fc473\" -C \"node_modules/scratch-gui/node_modules/core-js\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/core-js-compat\"",
-      "tar -xzf \"flatpak-node/npm/core-js-compat-d8630bd99b027392d1ee1658cf80179a3430f33bb2d93fffd909edc1d9e9b9823b8ed793e8655824bec5e82d82e7b47b81262b72a556de50002de7dd6e104b0c\" -C \"node_modules/core-js-compat\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/core-js-compat-811a153016b0660d0e9f1695bf7ce9a8b2f16879acb9b106c939ea76923f08406f5f825a748d5d3121f16a04e1a6b611b5255bb90c6f8ba8946ad74fc68847a4\" -C \"node_modules/core-js-compat\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/core-util-is\"",
       "tar -xzf \"flatpak-node/npm/core-util-is-de5ab3e588d64d89d6e9d9436b94cb69309c4a17daaf57b8d2b99c255c020490ba996945ba3d1e0872049661b5839932b89fc60fef169f814509ccf88093df69\" -C \"node_modules/core-util-is\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/core-util-is\"",
@@ -11574,16 +12414,12 @@
       "tar -xzf \"flatpak-node/npm/create-hmac-3091bd962899fa881ce13cd4c2ebdb111d4945d82f505481e7e551fe0e61f367c668845631675db4a0478bbfec5617e3419e927a197286f418adc6246942292e\" -C \"node_modules/scratch-gui/node_modules/create-hmac\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/create-hmac\"",
       "tar -xzf \"flatpak-node/npm/create-hmac-3091bd962899fa881ce13cd4c2ebdb111d4945d82f505481e7e551fe0e61f367c668845631675db4a0478bbfec5617e3419e927a197286f418adc6246942292e\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/create-hmac\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/cross-dirname\"",
-      "tar -xzf \"flatpak-node/npm/cross-dirname-f91d3cfe82349e5def7cf72a7ed651a72b64b015c3cce52f781abf341571d2c529d5ac70ccf42b2a29cdc79c9de6cc4fbbc8f5c08cbc01f9d543ee5e15d85ae9\" -C \"node_modules/cross-dirname\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/cross-env\"",
-      "tar -xzf \"flatpak-node/npm/cross-env-fbf1ca77a1207100891a1d8f4a366e522b50050ca72a8af8c2b15b460e03b40812d5a58efa0539db1a47eccf52706817498980552f5b209f04cee686c34a0d03\" -C \"node_modules/cross-env\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/cross-env-1ac628b209c00994c00dc984c8972d909228a808478edb70ed1b05ad5a093576ec596a9aaba626fbb9198eaea64b8e4ed238a3eafb6245ea6929012da96cba0f\" -C \"node_modules/cross-env\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/cross-fetch\"",
       "tar -xzf \"flatpak-node/npm/cross-fetch-96f6f5481b08d19ec60f09ae89dfa6537916541c135546deed2d07e76c9a680750397ab6624b5309976501c34a17313a42d473d2c9e9c3d6cd88f78e224910bf\" -C \"node_modules/cross-fetch\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/cross-fetch\"",
       "tar -xzf \"flatpak-node/npm/cross-fetch-96f6f5481b08d19ec60f09ae89dfa6537916541c135546deed2d07e76c9a680750397ab6624b5309976501c34a17313a42d473d2c9e9c3d6cd88f78e224910bf\" -C \"node_modules/scratch-gui/node_modules/cross-fetch\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/cross-spawn\"",
-      "tar -xzf \"flatpak-node/npm/cross-spawn-b95d903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc\" -C \"node_modules/cross-spawn\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/crypto-browserify\"",
       "tar -xzf \"flatpak-node/npm/crypto-browserify-af8112c3f225bac0f5ee58108b53b6d056b7a8d9ec724475dba4dd52e06002eec60584883ef74dc8e35ddd9af1874c42c00e3eeb0fd30c0ac13ec32f86eafe29\" -C \"node_modules/crypto-browserify\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/crypto-browserify\"",
@@ -11866,10 +12702,6 @@
       "tar -xzf \"flatpak-node/npm/pify-0b716c54d1f5b9d4845f8f20197d717efc1359fb185a3e54fbcfee2b5e411b3206acaa14a60857f21599c1afce1676a406289536606f7a64c947999ccbb88f72\" -C \"node_modules/scratch-gui/node_modules/decompress/node_modules/make-dir/node_modules/pify\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/got/node_modules/pify\"",
       "tar -xzf \"flatpak-node/npm/pify-0b716c54d1f5b9d4845f8f20197d717efc1359fb185a3e54fbcfee2b5e411b3206acaa14a60857f21599c1afce1676a406289536606f7a64c947999ccbb88f72\" -C \"node_modules/scratch-gui/node_modules/got/node_modules/pify\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/deep-is\"",
-      "tar -xzf \"flatpak-node/npm/deep-is-a083f392c993838fccae289a6063bea245c34fbced9ffc37129b6fffe81221d31d2ac268d2ee027d834524fcbee1228cb82a86c36c319c0f9444c837b7c6bf6d\" -C \"node_modules/deep-is\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/deep-is\"",
-      "tar -xzf \"flatpak-node/npm/deep-is-a083f392c993838fccae289a6063bea245c34fbced9ffc37129b6fffe81221d31d2ac268d2ee027d834524fcbee1228cb82a86c36c319c0f9444c837b7c6bf6d\" -C \"node_modules/scratch-gui/node_modules/deep-is\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/defaults\"",
       "tar -xzf \"flatpak-node/npm/defaults-785b9a2e8cbf4716a5bf692bfa5a8c9549eb0d657ede3e299633882602c8848d39f0841f589eef5e1c84207bbe1ed0bbdfc9251802d8c4e2833b46d03f7b60f0\" -C \"node_modules/defaults\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/defer-to-connect\"",
@@ -11917,7 +12749,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/des.js\"",
       "tar -xzf \"flatpak-node/npm/des.js-af5ec6c638540a3491cbc6a2269afcfd469d148ccccc919ec48dcd9b3e000e2f4b612171e204c1a7cd3e35a5ff62c5d658b86967bbffbffb9b11cfdb08d7cac2\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/des.js\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/detect-libc\"",
-      "tar -xzf \"flatpak-node/npm/detect-libc-dd40eff86f42b0228ed5628c1b0f5fc2afd258961b23473963b2d4d405d8a0375b844d801d0e8de8d6f7e2c1bc163ed3e403f2f2a5c308abae207775051d2d54\" -C \"node_modules/detect-libc\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/detect-libc-06d8f604e38ef37a375b21f9f5ef0c817b3111055c6ab9143a9118aee6c1d2eaf09cdd74c90dfae2bb22072535d67665a966199b4e62fe87fb8a8e26ce2841b5\" -C \"node_modules/detect-libc\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/detect-node\"",
       "tar -xzf \"flatpak-node/npm/detect-node-4f4348b90a674ef14301336e1cde6ba0fc12046f37ac5b2e3be3175c7f7fdcdd5e15b9f8c1c3e3b6dbe330b10f589d11194620404edc1a04b7b4dc5ba8218cee\" -C \"node_modules/detect-node\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/diff\"",
@@ -11943,7 +12775,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/dir-glob\"",
       "tar -xzf \"flatpak-node/npm/dir-glob-5a4ad6a7d191e0a5df28663338b993b86562d545857f0b37efb9fd71ce79fed6fa0eeab217aa5c43901b88712c85a0e963dbfaa1a4abd9708389d1a633077320\" -C \"node_modules/scratch-gui/node_modules/dir-glob\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/dmg-builder\"",
-      "tar -xzf \"flatpak-node/npm/dmg-builder-e7d0800230214da20c08df32f640f9ef7bc39316ecd6e84372b14b1d282eb5874f706394df945ff79ef6e6c9efcc43b2e01141efe78b27c76308d3e61b01baef\" -C \"node_modules/dmg-builder\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/dmg-builder-d1e5c1eea5fd607890da8f3710c802f00e9543b05f0853fccf196152daadbeacb59c454865af176ce01c2223fc9dee7c461c0b60a5762c271f3753889971445a\" -C \"node_modules/dmg-builder\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/dmg-license\"",
       "tar -xzf \"flatpak-node/npm/dmg-license-65dce6ab02a6102396269a9e7e5a02e4e272d7e599041b1ee7e311f3ccfd83d667e1563e598524032a239a1cc97241f961b6d919c608b86024639fd8b3938cd9\" -C \"node_modules/dmg-license\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/dom-helpers\"",
@@ -12005,7 +12837,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/domutils\"",
       "tar -xzf \"flatpak-node/npm/domutils-2e07765dc27f363130fbbb45bdf2b13b3098299b1d72de6573343665a418f038f3ee97c00f719ba7cc92256b6b78823fbc394c566c706baa4799dc48620b6d0e\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/domutils\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/dotenv\"",
-      "tar -xzf \"flatpak-node/npm/dotenv-9bf0be030380afdfd6d54388654a36df67a330d9c9009b5842351b1e835304d4c94afab3cc387bbe7ade8b7a37af79bd6e57fa6680e4bdcc34566a33351149c6\" -C \"node_modules/dotenv\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/dotenv-b81ab87a05874dc4eddf76bbdafa521b4cf71e73ee225e8da98713aca120d9ace81329768695b4cea971cacab6a4af47943207c87c9a91e61a627480c1df1ba3\" -C \"node_modules/dotenv\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/dotenv-expand\"",
       "tar -xzf \"flatpak-node/npm/dotenv-expand-cc81f09993d1b21b02769303c95b2a1a68323f4c93f060205d49e4740a098acc6f7f7de4ef23ba3aea0a99c4c6b973d64ac9bc3a1f3c9d989c44b03d634ad478\" -C \"node_modules/dotenv-expand\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/download\"",
@@ -12094,24 +12926,16 @@
       "tar -xzf \"flatpak-node/npm/ecc-jsbn-7a1f4efa1c111cd6c6e012d38c49779f0d38e029069b95fa2e86827fb2cfa7b514f10aede3b258362ea73d7f318d6f7b4ca18a9b5a2e72d834412a597bdaab9f\" -C \"node_modules/ecc-jsbn\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/ecc-jsbn\"",
       "tar -xzf \"flatpak-node/npm/ecc-jsbn-7a1f4efa1c111cd6c6e012d38c49779f0d38e029069b95fa2e86827fb2cfa7b514f10aede3b258362ea73d7f318d6f7b4ca18a9b5a2e72d834412a597bdaab9f\" -C \"node_modules/scratch-gui/node_modules/ecc-jsbn\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/ecc-jsbn/node_modules/jsbn\"",
-      "tar -xzf \"flatpak-node/npm/jsbn-51553d7626ead897055b140f03a282aa3e4ee3654e980637cd051f10ac54d0aa53197c0da028e45f57b5dde1cdbf0ff13f29edea9534ad9d61b63593353497b2\" -C \"node_modules/ecc-jsbn/node_modules/jsbn\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/jsbn\"",
-      "tar -xzf \"flatpak-node/npm/jsbn-51553d7626ead897055b140f03a282aa3e4ee3654e980637cd051f10ac54d0aa53197c0da028e45f57b5dde1cdbf0ff13f29edea9534ad9d61b63593353497b2\" -C \"node_modules/scratch-gui/node_modules/jsbn\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/sshpk/node_modules/jsbn\"",
-      "tar -xzf \"flatpak-node/npm/jsbn-51553d7626ead897055b140f03a282aa3e4ee3654e980637cd051f10ac54d0aa53197c0da028e45f57b5dde1cdbf0ff13f29edea9534ad9d61b63593353497b2\" -C \"node_modules/sshpk/node_modules/jsbn\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/electron\"",
-      "tar -xzf \"flatpak-node/npm/electron-2cb38e644b96e68aaf9e30bb1c142122a8c820901908816343196d4062df102ed716c068660437bb78858fe2b3c3af178fdeeed67e7b25db7b3fdf2a2ef5226d\" -C \"node_modules/electron\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/electron-5a28f80335f84805745ff92dabe36b5aba79a624c2492f05e985a1d4a01c1be411b4dcf29ecf572ca1113faf271472307e9ae1c45d9808ddae8fb9f1f4369e27\" -C \"node_modules/electron\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/electron-builder\"",
-      "tar -xzf \"flatpak-node/npm/electron-builder-703d64cf9836b203d33051e32f17cc8d42b924006adfffc9e233ecc22f77b4e3c5cfa6edcd762d2b936b0edef5ecd45bba40940ceaebbe661539611196aa225c\" -C \"node_modules/electron-builder\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/electron-builder-76fcbdb0e0d613bbaacfb97af1ca29800b4ed842ae99d90ba82828a0d5a5edb4858ebb9b3268dfda1552ea2c12adc6fb84b1cbd363942c13cda78e5a78601ca4\" -C \"node_modules/electron-builder\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/electron-builder-squirrel-windows\"",
-      "tar -xzf \"flatpak-node/npm/electron-builder-squirrel-windows-929c1733b73f6b24546d8544ad06ec6749d0657e1a2c742b3c41bd0b887dbee2425f2970147f1aec9822d95a4a20e6f30973bb2ca1e20b0e0a762a052c53a0a8\" -C \"node_modules/electron-builder-squirrel-windows\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/electron-builder-squirrel-windows-c9ece3ecf9584f6f2ceb4353ba5df4ef5062ce90facee53c684c324d54a7d6d44db276cfc8aa706ccea8de9ac292e5db19ca250716aa3fe4abe63ba998da421a\" -C \"node_modules/electron-builder-squirrel-windows\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/electron-publish\"",
-      "tar -xzf \"flatpak-node/npm/electron-publish-6bc4111f4ac03c8587f56cb24b92db36f5bd02b93aa9eeb7fcba8307bbeed895d8a62d0699ae50eb40e1e2d993aa138142dd31b2bcc3f2a13b0be0fb8fe076e0\" -C \"node_modules/electron-publish\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/electron-publish-1b08210c83a4e6fccdb5b88c7971c421137ef613d1f1ca93392ccc89d5f8bc20bb53d18587cc21aee845840c9a23a318e589724cd993ef3e8ba4b94ef2770e5b\" -C \"node_modules/electron-publish\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/electron-to-chromium\"",
-      "tar -xzf \"flatpak-node/npm/electron-to-chromium-2f1711be760ee5ecf66cc385a5bbae56e008e5035e6359dc572b44fca5da2fa64d7f35f5c8f9403b49d23b2207c767d502e529acca8fb3f4dd561505672ed221\" -C \"node_modules/electron-to-chromium\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/electron-to-chromium\"",
-      "tar -xzf \"flatpak-node/npm/electron-to-chromium-2f1711be760ee5ecf66cc385a5bbae56e008e5035e6359dc572b44fca5da2fa64d7f35f5c8f9403b49d23b2207c767d502e529acca8fb3f4dd561505672ed221\" -C \"node_modules/scratch-gui/node_modules/electron-to-chromium\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/electron-to-chromium-ac50b144ec3b68e7b8b8f4df200c7ead7bfd704706c7e6ee005e27a6786d4ea0899392831519e1dfe2988fbadd561ea5b05b79fda3ecf88ae3f6b677dd6300ef\" -C \"node_modules/electron-to-chromium\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/electron-winstaller\"",
       "tar -xzf \"flatpak-node/npm/electron-winstaller-6cedf2d7462292e53052e0d441133829fc0d90a867a553bb20f75bb2b7a3c0df7f000049cf34d0e06787c32ccd4ab54efad107dff369db9e5adec559a590e3be\" -C \"node_modules/electron-winstaller\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/electron-winstaller/node_modules/fs-extra\"",
@@ -12137,11 +12961,7 @@
       "mkdir -p \"node_modules/encoding\"",
       "tar -xzf \"flatpak-node/npm/encoding-11305aba8c354f7e58fd664c922a3d8e2334679c631c7989e179a364eab597f757cf796bdac467f3b9c9cb6d11ba9a928751769b71c73d2a7c4a120f409ac9dc\" -C \"node_modules/encoding\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/end-of-stream\"",
-      "tar -xzf \"flatpak-node/npm/end-of-stream-faec358a720754f428695b87cd1c97776d6270cf9c9ede02cc3e6b5be342d708ce5124ceb3e4deec53afec084deef4bdc7fa08ca12cfe4f4751fea614001eee5\" -C \"node_modules/end-of-stream\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/end-of-stream\"",
-      "tar -xzf \"flatpak-node/npm/end-of-stream-faec358a720754f428695b87cd1c97776d6270cf9c9ede02cc3e6b5be342d708ce5124ceb3e4deec53afec084deef4bdc7fa08ca12cfe4f4751fea614001eee5\" -C \"node_modules/scratch-gui/node_modules/end-of-stream\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/end-of-stream\"",
-      "tar -xzf \"flatpak-node/npm/end-of-stream-faec358a720754f428695b87cd1c97776d6270cf9c9ede02cc3e6b5be342d708ce5124ceb3e4deec53afec084deef4bdc7fa08ca12cfe4f4751fea614001eee5\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/end-of-stream\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/end-of-stream-a2810673a1cfdbac57abf37e18218e4f424a08b0c6aead9b41466b43b832ac989900d27ff180d3c53a5005718c9fe59b2105cd569c96ca69bb2985480909f23a\" -C \"node_modules/end-of-stream\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/enhanced-resolve\"",
       "tar -xzf \"flatpak-node/npm/enhanced-resolve-36ff66dfa4bfbf1a6c23e1dce3f64646cd27f665ea496186ab8f73c5bfdc25f3c040c6d4b6db4902534f4b8010cda05dc3fa4ab24c396cc6de913fd8ed6fd696\" -C \"node_modules/enhanced-resolve\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/enhanced-resolve\"",
@@ -12182,8 +13002,6 @@
       "tar -xzf \"flatpak-node/npm/escalade-5948f6aa5c5a42d3b883a3eae5cdbd193716183c9df22b4bf334e58a98040b3dc97ac02288e2a8b5df0953aa2d0773c00a01bac64254c9585ba0c4be6e37bf8c\" -C \"node_modules/escalade\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/escalade\"",
       "tar -xzf \"flatpak-node/npm/escalade-5948f6aa5c5a42d3b883a3eae5cdbd193716183c9df22b4bf334e58a98040b3dc97ac02288e2a8b5df0953aa2d0773c00a01bac64254c9585ba0c4be6e37bf8c\" -C \"node_modules/scratch-gui/node_modules/escalade\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/escape-string-regexp\"",
-      "tar -xzf \"flatpak-node/npm/escape-string-regexp-4eda5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80\" -C \"node_modules/escape-string-regexp\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/escodegen\"",
       "tar -xzf \"flatpak-node/npm/escodegen-ea14e33b53405a41e70e4dcea90e18ac2bb0c261872fd4b79cf97304e506fd1e38add6b7c0b36b7ef4397e44868f284714a33b00b3ca70a1abc2f08b7b4942ed\" -C \"node_modules/escodegen\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/escodegen\"",
@@ -12198,20 +13016,6 @@
       "tar -xzf \"flatpak-node/npm/esprima-016c1530dc7084df3e3483d0cc04190a6ed190b0b845b3370753a86ccbb2a778bec3bdd7e7b28229a548c5a4596fe0d80a88eaeebb29a3e7e6b907c06e8ca116\" -C \"node_modules/esprima\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/esprima\"",
       "tar -xzf \"flatpak-node/npm/esprima-016c1530dc7084df3e3483d0cc04190a6ed190b0b845b3370753a86ccbb2a778bec3bdd7e7b28229a548c5a4596fe0d80a88eaeebb29a3e7e6b907c06e8ca116\" -C \"node_modules/scratch-gui/node_modules/esprima\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/esrecurse\"",
-      "tar -xzf \"flatpak-node/npm/esrecurse-2a67ca2f76fa1be457bcff0dd6faf74ead642ffa021609f63585c4b6a3fcfcbde929aa540381bc70555aa05dd2537db7083e17ca947f7df8a81e692d8bafd36a\" -C \"node_modules/esrecurse\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/esrecurse\"",
-      "tar -xzf \"flatpak-node/npm/esrecurse-2a67ca2f76fa1be457bcff0dd6faf74ead642ffa021609f63585c4b6a3fcfcbde929aa540381bc70555aa05dd2537db7083e17ca947f7df8a81e692d8bafd36a\" -C \"node_modules/scratch-gui/node_modules/esrecurse\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/esrecurse\"",
-      "tar -xzf \"flatpak-node/npm/esrecurse-2a67ca2f76fa1be457bcff0dd6faf74ead642ffa021609f63585c4b6a3fcfcbde929aa540381bc70555aa05dd2537db7083e17ca947f7df8a81e692d8bafd36a\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/esrecurse\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/esrecurse/node_modules/estraverse\"",
-      "tar -xzf \"flatpak-node/npm/estraverse-30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004\" -C \"node_modules/esrecurse/node_modules/estraverse\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/estraverse\"",
-      "tar -xzf \"flatpak-node/npm/estraverse-30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004\" -C \"node_modules/scratch-gui/node_modules/estraverse\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/estraverse\"",
-      "tar -xzf \"flatpak-node/npm/estraverse-30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/estraverse\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/static-eval/node_modules/estraverse\"",
-      "tar -xzf \"flatpak-node/npm/estraverse-30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004\" -C \"node_modules/static-eval/node_modules/estraverse\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/estraverse\"",
       "tar -xzf \"flatpak-node/npm/estraverse-dfd9e729f7d6cfcc4dd4153fd9cefd9fd9c1f470f3a349e2614ab1eb1caa527ca8027432c96a4e4dd6447a209c87c041bb9d79b78c29f599a055f5619fd101a7\" -C \"node_modules/estraverse\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/escodegen/node_modules/estraverse\"",
@@ -12220,10 +13024,6 @@
       "tar -xzf \"flatpak-node/npm/estraverse-dfd9e729f7d6cfcc4dd4153fd9cefd9fd9c1f470f3a349e2614ab1eb1caa527ca8027432c96a4e4dd6447a209c87c041bb9d79b78c29f599a055f5619fd101a7\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/webpack/node_modules/estraverse\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/webpack/node_modules/estraverse\"",
       "tar -xzf \"flatpak-node/npm/estraverse-dfd9e729f7d6cfcc4dd4153fd9cefd9fd9c1f470f3a349e2614ab1eb1caa527ca8027432c96a4e4dd6447a209c87c041bb9d79b78c29f599a055f5619fd101a7\" -C \"node_modules/scratch-gui/node_modules/webpack/node_modules/estraverse\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/esutils\"",
-      "tar -xzf \"flatpak-node/npm/esutils-915b1ca97938382a7af126747648042958baffc8a3df4d0a0564c9ab7d8ffdd61e5934b02b8d56c93c5a94dd5e46603967d514fcb5fd0fb1564a657d480631ea\" -C \"node_modules/esutils\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/esutils\"",
-      "tar -xzf \"flatpak-node/npm/esutils-915b1ca97938382a7af126747648042958baffc8a3df4d0a0564c9ab7d8ffdd61e5934b02b8d56c93c5a94dd5e46603967d514fcb5fd0fb1564a657d480631ea\" -C \"node_modules/scratch-gui/node_modules/esutils\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/events\"",
       "tar -xzf \"flatpak-node/npm/events-990c3ed9f9106c02f343b574318d08a9d9d734e793b4fe2bd2537dcfb0006b009782a79aedb0e28b6d0062b201ac577f1f1d0cd8e733e92d75d4268591471bd1\" -C \"node_modules/events\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/events\"",
@@ -12246,8 +13046,44 @@
       "tar -xzf \"flatpak-node/npm/expand-brackets-c3fa3338a47d39b937aa859e63f5838ba305b5af40a0c47ecee77ad267676e788c701c51b852720edd8b757ff5e00d540017aa93e524f8b0df529be818aa6964\" -C \"node_modules/scratch-gui/node_modules/expand-brackets\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/expand-brackets\"",
       "tar -xzf \"flatpak-node/npm/expand-brackets-c3fa3338a47d39b937aa859e63f5838ba305b5af40a0c47ecee77ad267676e788c701c51b852720edd8b757ff5e00d540017aa93e524f8b0df529be818aa6964\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/expand-brackets\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/expand-brackets/node_modules/debug\"",
+      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/expand-brackets/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/react-popover/node_modules/debug\"",
+      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/react-popover/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/expand-brackets/node_modules/debug\"",
+      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/scratch-gui/node_modules/expand-brackets/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/react-popover/node_modules/debug\"",
+      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/scratch-gui/node_modules/react-popover/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/expand-brackets/node_modules/debug\"",
+      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/expand-brackets/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/snapdragon/node_modules/debug\"",
+      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/snapdragon/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/snapdragon/node_modules/debug\"",
+      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/scratch-gui/node_modules/snapdragon/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/snapdragon/node_modules/debug\"",
+      "tar -xzf \"flatpak-node/npm/debug-6c2ec496b7496899cf6c03fed44a2d62fa99b1bdde725e708ba05f8ba0494d470da30a7a72fb298348d7ce74532838e6fc4ec076014155e00f54c35c286b0730\" -C \"node_modules/snapdragon/node_modules/debug\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/expand-brackets/node_modules/ms\"",
+      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/expand-brackets/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/mocha/node_modules/ms\"",
+      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/mocha/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/react-popover/node_modules/ms\"",
+      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/react-popover/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/expand-brackets/node_modules/ms\"",
+      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/scratch-gui/node_modules/expand-brackets/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/mocha/node_modules/ms\"",
+      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/scratch-gui/node_modules/mocha/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/react-popover/node_modules/ms\"",
+      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/scratch-gui/node_modules/react-popover/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/expand-brackets/node_modules/ms\"",
+      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/expand-brackets/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/snapdragon/node_modules/ms\"",
+      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/snapdragon/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/snapdragon/node_modules/ms\"",
+      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/scratch-gui/node_modules/snapdragon/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/snapdragon/node_modules/ms\"",
+      "tar -xzf \"flatpak-node/npm/ms-4e9a7ad0fe885090d3b8eabfe59f1c76c93326e8dfc2a7ce4e4af02308fb211212a679099d3e92c89e0f08f9c63281630bd75d85a979295218b40b7dee2c74e4\" -C \"node_modules/snapdragon/node_modules/ms\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/exponential-backoff\"",
-      "tar -xzf \"flatpak-node/npm/exponential-backoff-f10c584d55d492ecbb7c82288ad4243f01a89c1f05dd98fc7843bc4aa83d66ffdb908ed1240ce8c1e7b882bf351da93f7544e903667b55f420a228e33cd95464\" -C \"node_modules/exponential-backoff\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/exponential-backoff-66011e6578f7d2af88d0437e09b492a48c8f689e475500f5f19d66faed455db01e4fde26af5cf0e74ab8aba8e2882e38ecd97f61370861201fb621aa7adc1708\" -C \"node_modules/exponential-backoff\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/exports-loader\"",
       "tar -xzf \"flatpak-node/npm/exports-loader-44ac02acee00e8888a9b4a46ddcf55e3a271207703a65c301899faf8927545c56787f5921896b4c649a4e5c455b6038fcc202d4cc1a3d85ee796e87d2f4be948\" -C \"node_modules/exports-loader\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-blocks/node_modules/exports-loader\"",
@@ -12314,30 +13150,10 @@
       "tar -xzf \"flatpak-node/npm/falafel-1ee0b5a85f624e71c39cc2fd61901d0834304f4c8a97f539e4ae174945ea18003618ba1a7c581646a7406e1589c576980f8a72a15c4027cc07ebbd2332923d0d\" -C \"node_modules/falafel\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/falafel\"",
       "tar -xzf \"flatpak-node/npm/falafel-1ee0b5a85f624e71c39cc2fd61901d0834304f4c8a97f539e4ae174945ea18003618ba1a7c581646a7406e1589c576980f8a72a15c4027cc07ebbd2332923d0d\" -C \"node_modules/scratch-gui/node_modules/falafel\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/fast-deep-equal\"",
-      "tar -xzf \"flatpak-node/npm/fast-deep-equal-7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1\" -C \"node_modules/fast-deep-equal\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/fast-deep-equal\"",
-      "tar -xzf \"flatpak-node/npm/fast-deep-equal-7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1\" -C \"node_modules/scratch-gui/node_modules/fast-deep-equal\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/fast-deep-equal\"",
-      "tar -xzf \"flatpak-node/npm/fast-deep-equal-7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/fast-deep-equal\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/fast-glob\"",
       "tar -xzf \"flatpak-node/npm/fast-glob-ecca6d2fc53472a705773233c0e4c7a22957f71e41acdab27bb67f2ee0bb9023118a8d44312caa44adc1100503eec5d1ab8893e00cd356e65d8604364c2bd82e\" -C \"node_modules/fast-glob\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/fast-glob\"",
       "tar -xzf \"flatpak-node/npm/fast-glob-ecca6d2fc53472a705773233c0e4c7a22957f71e41acdab27bb67f2ee0bb9023118a8d44312caa44adc1100503eec5d1ab8893e00cd356e65d8604364c2bd82e\" -C \"node_modules/scratch-gui/node_modules/fast-glob\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/fast-json-stable-stringify\"",
-      "tar -xzf \"flatpak-node/npm/fast-json-stable-stringify-96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f\" -C \"node_modules/fast-json-stable-stringify\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/fast-json-stable-stringify\"",
-      "tar -xzf \"flatpak-node/npm/fast-json-stable-stringify-96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f\" -C \"node_modules/scratch-gui/node_modules/fast-json-stable-stringify\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-parser/node_modules/fast-json-stable-stringify\"",
-      "tar -xzf \"flatpak-node/npm/fast-json-stable-stringify-96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f\" -C \"node_modules/scratch-gui/node_modules/scratch-parser/node_modules/fast-json-stable-stringify\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/fast-json-stable-stringify\"",
-      "tar -xzf \"flatpak-node/npm/fast-json-stable-stringify-96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/fast-json-stable-stringify\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/scratch-parser/node_modules/fast-json-stable-stringify\"",
-      "tar -xzf \"flatpak-node/npm/fast-json-stable-stringify-96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/scratch-parser/node_modules/fast-json-stable-stringify\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/fast-levenshtein\"",
-      "tar -xzf \"flatpak-node/npm/fast-levenshtein-0c25eee887e1a9c92ced364a6371f1a77cbaaa9858e522599ab58c0eb29c11148e5d641d32153d220fcf62bcf2c3fba5f63388ca1d0de0cd2d6c2e61a1d83c77\" -C \"node_modules/fast-levenshtein\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/fast-levenshtein\"",
-      "tar -xzf \"flatpak-node/npm/fast-levenshtein-0c25eee887e1a9c92ced364a6371f1a77cbaaa9858e522599ab58c0eb29c11148e5d641d32153d220fcf62bcf2c3fba5f63388ca1d0de0cd2d6c2e61a1d83c77\" -C \"node_modules/scratch-gui/node_modules/fast-levenshtein\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/fastest-levenshtein\"",
       "tar -xzf \"flatpak-node/npm/fastest-levenshtein-7919c2b534ed199169402c2126250ebb13d05915d52980e7d1bd8f7877d72fafd98b9dd22c0cc01df5615562b602bc82fd61f4e6419fc611483ef4c5d125d0ce\" -C \"node_modules/fastest-levenshtein\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/fastestsmallesttextencoderdecoder\"",
@@ -12404,6 +13220,8 @@
       "tar -xzf \"flatpak-node/npm/commander-276c276fa4ca9e25cd3ada074bc4d2ac6f4839096e3ebb26c8027ca025093819affae2c10b23d8019903da316fc360c2cc85cd9c8488334d4d22faf7e5390131\" -C \"node_modules/scratch-gui/node_modules/findup/node_modules/commander\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/flat\"",
       "tar -xzf \"flatpak-node/npm/flat-6fab2e103fb9ff7ad3a5405d1b582ea4897c30f14200c034417c269632e1bc250a714bdd138816932f73a6e1827171ceb33e09f703c6356aba38aa66233cf785\" -C \"node_modules/flat\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/for-each\"",
+      "tar -xzf \"flatpak-node/npm/for-each-74ac75d9e442548cea0b1146a65c8528930fbcb11682636d52ba53889211e6ef7bcc48511bcc92aed6e83c7657c7b75a2f1415ae5eb8ddc4f36da6f6b64423c6\" -C \"node_modules/for-each\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/for-in\"",
       "tar -xzf \"flatpak-node/npm/for-in-ec4c265eb3a3c8bf82871321986e659d6f4c3edd5a21e644c0a850ce8054753574377ceec160d961525ab43bd9d8ecb33d4bdd200643b027ad937728c8c7dc9d\" -C \"node_modules/for-in\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/for-in\"",
@@ -12419,7 +13237,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/forever-agent\"",
       "tar -xzf \"flatpak-node/npm/forever-agent-8f428b60f866eb379a738973de8277a3ae6abe040270fb9b8b2a2d66b5ea11a1b884d6a03583bca9d954ad7e6fc2abfda21a9e4ff6778fafb25b4ebbc9659d53\" -C \"node_modules/scratch-gui/node_modules/forever-agent\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/form-data\"",
-      "tar -xzf \"flatpak-node/npm/form-data-aac21340f7e6bcc39201d7b267ed7623573e08a4acb40140c2efbdef3ae75806c8af9bbcc1fb04c54cc27ac54b0bc3601ee454a8d378672e943d6513446b2570\" -C \"node_modules/form-data\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/form-data-2ab1a12fd438ce38f492252de4e3b832bfc0fe3948da30d8b397870696073dc0445528a2a40be7d8aa361e73dedb4ae672ebaf30735d645a7ee089464cc1743b\" -C \"node_modules/form-data\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/format-message\"",
       "tar -xzf \"flatpak-node/npm/format-message-ea005723e30e13da6ef5035e65ff7957cec629888b09d52f862b23b6cef9c689da3c0b21b41bb6d0d4d9b7697c91b61ca0cb713721fd13d69ff9a89e2117d59b\" -C \"node_modules/format-message\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/format-message\"",
@@ -12465,7 +13283,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/fs-constants\"",
       "tar -xzf \"flatpak-node/npm/fs-constants-cba380c284887fb1728cc22ff78bbe6f9add85e6448f347adc64f26499b9aa1e018bed988302c2708fdf3c56642f93d28b13ade9934a9bec3e1dfa7f05c8b0a3\" -C \"node_modules/scratch-gui/node_modules/fs-constants\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/fs-extra\"",
-      "tar -xzf \"flatpak-node/npm/fs-extra-85c8376667a94b7d3fec1485a91be8a370ce310bbb223ab13b99c20edfb333d5d68dbdf75a0ef388d4fe42fa9bb9cdfe816a733b4d89b9b5729361b866fa3539\" -C \"node_modules/fs-extra\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/fs-extra-a115c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d\" -C \"node_modules/fs-extra\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/fs-minipass\"",
       "tar -xzf \"flatpak-node/npm/fs-minipass-57f26038b1424be47a55cab4b250ae69e58474d0b7a2e0e524c348b1a707d95b402e2bbd995e0b3eb1dce5c0e5f24e5ac3a27c8f08165a9893a39458866233be\" -C \"node_modules/fs-minipass\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/fs-minipass\"",
@@ -12534,10 +13352,6 @@
       "tar -xzf \"flatpak-node/npm/process-a0da5cbad8fe9d85f61637445bb3c696d5a15ee9409c594cd0ccbf938f0bf74840442389b6f05b41773fea2b55da30ef539c4002da273feafac2642009c6c050\" -C \"node_modules/global/node_modules/process\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/global/node_modules/process\"",
       "tar -xzf \"flatpak-node/npm/process-a0da5cbad8fe9d85f61637445bb3c696d5a15ee9409c594cd0ccbf938f0bf74840442389b6f05b41773fea2b55da30ef539c4002da273feafac2642009c6c050\" -C \"node_modules/scratch-gui/node_modules/global/node_modules/process\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/globals\"",
-      "tar -xzf \"flatpak-node/npm/globals-58e069fc410652222c252a7bc1cbffcba30efa557d5289dc5aac6e15f9bc781c3358d8327c177a1b3f8878a43d8c29b28681fdf60d793374fe41a5471638b354\" -C \"node_modules/globals\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/globals\"",
-      "tar -xzf \"flatpak-node/npm/globals-58e069fc410652222c252a7bc1cbffcba30efa557d5289dc5aac6e15f9bc781c3358d8327c177a1b3f8878a43d8c29b28681fdf60d793374fe41a5471638b354\" -C \"node_modules/scratch-gui/node_modules/globals\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/globalthis\"",
       "tar -xzf \"flatpak-node/npm/globalthis-0e92ca6cd5385b2969c49ca442e8df09cc185a257f2619b9d06a28d30ad520b02fe633abf5df87f944773e14820f6ac2084220d2e73e1be9ae053c03e782610d\" -C \"node_modules/globalthis\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/globby\"",
@@ -12722,20 +13536,12 @@
       "tar -xzf \"flatpak-node/npm/https-browserify-27e16449dc83fb4980d0dfbcd6d328b5a44c7d22fd4868bec690f74fa600a4ab1cddb1925c995f5eb8b757214e79891f2d1422b039355be8c814528179405b06\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/https-browserify\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/https-proxy-agent\"",
       "tar -xzf \"flatpak-node/npm/https-proxy-agent-bcaf4fe7f8947dd97de4023e255c94b88715b5de287efb6b3abdc736d336cb10bd6e731b11da77c74d4e8503678dbf082588b7f159531379815f071fbf2c2e4b\" -C \"node_modules/https-proxy-agent\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/hull.js\"",
-      "tar -xzf \"flatpak-node/npm/hull.js-50edd6df41f185681e4a934a09d5edd34c64c234531a68506a864d3fc965e74f4d97e0cff63b97137c111a2ce286ea29d3c152078c6d01621b5927be471128a2\" -C \"node_modules/hull.js\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/hull.js\"",
-      "tar -xzf \"flatpak-node/npm/hull.js-50edd6df41f185681e4a934a09d5edd34c64c234531a68506a864d3fc965e74f4d97e0cff63b97137c111a2ce286ea29d3c152078c6d01621b5927be471128a2\" -C \"node_modules/scratch-gui/node_modules/hull.js\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/humanize-ms\"",
-      "tar -xzf \"flatpak-node/npm/humanize-ms-165ef4bd8b6c0056ff0b4e8f4d2f5d641a3b8a16aef93bbf0cd0a4fcec8785e6b4ed2f9a78c5a914591469745af1f23e49c65b108f1d7d2c7063b83167d48055\" -C \"node_modules/humanize-ms\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/hyphenate-style-name\"",
       "tar -xzf \"flatpak-node/npm/hyphenate-style-name-5830bfba2d95551af3de33958be5ed8ea9038e25634ed15a006896dfb93a6fea21c90e7060338692f0996bcf87d27c77832befd3e0524fdc6e3a0232190d3483\" -C \"node_modules/hyphenate-style-name\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/hyphenate-style-name\"",
       "tar -xzf \"flatpak-node/npm/hyphenate-style-name-5830bfba2d95551af3de33958be5ed8ea9038e25634ed15a006896dfb93a6fea21c90e7060338692f0996bcf87d27c77832befd3e0524fdc6e3a0232190d3483\" -C \"node_modules/scratch-gui/node_modules/hyphenate-style-name\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/iconv-corefoundation\"",
       "tar -xzf \"flatpak-node/npm/iconv-corefoundation-4f5d2abe4c34cf3e309e6e7ad253848343e8bd5a945ee3858611c0922c70f3fb32732ed326deeffd1ae410a1109c0c36be23d226eea202412bc67cd1d20f0fa5\" -C \"node_modules/iconv-corefoundation\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/iconv-lite\"",
-      "tar -xzf \"flatpak-node/npm/iconv-lite-e1f0a4efdc2c84c773329dab1f4eaa5ab244e22a25a8b842507f8e8ae22053ef91074fbde0d9432fcd5ab4eec65f9e6e50ab9ea34b711cdb6f13223a0fb59d33\" -C \"node_modules/iconv-lite\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/icss-replace-symbols\"",
       "tar -xzf \"flatpak-node/npm/icss-replace-symbols-72121a637561da68764374465edb5a0c8cde88fbda55727e0b80c087fc37737ed2299fd4e8f18c9ae89c476110429f5b286f332cc0a5ec8f8fb48a0e38fa7c1a\" -C \"node_modules/icss-replace-symbols\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/icss-replace-symbols\"",
@@ -12760,10 +13566,6 @@
       "tar -xzf \"flatpak-node/npm/bl-a6f70da5ad1453af544f7e35acee80632e05540224507b995d12166eafb31e7b15711cc30e3200846bae6288b477ffdcc08c2db78a64a4ac9c5847e3755fafc3\" -C \"node_modules/scratch-gui/node_modules/bl\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/tar-stream/node_modules/bl\"",
       "tar -xzf \"flatpak-node/npm/bl-a6f70da5ad1453af544f7e35acee80632e05540224507b995d12166eafb31e7b15711cc30e3200846bae6288b477ffdcc08c2db78a64a4ac9c5847e3755fafc3\" -C \"node_modules/tar-stream/node_modules/bl\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/ignore\"",
-      "tar -xzf \"flatpak-node/npm/ignore-86c053354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa\" -C \"node_modules/ignore\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/ignore\"",
-      "tar -xzf \"flatpak-node/npm/ignore-86c053354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa\" -C \"node_modules/scratch-gui/node_modules/ignore\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/immediate\"",
       "tar -xzf \"flatpak-node/npm/immediate-5d7385b72a838cd0c043155f631b85ee0f4897f21b5a69a5420d8c60a387f04c484f5aa0eb1738cf24b71da10401382cd5bb5fcf1ab5e5c894898ee08d25d119\" -C \"node_modules/immediate\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/immediate\"",
@@ -12784,8 +13586,6 @@
       "tar -xzf \"flatpak-node/npm/import-cwd-130e4067325016aace5790535b7108a07027a227b52e88d92d729c090ff24d1c95668b0184ad71d558988c719fe690053aaf19c82859a7a9bf7d237ba49c99b6\" -C \"node_modules/import-cwd\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/import-cwd\"",
       "tar -xzf \"flatpak-node/npm/import-cwd-130e4067325016aace5790535b7108a07027a227b52e88d92d729c090ff24d1c95668b0184ad71d558988c719fe690053aaf19c82859a7a9bf7d237ba49c99b6\" -C \"node_modules/scratch-gui/node_modules/import-cwd\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/import-fresh\"",
-      "tar -xzf \"flatpak-node/npm/import-fresh-4d1dca7eb4d94d82cf07a8d48dfc7a305f56716ac72fdb2ee5339b2b866462005d58a3ce1684a8408744b93b91f36a66b711f6b29586f61e9eb707ebd692c1a9\" -C \"node_modules/import-fresh\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/import-from\"",
       "tar -xzf \"flatpak-node/npm/import-from-d2f7672cbdb04869e19519b31c9020e491e3b75976bd887327bb4d2c66de560d1fb1ee7ab6919a1f4bb31feafd4a57a3f814975c41ef04a0c49d548b2c4f7ffb\" -C \"node_modules/import-from\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/import-from\"",
@@ -12806,12 +13606,6 @@
       "tar -xzf \"flatpak-node/npm/imports-loader-91758bed2729f0a438e79d9971d55379a4026522d6f9eea725fa7773050c07aef74fb1ebf7c5e3c7924afaa97b00394952f8f5252e4ed3544b6caa2eb4de500d\" -C \"node_modules/scratch-blocks/node_modules/imports-loader\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/imports-loader\"",
       "tar -xzf \"flatpak-node/npm/imports-loader-91758bed2729f0a438e79d9971d55379a4026522d6f9eea725fa7773050c07aef74fb1ebf7c5e3c7924afaa97b00394952f8f5252e4ed3544b6caa2eb4de500d\" -C \"node_modules/scratch-gui/node_modules/imports-loader\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/imurmurhash\"",
-      "tar -xzf \"flatpak-node/npm/imurmurhash-2665cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c\" -C \"node_modules/imurmurhash\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/imurmurhash\"",
-      "tar -xzf \"flatpak-node/npm/imurmurhash-2665cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c\" -C \"node_modules/scratch-gui/node_modules/imurmurhash\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/imurmurhash\"",
-      "tar -xzf \"flatpak-node/npm/imurmurhash-2665cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/imurmurhash\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/indent-string\"",
       "tar -xzf \"flatpak-node/npm/indent-string-11d0c366ee00d8ec882bb2ebff6cc6fb0e6399bba4d435419c4c11110bc1ceca412640846d16bc1b153596085871a1890a745689b8c35e5abbefd5f5ff2e71c2\" -C \"node_modules/indent-string\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/indent-string\"",
@@ -12863,7 +13657,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/invariant\"",
       "tar -xzf \"flatpak-node/npm/invariant-a6125f41506e689339ada3a926349f9220fa0696c213836cfff2da5e5eb0198b54058f379d64ba45ff6d5e6d9ef1568aeb42448d895d6cf89ffc0d81d42da034\" -C \"node_modules/scratch-gui/node_modules/invariant\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/ip-address\"",
-      "tar -xzf \"flatpak-node/npm/ip-address-cc7b50cc6a236574f06531d0aab6be11329de129f7be08bbb819a53e85d5599a98bee2a6b48d25fd56538ea1a6258f71f3c18639a67df86f444bc842e13e17f2\" -C \"node_modules/ip-address\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/ip-address-356bfd60b5b83e85b607bc6dcda4b7342a2def99ba9caec871dbf4a3795f31c7895517d2a10c2a0f8c041f9acbc28289c14899feb7e98950619da17414ae07a0\" -C \"node_modules/ip-address\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/is-accessor-descriptor\"",
       "tar -xzf \"flatpak-node/npm/is-accessor-descriptor-60151a9cb23c6288a1c3ddb761e1544b97ecd1f1767f94d21533626000338610ec7036b7944a98bb3d690ce10fe4abd7f7823d7b2defb2a8c970b545554fb740\" -C \"node_modules/is-accessor-descriptor\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/is-accessor-descriptor\"",
@@ -12886,8 +13680,8 @@
       "tar -xzf \"flatpak-node/npm/is-buffer-35c7402f0a579139b966fbdb93ba303944af56f04a0e028fe7f7b07d71339e64057ece194666a739e2814e34558e46b7405a0de9727ef45dd44aa7c7a93694e7\" -C \"node_modules/scratch-gui/node_modules/is-buffer\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/is-buffer\"",
       "tar -xzf \"flatpak-node/npm/is-buffer-35c7402f0a579139b966fbdb93ba303944af56f04a0e028fe7f7b07d71339e64057ece194666a739e2814e34558e46b7405a0de9727ef45dd44aa7c7a93694e7\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/is-buffer\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/is-ci\"",
-      "tar -xzf \"flatpak-node/npm/is-ci-658bc282b79fc2aa10eb24f26146d0bbae07b084d9dcd7ca5f597368461d9130dc7cacf3088ff0b6145160a91d8c72855603625ca00a9bae59a35a64d9ab3f41\" -C \"node_modules/is-ci\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/is-callable\"",
+      "tar -xzf \"flatpak-node/npm/is-callable-d410b40551614bfa74aadc3a7a7a7c7bef0e0f452b2b4a052f3b528cdce170a037583b89c7100f5f33ee3ed2a48c463d514a045a55fff1f80a7aed92f22f494c\" -C \"node_modules/is-callable\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/is-core-module\"",
       "tar -xzf \"flatpak-node/npm/is-core-module-51fa1e300e9f209f304d81445237a59da188ebbbfaf8deea5c912f42e2066bdf65e31b02aee498395490d2e3c0367e1d0339bc96460f68a2ebae28cbabbc76df\" -C \"node_modules/is-core-module\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/is-core-module\"",
@@ -12954,32 +13748,18 @@
       "tar -xzf \"flatpak-node/npm/is-extendable-e413142cda1bd6f8055fa123430e62cd60f1ade7162bd00cef6aee80daf44c595d30e8b47e3e8993ecde288b74c468f87047d0209b61e30dce296389e1ff8017\" -C \"node_modules/scratch-gui/node_modules/watchpack-chokidar2/node_modules/is-extendable\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/webpack/node_modules/is-extendable\"",
       "tar -xzf \"flatpak-node/npm/is-extendable-e413142cda1bd6f8055fa123430e62cd60f1ade7162bd00cef6aee80daf44c595d30e8b47e3e8993ecde288b74c468f87047d0209b61e30dce296389e1ff8017\" -C \"node_modules/scratch-gui/node_modules/webpack/node_modules/is-extendable\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/is-extglob\"",
-      "tar -xzf \"flatpak-node/npm/is-extglob-49b29b00d90deb4dd58b88c466fe3d2de549327e321b0b1bcd9c28ac4a32122badb0dde725875b3b7eb37e1189e90103a4e6481640ed9eae494719af9778eca1\" -C \"node_modules/is-extglob\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/is-extglob\"",
-      "tar -xzf \"flatpak-node/npm/is-extglob-49b29b00d90deb4dd58b88c466fe3d2de549327e321b0b1bcd9c28ac4a32122badb0dde725875b3b7eb37e1189e90103a4e6481640ed9eae494719af9778eca1\" -C \"node_modules/scratch-gui/node_modules/is-extglob\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/is-extglob\"",
-      "tar -xzf \"flatpak-node/npm/is-extglob-49b29b00d90deb4dd58b88c466fe3d2de549327e321b0b1bcd9c28ac4a32122badb0dde725875b3b7eb37e1189e90103a4e6481640ed9eae494719af9778eca1\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/is-extglob\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/is-fullwidth-code-point\"",
       "tar -xzf \"flatpak-node/npm/is-fullwidth-code-point-cf29a6e7ebbeb02b125b20fda8d69e8d5dc316f84229c94a762cd868952e1c0f3744b8dbee74ae1a775d0871afd2193e298ec130096c59e2b851e83a115e9742\" -C \"node_modules/is-fullwidth-code-point\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/is-function\"",
       "tar -xzf \"flatpak-node/npm/is-function-970ec3529d1a597620f8204237e24a91c13443645ac999d2be76419708311c1421aade6964d572e118bb1fd1a699791dbbb2d4b61b3333e4e8af5bbfda205ca5\" -C \"node_modules/is-function\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/is-function\"",
       "tar -xzf \"flatpak-node/npm/is-function-970ec3529d1a597620f8204237e24a91c13443645ac999d2be76419708311c1421aade6964d572e118bb1fd1a699791dbbb2d4b61b3333e4e8af5bbfda205ca5\" -C \"node_modules/scratch-gui/node_modules/is-function\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/is-glob\"",
-      "tar -xzf \"flatpak-node/npm/is-glob-c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a\" -C \"node_modules/is-glob\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/is-glob\"",
-      "tar -xzf \"flatpak-node/npm/is-glob-c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a\" -C \"node_modules/scratch-gui/node_modules/is-glob\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/is-glob\"",
-      "tar -xzf \"flatpak-node/npm/is-glob-c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/is-glob\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/is-in-browser\"",
       "tar -xzf \"flatpak-node/npm/is-in-browser-15e5c80601bf08f19dfd6531b84caf8064c47f0886f59e04286c6334c46abe288821fb2682ba671cb7df103770507a8dbdad55116f75a37c414ff9bc125825f6\" -C \"node_modules/is-in-browser\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/is-in-browser\"",
       "tar -xzf \"flatpak-node/npm/is-in-browser-15e5c80601bf08f19dfd6531b84caf8064c47f0886f59e04286c6334c46abe288821fb2682ba671cb7df103770507a8dbdad55116f75a37c414ff9bc125825f6\" -C \"node_modules/scratch-gui/node_modules/is-in-browser\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/is-interactive\"",
       "tar -xzf \"flatpak-node/npm/is-interactive-d87bc810a468a92eb682e102faa063a6f46e6dd5fdd7458232e25367e23dcafa8a536ff5d9e48be78f47330b5a6dbe28ba9763dac30fe7493e5c97c1ffc244eb\" -C \"node_modules/is-interactive\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/is-lambda\"",
-      "tar -xzf \"flatpak-node/npm/is-lambda-cfb08c14636b10dab988507d06aa3ae1793a63db20f9ea6ad66c8871d1da1a76cc4d83b1bf3b04b5d62a414ca507b2f17e4be0aeb8cfdf64fa6307228a8f5421\" -C \"node_modules/is-lambda\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/is-natural-number\"",
       "tar -xzf \"flatpak-node/npm/is-natural-number-6382d36a631ed030d020802569eafd78a79b0250d257a86ecbe4d684954f973661da8e2d44fe524161652e7e4dd13a389830f6dbfa9d3aafaf7a8d5c48848b81\" -C \"node_modules/is-natural-number\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/is-natural-number\"",
@@ -13014,6 +13794,8 @@
       "tar -xzf \"flatpak-node/npm/is-stream-b903e6f2472ce3b8f1dfc6ad01c593571ca5b506283d3ebccbd69661d57ac965d2c96f26cd26add132fa0a259d65e09d1772ab02fa55b671db4efe1137eaea75\" -C \"node_modules/is-stream\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/is-stream\"",
       "tar -xzf \"flatpak-node/npm/is-stream-b903e6f2472ce3b8f1dfc6ad01c593571ca5b506283d3ebccbd69661d57ac965d2c96f26cd26add132fa0a259d65e09d1772ab02fa55b671db4efe1137eaea75\" -C \"node_modules/scratch-gui/node_modules/is-stream\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/is-typed-array\"",
+      "tar -xzf \"flatpak-node/npm/is-typed-array-a7711cb227178e2b7b49ab245c7b35840f75431813c38e85bfa10528a192e434452c3f322a7a218c5de1c688eef786ff39c319a10ba4ce93e9044f6e2d52b381\" -C \"node_modules/is-typed-array\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/is-typedarray\"",
       "tar -xzf \"flatpak-node/npm/is-typedarray-732039ea208c1c087909dce32486b86a8849c9e3b561bc0b8b725cdf9326454ea9a2ba058c8199cd4ceea468913ce8e01e0f532eee37c5ba705e4e76ddf33128\" -C \"node_modules/is-typedarray\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/is-typedarray\"",
@@ -13031,9 +13813,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/falafel/node_modules/isarray\"",
       "tar -xzf \"flatpak-node/npm/isarray-c478e10ebddc3412b40737542523d7667b50531fe6c0c4b9470e00ee53c9f745c600ee8848ffde3c336ea34be1a8e654f940f9268a1dc02000a1941ddc57802b\" -C \"node_modules/scratch-gui/node_modules/falafel/node_modules/isarray\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/isbinaryfile\"",
-      "tar -xzf \"flatpak-node/npm/isbinaryfile-60a04a5642a1b72eecf2bc5d75be34a0e92e3f435b69e5eb42f2e29fa40c1cbed8a62cb6456f4bc0e56b560651c8eae14256b231df6df83f320f2f0c2854d20d\" -C \"node_modules/isbinaryfile\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/isexe\"",
-      "tar -xzf \"flatpak-node/npm/isexe-447c4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23\" -C \"node_modules/isexe\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/isbinaryfile-23e36621f047525fabdb070377a27013dc968defcf21563f479fc2995f1d5cb65de4af8bf57da49403b07c01cd9e89dd2d791b1f24c095e4005a89e94c9053b7\" -C \"node_modules/isbinaryfile\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/isobject\"",
       "tar -xzf \"flatpak-node/npm/isobject-5a107dcc292eec41938ff1d0411cf969440451ea10647d9b59c96d444acea72989e1ba1813ac0bf536ebdb792b44f499f82e73a8d4ab4b0f8273bb196786fbbe\" -C \"node_modules/isobject\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/isobject\"",
@@ -13050,12 +13830,12 @@
       "tar -xzf \"flatpak-node/npm/isurl-d4fff25acc4f943b67ed07910fe50b2903da21a37ac85dfaf06676bc37efd002f4370a52b5a7e35820c3767d24f30805316a5502a1bba098711e796e778da2f7\" -C \"node_modules/scratch-gui/node_modules/isurl\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/jackspeak\"",
       "tar -xzf \"flatpak-node/npm/jackspeak-386959429cf6c9f6a103f45dd58f0277d48812caaf5e42d5a12c3f720c219e114c0dbb1015e658a0927b6c86414bd05c6a6516f7a6acabf9e93d6ba033e45007\" -C \"node_modules/jackspeak\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/jake\"",
-      "tar -xzf \"flatpak-node/npm/jake-d8fe124341eb2d0f9fc3a965a4b9ce68602f37666eebbefc48932b094c27b387cea06f5acab4e2664dd557cb023e455917c69bd3392c5694bc143639a5108d04\" -C \"node_modules/jake\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/jest-worker\"",
       "tar -xzf \"flatpak-node/npm/jest-worker-2966155757388be8db3296810be53efb855ad1ca7c3a2b14d7ce68ef74f5be8f7d86a8bbc3cb5225f51762cc30aaaae3cf0c5ae8aa512b9e1684fbf07f9c3a3d\" -C \"node_modules/jest-worker\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/terser-webpack-plugin/node_modules/jest-worker\"",
       "tar -xzf \"flatpak-node/npm/jest-worker-2966155757388be8db3296810be53efb855ad1ca7c3a2b14d7ce68ef74f5be8f7d86a8bbc3cb5225f51762cc30aaaae3cf0c5ae8aa512b9e1684fbf07f9c3a3d\" -C \"node_modules/scratch-gui/node_modules/terser-webpack-plugin/node_modules/jest-worker\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/jiti\"",
+      "tar -xzf \"flatpak-node/npm/jiti-b7042879c60f8950392bf87a4b1b4e470fc1b376abfa62d4b683d273b88c5f34332bc77b789fd1d3dc264f002389a9844e7d5c5d83c67cd9eeec33281e0bb5db\" -C \"node_modules/jiti\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/js-base64\"",
       "tar -xzf \"flatpak-node/npm/js-base64-c5c8a72f702e0c993b552cec1e06fd0efbc85dac816da76d319e0714fc7cad4b336d6d4cb8d325c18542e33cc267a7b5b2a6699cd4b964560e857a80dfd4fb2d\" -C \"node_modules/js-base64\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/js-base64\"",
@@ -13072,16 +13852,14 @@
       "tar -xzf \"flatpak-node/npm/js-tokens-45d2547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29\" -C \"node_modules/scratch-gui/node_modules/js-tokens\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-paint/node_modules/js-tokens\"",
       "tar -xzf \"flatpak-node/npm/js-tokens-45d2547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29\" -C \"node_modules/scratch-gui/node_modules/scratch-paint/node_modules/js-tokens\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/js-yaml\"",
-      "tar -xzf \"flatpak-node/npm/js-yaml-c29c59b3d368c596891122462194f20c4698a65d0529203e141f5a262c9e98a84cc24c5083ade1e13d4a2605061e94ea3c33517269982ee82b46326506d5af44\" -C \"node_modules/js-yaml\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/jsbn\"",
-      "tar -xzf \"flatpak-node/npm/jsbn-e1b61557768032d0d34eee3ec6c0d86bab32f46c89ebdfda9acbbdb18176cea8e2128640e71262dc1adf5f7b98fbf21e908bbb33074e6dd6c35a9a19741bf7fc\" -C \"node_modules/jsbn\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/jsbn-51553d7626ead897055b140f03a282aa3e4ee3654e980637cd051f10ac54d0aa53197c0da028e45f57b5dde1cdbf0ff13f29edea9534ad9d61b63593353497b2\" -C \"node_modules/jsbn\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/jsbn\"",
+      "tar -xzf \"flatpak-node/npm/jsbn-51553d7626ead897055b140f03a282aa3e4ee3654e980637cd051f10ac54d0aa53197c0da028e45f57b5dde1cdbf0ff13f29edea9534ad9d61b63593353497b2\" -C \"node_modules/scratch-gui/node_modules/jsbn\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/jsesc\"",
       "tar -xzf \"flatpak-node/npm/jsesc-fec33774ed853b35e3290849ba8d10d7bdf07f628ea3cb7823cbc7cba945f69a14a7b6ca4f4fcd1c4f1f3d7db73f07e19f291faa70b6c51c4e9d5c395ee18868\" -C \"node_modules/jsesc\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/jsesc\"",
       "tar -xzf \"flatpak-node/npm/jsesc-fec33774ed853b35e3290849ba8d10d7bdf07f628ea3cb7823cbc7cba945f69a14a7b6ca4f4fcd1c4f1f3d7db73f07e19f291faa70b6c51c4e9d5c395ee18868\" -C \"node_modules/scratch-gui/node_modules/jsesc\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/json-buffer\"",
-      "tar -xzf \"flatpak-node/npm/json-buffer-e1b57905f4769aa7d04c99be579b4f3dd7fe669ba1888bd3b8007983c91cad7399a534ff430c15456072c17d68cebea512e3dd6c7c70689966f46ea6236b1f49\" -C \"node_modules/json-buffer\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/json-parse-better-errors\"",
       "tar -xzf \"flatpak-node/npm/json-parse-better-errors-9abab264a7d7e4484bee1bea715e961b5c988e78deb980f30e185c00052babc3e8f3934140124ff990d44fbe6a650f7c22452806a76413192e90e53b4ecdb0af\" -C \"node_modules/json-parse-better-errors\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/json-parse-better-errors\"",
@@ -13096,12 +13874,6 @@
       "tar -xzf \"flatpak-node/npm/json-schema-7acf783379d321fb043e2b1169f6a4f870cb7c75e7281855def5397aa3dc4b77e5216a9cc495a05c75e27b2dd8ae968db1a9d8e5e8b55686046cece28eeabd04\" -C \"node_modules/json-schema\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/json-schema\"",
       "tar -xzf \"flatpak-node/npm/json-schema-7acf783379d321fb043e2b1169f6a4f870cb7c75e7281855def5397aa3dc4b77e5216a9cc495a05c75e27b2dd8ae968db1a9d8e5e8b55686046cece28eeabd04\" -C \"node_modules/scratch-gui/node_modules/json-schema\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/json-schema-traverse\"",
-      "tar -xzf \"flatpak-node/npm/json-schema-traverse-c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756\" -C \"node_modules/json-schema-traverse\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/json-schema-traverse\"",
-      "tar -xzf \"flatpak-node/npm/json-schema-traverse-c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756\" -C \"node_modules/scratch-gui/node_modules/json-schema-traverse\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/json-schema-traverse\"",
-      "tar -xzf \"flatpak-node/npm/json-schema-traverse-c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/json-schema-traverse\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/json-stringify-safe\"",
       "tar -xzf \"flatpak-node/npm/json-stringify-safe-642960e80698bda9af60413cd9ddc8c9ddef49222343ea1d823693cd1b8edeceeda0274529cce86f68b4cc287b244f245a7d7bcaf016854571bea1b051a96c44\" -C \"node_modules/json-stringify-safe\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/json-stringify-safe\"",
@@ -13111,7 +13883,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/json5\"",
       "tar -xzf \"flatpak-node/npm/json5-5e63967bb7b21d81f5e1c2dd54fa3283e18e1f7ad85fef8aa73af2949c125bdf2ddcd93e53c5ce97c15628e830b7375bf255c67facd8c035337873167f16acca\" -C \"node_modules/scratch-gui/node_modules/json5\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/jsonfile\"",
-      "tar -xzf \"flatpak-node/npm/jsonfile-e5d8277563ab8984a6e5c9d86893616a52cd0ca3aa170c8307faebd44f59b067221af28fb3c476c5818269cb9fdf3e8ad58283cf5f367ddf9f637727de932a5d\" -C \"node_modules/jsonfile\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/jsonfile-146b8fc37d0074e2144d1302d8e311b5057e8e4563d9c7cfa927965efd4d100275a99e736f55facf598585b7ce07f8b2decb09083fb72ae67cafc0b7b9516502\" -C \"node_modules/jsonfile\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/jsprim\"",
       "tar -xzf \"flatpak-node/npm/jsprim-3f66d238c01cfdc88bcfa0f38235651893fdf81ac95aee540c62bbd02da2c1e0b940121e15fd195d1bc68c48f6b9882b63632400086c4961c35a516d12ba195b\" -C \"node_modules/jsprim\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/jsprim\"",
@@ -13126,8 +13898,6 @@
       "tar -xzf \"flatpak-node/npm/keymirror-bc89190055a80e28e0413fcdbe5d801c23269de80dd9e8604cf62ecb2da15909104a7b48d12ec4498a9d2e4a127b51f21011471e40a0488bd57521225b02af0a\" -C \"node_modules/scratch-gui/node_modules/keymirror\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-paint/node_modules/keymirror\"",
       "tar -xzf \"flatpak-node/npm/keymirror-bc89190055a80e28e0413fcdbe5d801c23269de80dd9e8604cf62ecb2da15909104a7b48d12ec4498a9d2e4a127b51f21011471e40a0488bd57521225b02af0a\" -C \"node_modules/scratch-gui/node_modules/scratch-paint/node_modules/keymirror\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/keyv\"",
-      "tar -xzf \"flatpak-node/npm/keyv-a3154790747f1097f608d5e75b144b5ba9a0ec9c82094706d03b441a62f672d528d4f3538a7d4f52297eafffb8af93295600bf7e7d648ecc7b9a34ae8caa88a7\" -C \"node_modules/keyv\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/kind-of\"",
       "tar -xzf \"flatpak-node/npm/kind-of-75c4b5ba5fbdb66783f794fec76f3f7a12e077d98435adcbb2f0d3b739b7bf20443bb44fa6dbc00feb78e165576948d305172ba45785942f160abb94478e7a87\" -C \"node_modules/kind-of\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/kind-of\"",
@@ -13243,29 +14013,43 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/find-cache-dir/node_modules/make-dir\"",
       "tar -xzf \"flatpak-node/npm/make-dir-83715e3f6d0b3708402dbffa0b3e837781769e0cded23cfbb5bceb0f6c0057ea3d15e3477b8acbfb22b699dd09fdf8927f5b1ad400e15ea8b9fa857038cfde1b\" -C \"node_modules/scratch-gui/node_modules/find-cache-dir/node_modules/make-dir\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/make-fetch-happen\"",
-      "tar -xzf \"flatpak-node/npm/make-fetch-happen-36038f6d189a40cd740d85ef377fe1846548d8ce4cb484c5af2cc11b11cce69e309c5c6c5426f192b06b0ec93e119e4e0788c4393ec08c3c6d745f8a544153ef\" -C \"node_modules/make-fetch-happen\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/make-fetch-happen-40c8c66c54cfd1b963f7b11e89d1b9864fd084a4374f82027244062e0cf7f1017b5606e4e9ee854c044df0a84ac7205b5a7f11d0753e6e7c3c692a053c3e2ab5\" -C \"node_modules/make-fetch-happen\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/make-fetch-happen/node_modules/@npmcli/fs\"",
-      "tar -xzf \"flatpak-node/npm/fs-c8e24a46fa2114e68baa2a4db70601f56ba0c992a10bf0d90b85583e6a5a0b30c1ac0f18a4adea1d9f3f1c6b1c3271381aa6e42cdb957029f191e404746b7a2d\" -C \"node_modules/make-fetch-happen/node_modules/@npmcli/fs\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/make-fetch-happen/node_modules/@npmcli/move-file\"",
-      "tar -xzf \"flatpak-node/npm/move-file-9897766794e3616abfb6d3cb2c6a80addb670bbe09e9b3b3838acc0e737ea75c5369c676c8f442936cb4a12590b7280b47d61541780e70e36bc2d9e4dc9ba9c5\" -C \"node_modules/make-fetch-happen/node_modules/@npmcli/move-file\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/make-fetch-happen/node_modules/agent-base\"",
-      "tar -xzf \"flatpak-node/npm/agent-base-45937035c945efe312ffc6c383bd1a9a0df6772799199c620ee42667128b025423af78c6c8bc7ee0a924e7c50eec3d90760148402a2fb92b991129dee911ba5d\" -C \"node_modules/make-fetch-happen/node_modules/agent-base\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/socks-proxy-agent/node_modules/agent-base\"",
-      "tar -xzf \"flatpak-node/npm/agent-base-45937035c945efe312ffc6c383bd1a9a0df6772799199c620ee42667128b025423af78c6c8bc7ee0a924e7c50eec3d90760148402a2fb92b991129dee911ba5d\" -C \"node_modules/socks-proxy-agent/node_modules/agent-base\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/fs-ff11a57b323ac5f18ef4dc2e2659f0cff2b5e2a0f59024801ad69c0479c6cde008b8919acdca78e4a3f936ec80457a0a6fb730ba5006595b1b792c5d1bf71bd1\" -C \"node_modules/make-fetch-happen/node_modules/@npmcli/fs\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/make-fetch-happen/node_modules/cacache\"",
-      "tar -xzf \"flatpak-node/npm/cacache-ffe126723f43017c57e1cc252e6448f5cd7ae91b8bdf0df4ce9e11ec9a22bf67104ed4ed03e8deb820231f76651a7612ded284352aca840cd554ff46572cde61\" -C \"node_modules/make-fetch-happen/node_modules/cacache\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/make-fetch-happen/node_modules/http-proxy-agent\"",
-      "tar -xzf \"flatpak-node/npm/http-proxy-agent-9f6858f18768444d62eebe8cd30f43230e468193741b6e4ff332c2450f2b8d7b53537bec345048fef58afd421e13a839314533e9abf000f5e62fa172f43ffdd3\" -C \"node_modules/make-fetch-happen/node_modules/http-proxy-agent\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/make-fetch-happen/node_modules/https-proxy-agent\"",
-      "tar -xzf \"flatpak-node/npm/https-proxy-agent-7457008e94d0160a0b3330b657053e0bf09b4bbb912f49569b10c84e6aa6ec2fbb17439d9a3eacf65e9a95973a0042d786b9e080cd827964971c639d5f662dc0\" -C \"node_modules/make-fetch-happen/node_modules/https-proxy-agent\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/make-fetch-happen/node_modules/lru-cache\"",
-      "tar -xzf \"flatpak-node/npm/lru-cache-8ee9a573404852b4b7a891a0224599b327c033b3425a205c08386777edcd34ce4a6c198b4e01d57d605c83a5beacb52c229ce91113ecbf050fec272401048ea0\" -C \"node_modules/make-fetch-happen/node_modules/lru-cache\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/cacache-85db14c6e9570a2e524c877bf2f455604b43023abdf48080524b4b4de4d8b0ba1313a67c752d1cf2958d0b1c1dae4f587c97a86c365cd98d7cea10ffe5942015\" -C \"node_modules/make-fetch-happen/node_modules/cacache\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/make-fetch-happen/node_modules/chownr\"",
+      "tar -xzf \"flatpak-node/npm/chownr-f88c7363d05939077f5ee60f466aef1158c5fe7aa3e64813e2412aed5a1fac3a0cd4cc6846311692b082dc4b4b8b9f5355ac314c09fea2b27015072ba84375fa\" -C \"node_modules/make-fetch-happen/node_modules/chownr\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/node-gyp/node_modules/chownr\"",
+      "tar -xzf \"flatpak-node/npm/chownr-f88c7363d05939077f5ee60f466aef1158c5fe7aa3e64813e2412aed5a1fac3a0cd4cc6846311692b082dc4b4b8b9f5355ac314c09fea2b27015072ba84375fa\" -C \"node_modules/node-gyp/node_modules/chownr\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/make-fetch-happen/node_modules/fs-minipass\"",
+      "tar -xzf \"flatpak-node/npm/fs-minipass-5d4040f570a51db9c95927c1ce3926e91bcfb32837b2bc99b74e81110a17705ec42bfc6919a41826040a0c94941f948667be98ee9171d500675f3d3dad4e456f\" -C \"node_modules/make-fetch-happen/node_modules/fs-minipass\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/make-fetch-happen/node_modules/glob\"",
+      "tar -xzf \"flatpak-node/npm/glob-ec1bfc445d24eb18e8edde00fcfc582db5027dbe9cf95a5ddbf981db244395ec3b25be611178820fd89b7ceef0a64f22e2c7af2ba0c59f2f61ec461b337fec1e\" -C \"node_modules/make-fetch-happen/node_modules/glob\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/make-fetch-happen/node_modules/minipass-collect\"",
+      "tar -xzf \"flatpak-node/npm/minipass-collect-0fb57c3cef686b3ecf5862db0800ae235a843acabb50a7cba2dc7f0b401eb78ddf09407fc1f43b0d87aada847fb2f1491980c73ebdfc48701379a8ff6682872b\" -C \"node_modules/make-fetch-happen/node_modules/minipass-collect\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/make-fetch-happen/node_modules/minizlib\"",
+      "tar -xzf \"flatpak-node/npm/minizlib-299c58a350549160f64d514baf4310a0cf2f5148a0583dcb943f376bfef906a0bee2a1341dbd55a39bf516071f68d5ef7d7cebfb912143a8a783f09a0628d397\" -C \"node_modules/make-fetch-happen/node_modules/minizlib\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/minipass-fetch/node_modules/minizlib\"",
+      "tar -xzf \"flatpak-node/npm/minizlib-299c58a350549160f64d514baf4310a0cf2f5148a0583dcb943f376bfef906a0bee2a1341dbd55a39bf516071f68d5ef7d7cebfb912143a8a783f09a0628d397\" -C \"node_modules/minipass-fetch/node_modules/minizlib\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/node-gyp/node_modules/minizlib\"",
+      "tar -xzf \"flatpak-node/npm/minizlib-299c58a350549160f64d514baf4310a0cf2f5148a0583dcb943f376bfef906a0bee2a1341dbd55a39bf516071f68d5ef7d7cebfb912143a8a783f09a0628d397\" -C \"node_modules/node-gyp/node_modules/minizlib\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/make-fetch-happen/node_modules/p-map\"",
+      "tar -xzf \"flatpak-node/npm/p-map-5649dd22fd9f201f7db30bd0a00eb96e6f9fb26b7a50d746788074a3106cf9684085d874f10034e095e923badb07daf4f3f9e46f2b0aa326bdaed0c445839830\" -C \"node_modules/make-fetch-happen/node_modules/p-map\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/make-fetch-happen/node_modules/ssri\"",
-      "tar -xzf \"flatpak-node/npm/ssri-a39ed6727eba8cc42f7c71b516561b59e6565bf7476612578e921c4df5e5757124e67cf9952b4fa3798ad0e2507c647745b65495b2127b16e58e4273b848fff1\" -C \"node_modules/make-fetch-happen/node_modules/ssri\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/ssri-4bb886368b1ea71f5169d5fcda88a6524bebd02b7b22325b11bb38989713c6cb7cba6f79277b03614d510443af76eea82f559e9363832398b8300c3e759e9c01\" -C \"node_modules/make-fetch-happen/node_modules/ssri\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/make-fetch-happen/node_modules/tar\"",
+      "tar -xzf \"flatpak-node/npm/tar-9e51a9c5ffa1bf4bfb1a45812b657db2981a72d18ea74aaf7d647150c8ea1f2cebb774a0c04e3c0c8bff161a8f1c960b1e9816d68a6ade71116f3e409eaee7d6\" -C \"node_modules/make-fetch-happen/node_modules/tar\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/node-gyp/node_modules/tar\"",
+      "tar -xzf \"flatpak-node/npm/tar-9e51a9c5ffa1bf4bfb1a45812b657db2981a72d18ea74aaf7d647150c8ea1f2cebb774a0c04e3c0c8bff161a8f1c960b1e9816d68a6ade71116f3e409eaee7d6\" -C \"node_modules/node-gyp/node_modules/tar\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/make-fetch-happen/node_modules/unique-filename\"",
-      "tar -xzf \"flatpak-node/npm/unique-filename-383587b6491dc7720047ebde2b1155f9506450c70df856aacd451dec8673b7ed338436453c5c6196ac0f177610bcc1f1d530f4b5d81897e92e3e727c13aaa5ec\" -C \"node_modules/make-fetch-happen/node_modules/unique-filename\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/unique-filename-5d29c47b05e643ebde3fbc57d9d4b9438c9902f3b8d1c04dd8c5a427b0ffeac5b80e0eb060137033556b9f3d45847e4075e2c89545d123d7b6f33d58662ef535\" -C \"node_modules/make-fetch-happen/node_modules/unique-filename\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/make-fetch-happen/node_modules/unique-slug\"",
-      "tar -xzf \"flatpak-node/npm/unique-slug-f04c8cca787aefdc7fd20a84f5f4fda22946faa12dfa26c5caa8ee553b199f5f823311fe5cb969bebd94671e2755c0b04e9c7cd67202af625016433e1cf2eae3\" -C \"node_modules/make-fetch-happen/node_modules/unique-slug\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/unique-slug-f4e75aa8ee64c2a47ed645601c086ca79bcf354d219f145adbaac114d7cd80ceccea936d8337819f7b3fc5bc8240bddd723cce6ad71e7fa5141e907fe8c6844e\" -C \"node_modules/make-fetch-happen/node_modules/unique-slug\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/make-fetch-happen/node_modules/yallist\"",
+      "tar -xzf \"flatpak-node/npm/yallist-620bd44dfc2ac9ced45d532b07e4889ac5584a64d2f17fed4abb5d35930898cfa7efe413ae2457c978a6d2606b4d735eab3545d0a5868073de8b2562145acd0f\" -C \"node_modules/make-fetch-happen/node_modules/yallist\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/node-gyp/node_modules/yallist\"",
+      "tar -xzf \"flatpak-node/npm/yallist-620bd44dfc2ac9ced45d532b07e4889ac5584a64d2f17fed4abb5d35930898cfa7efe413ae2457c978a6d2606b4d735eab3545d0a5868073de8b2562145acd0f\" -C \"node_modules/node-gyp/node_modules/yallist\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/map-cache\"",
       "tar -xzf \"flatpak-node/npm/map-cache-f32fde57d4106428b29f54a9ad74ab0a6a89374c8d4404def8f3bccedc2aaefadb7512c0dde609174c9a47461ac8b5a431bb1048a592f4dda03dc18473852c66\" -C \"node_modules/map-cache\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/map-cache\"",
@@ -13344,6 +14128,14 @@
       "tar -xzf \"flatpak-node/npm/miller-rabin-d75e5f2e1bd956a5b01cf6c29729edc4455f5437e5f432cb4ee26fab78363bf3b18bc022368b801ef0d2cc74b4be250973e579be6ddeabdd57c2a9fd769e2344\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/miller-rabin\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/mime\"",
       "tar -xzf \"flatpak-node/npm/mime-5123e431e113df5ace3226abb013481d928b1a0bca73f2eb8e87c09c194eb6d7f96a346faa2440f10b1e9db728a1cb4ae9de93b3a6aa657040f976e42ad86242\" -C \"node_modules/mime\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/mime-db\"",
+      "tar -xzf \"flatpak-node/npm/mime-db-b0f538b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be\" -C \"node_modules/mime-db\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/mime-types/node_modules/mime-db\"",
+      "tar -xzf \"flatpak-node/npm/mime-db-b0f538b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be\" -C \"node_modules/scratch-gui/node_modules/mime-types/node_modules/mime-db\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/mime-types\"",
+      "tar -xzf \"flatpak-node/npm/mime-types-64363e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b\" -C \"node_modules/mime-types\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/mime-types\"",
+      "tar -xzf \"flatpak-node/npm/mime-types-64363e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b\" -C \"node_modules/scratch-gui/node_modules/mime-types\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/mimic-fn\"",
       "tar -xzf \"flatpak-node/npm/mimic-fn-3aa6ce939a0441e019f165d6c9d96ef47263cfd59574422f6a63027179aea946234e49c7fecaac5af850def830285451d47a63bcd04a437ee76c9818cc6a8672\" -C \"node_modules/mimic-fn\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/mimic-response\"",
@@ -13393,7 +14185,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/minipass-collect\"",
       "tar -xzf \"flatpak-node/npm/minipass-collect-e93ea51f41fc386f642139bf266ead768a086e8806f5ed2d2e0a58ea6a615d29bf03dbbc36ad6bc811be42ca62b9bf4b8d69413ec3d2ded590fc1a2dab815dc4\" -C \"node_modules/scratch-gui/node_modules/minipass-collect\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/minipass-fetch\"",
-      "tar -xzf \"flatpak-node/npm/minipass-fetch-2d3e3d662dbf58c44e1d8a2a1a0765408661f262cf6663ab37635d263317c587b89e437a154cae3ee38039e74d243af1d0844683dfb882e65ec2da7c844e93c4\" -C \"node_modules/minipass-fetch\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/minipass-fetch-8fb535d42e475e2815baeb7179b15a7686016dded549d65682049eeb835576f58d06a1808973cbd905427a18e6c3b958d6817d80e96561b39187e8623607cf81\" -C \"node_modules/minipass-fetch\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/minipass-flush\"",
       "tar -xzf \"flatpak-node/npm/minipass-flush-266412618a4f52a5f92729f5997691c0e75ad6e43c1cfe4a013fe80d22c2cedd41611850534fe10edb01d6e7d97c4133319f5a0159ac070f3e156b085e50a55b\" -C \"node_modules/minipass-flush\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/minipass-flush\"",
@@ -13477,9 +14269,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/multipipe\"",
       "tar -xzf \"flatpak-node/npm/multipipe-65471ea4d74c78a0519ff92c9b65d3c459e105aaa704949936ac1a8e689e9ba6fb469ddf34002afadc189f792ac3d60c63b1c9b9cec8ece39b5fd70c801d4036\" -C \"node_modules/scratch-gui/node_modules/multipipe\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/nan\"",
-      "tar -xzf \"flatpak-node/npm/nan-0c03608711644b5a650dd46c5f45fda66d19e9224d37a80176d5df6a7c2867c868a02e60a2c1854811916075153f3d5ab0a03f90c46a0d1747ae5b99eb54a905\" -C \"node_modules/nan\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/nan\"",
-      "tar -xzf \"flatpak-node/npm/nan-0c03608711644b5a650dd46c5f45fda66d19e9224d37a80176d5df6a7c2867c868a02e60a2c1854811916075153f3d5ab0a03f90c46a0d1747ae5b99eb54a905\" -C \"node_modules/scratch-gui/node_modules/nan\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/nan-d54c6ec9819da101dc1a0f3b2e4aa6dc5cde7ee7136b434088e72e46c0e6cac7a9ddcd4b54244ada4aeb50369f316b63486d3886dbc09af83debe4839273a681\" -C \"node_modules/nan\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/nanoid\"",
       "tar -xzf \"flatpak-node/npm/nanoid-37c4a97cf527529d5b2be3cc616f2a496765f54fb0c0d588e102b13980f2f4902ba3758c5fba7639e55117dbfedf8ee99da90d7af3e688784d999d876c503beb\" -C \"node_modules/nanoid\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/nanomatch\"",
@@ -13523,7 +14313,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/neo-async\"",
       "tar -xzf \"flatpak-node/npm/neo-async-61ddd4112e665824aa47ea8d4fddd2dd4a18524a8067d94b83c6bb83dae29ac5a66062bc7154e8038fec17746bb21772577b0018c5d5526a4c60ec3e74ba4ebb\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/neo-async\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/node-abi\"",
-      "tar -xzf \"flatpak-node/npm/node-abi-3a161a639b03b0891aec7ec0b628ed23d8f01982f2976f5e427fd6eb6dc388dfcc22fe6c52a73883b0480d3857fa06fb762f5feb12b4da7929f2c75f15664b4e\" -C \"node_modules/node-abi\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/node-abi-1389fdd4ae0d93545c8762b30fe79d5366df6533f85b8d86ca90140d7538beed40fb8bbd3ef50d0e4188d1d5dbb32f19785dd61a3d120ffb87c675c3fec5bedf\" -C \"node_modules/node-abi\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/node-addon-api\"",
       "tar -xzf \"flatpak-node/npm/node-addon-api-89b3cade203ebda6357848c44a442433405b0aa14e6993225d14ed741d2eedbe1d8ed63a267b23bcf7541d5320eb142ddc1f1fa534d61c8f40f800e333d7ebce\" -C \"node_modules/node-addon-api\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/node-api-version\"",
@@ -13532,6 +14322,8 @@
       "tar -xzf \"flatpak-node/npm/node-fetch-66330f1447d5c798fecb6c85df92b3c79b05ee40f3c6e0e3eb3887e0515b3a9f3bcca0d9371f321312486f4e4e185e0d96df481c520c064465e3555dbdc35d6d\" -C \"node_modules/node-fetch\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/node-fetch\"",
       "tar -xzf \"flatpak-node/npm/node-fetch-66330f1447d5c798fecb6c85df92b3c79b05ee40f3c6e0e3eb3887e0515b3a9f3bcca0d9371f321312486f4e4e185e0d96df481c520c064465e3555dbdc35d6d\" -C \"node_modules/scratch-gui/node_modules/node-fetch\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/node-gyp\"",
+      "tar -xzf \"flatpak-node/npm/node-gyp-de00feeb3b2b2d01fb0f260e508bad69abae5eb732c5e4cfc90b9940242834f64c1cc312e66e32d31725369bd8ce82b754dceecb14fa785e269082f859267579\" -C \"node_modules/node-gyp\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/node-libs-browser\"",
       "tar -xzf \"flatpak-node/npm/node-libs-browser-87fcdc0fc1fd91a0d9f402d45b0941503a3a4ca17c6bba8148248419f8d354861eaac8a848a6805fe04decd822306a7a8922176773f1802bbc292ddbef560ae5\" -C \"node_modules/node-libs-browser\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/node-libs-browser\"",
@@ -13559,7 +14351,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/node-releases\"",
       "tar -xzf \"flatpak-node/npm/node-releases-c7139626c04ab7302aec363427e0d3ceecf9f0af1eeec25b760c246cc5907bc51807a7a49ac438e6ad0cfed243b0669999b0be97b9f9ed457c1e5e6d1f13bdbb\" -C \"node_modules/scratch-gui/node_modules/node-releases\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/nopt\"",
-      "tar -xzf \"flatpak-node/npm/nopt-6702e96d381d86e6549d9ce377b9dbd5957ee03a220bafec7e254aa24ef6ca6ff84e57fe0c57651d8993d893e670d35657a3e2dd20dfd644fe038afd453b93f6\" -C \"node_modules/nopt\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/nopt-89e1aee36bbf42c6b84c592d99a284c0ce8c407d293969da07786dce1d0946dc7ce3e31e6dcd1c6d960de5b0bee964d9e3eefbc6b2fd3e7e66ec257a548915ec\" -C \"node_modules/nopt\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/normalize-package-data\"",
       "tar -xzf \"flatpak-node/npm/normalize-package-data-ff908c3774f44785d38f80dc19a7b1a3eae8652752156ff400e39344eae3c73086d70ad65c4b066d129ebe39482fe643138b19949af9103e185b4caa9a42be78\" -C \"node_modules/normalize-package-data\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/normalize-package-data\"",
@@ -13630,12 +14422,6 @@
       "tar -xzf \"flatpak-node/npm/omggif-558010452668eeaa017300791b6f58a953cb9f1bc3916ba5137c77e64c07ddbab819d1ff6641eb70f3e1c557da386606679295dbfe795297237323483b5a99a1\" -C \"node_modules/omggif\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/omggif\"",
       "tar -xzf \"flatpak-node/npm/omggif-558010452668eeaa017300791b6f58a953cb9f1bc3916ba5137c77e64c07ddbab819d1ff6641eb70f3e1c557da386606679295dbfe795297237323483b5a99a1\" -C \"node_modules/scratch-gui/node_modules/omggif\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/once\"",
-      "tar -xzf \"flatpak-node/npm/once-94d689808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb\" -C \"node_modules/once\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/once\"",
-      "tar -xzf \"flatpak-node/npm/once-94d689808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb\" -C \"node_modules/scratch-gui/node_modules/once\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/once\"",
-      "tar -xzf \"flatpak-node/npm/once-94d689808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/once\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/onetime\"",
       "tar -xzf \"flatpak-node/npm/onetime-91ba5a4921894d674063928f55e30e2974ab3edafc0bc0bbc287496dcb1de758d19e60fe199bbc63456853a0e6e59e2f5abd0883fd4d2ae59129fee3e5a6984a\" -C \"node_modules/onetime\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/optionator\"",
@@ -13664,10 +14450,6 @@
       "tar -xzf \"flatpak-node/npm/p-is-promise-ccbed51382554b62054a447619028348f115c64a07e37fe9ee8127c297429dd29824ed0755e441edf03c4c9c2e2ce4c1444b4ad1e6bc7876b1770729a1be5d9a\" -C \"node_modules/p-is-promise\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/p-is-promise\"",
       "tar -xzf \"flatpak-node/npm/p-is-promise-ccbed51382554b62054a447619028348f115c64a07e37fe9ee8127c297429dd29824ed0755e441edf03c4c9c2e2ce4c1444b4ad1e6bc7876b1770729a1be5d9a\" -C \"node_modules/scratch-gui/node_modules/p-is-promise\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/p-limit\"",
-      "tar -xzf \"flatpak-node/npm/p-limit-4d839a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945\" -C \"node_modules/p-limit\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/p-limit\"",
-      "tar -xzf \"flatpak-node/npm/p-limit-4d839a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945\" -C \"node_modules/scratch-gui/node_modules/p-limit\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/p-locate\"",
       "tar -xzf \"flatpak-node/npm/p-locate-47bf5967fd30031286bb7a18325cfc8f2fe46e1b0dad2ed2299ecfc441c1809e7e1769ad156d9f2b670eb4187570762442c6f3155ec8f84a1129ee98b74a0aec\" -C \"node_modules/p-locate\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/pkg-dir/node_modules/p-locate\"",
@@ -13708,8 +14490,6 @@
       "tar -xzf \"flatpak-node/npm/papaparse-2dbee337fe1b4e98ae18fad8cb8b642a8512f2c4e48bccda701e647b5a79ce89617121384e55a0ae5b318eb0d36c6fdd155874edc93b5f7ea151ffdbe55ebca6\" -C \"node_modules/papaparse\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/papaparse\"",
       "tar -xzf \"flatpak-node/npm/papaparse-2dbee337fe1b4e98ae18fad8cb8b642a8512f2c4e48bccda701e647b5a79ce89617121384e55a0ae5b318eb0d36c6fdd155874edc93b5f7ea151ffdbe55ebca6\" -C \"node_modules/scratch-gui/node_modules/papaparse\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/parent-module\"",
-      "tar -xzf \"flatpak-node/npm/parent-module-190d84591a5057cfe8f80c3c62ab5f6593df3515996246e2744f64e6ba65fe10b7bed1c705f1a6d887e2eaa595f9ca031a4ad42990311372e8b7991cb11961fa\" -C \"node_modules/parent-module\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/parse-asn1\"",
       "tar -xzf \"flatpak-node/npm/parse-asn1-09333992e591decc7d2056a6725e44adf3e5e9e6bf37c218c2227ebe9781da0fb58a49efef3065e6e3f06cc6d15739d155bacd63a946b83a04e5bdf482b99baa\" -C \"node_modules/parse-asn1\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/parse-asn1\"",
@@ -13752,36 +14532,30 @@
       "tar -xzf \"flatpak-node/npm/path-dirname-00bccd3e9c8dabd02a5cc0637b29888c50c0900147d3a987247fdc4811c0814d2ce2f7e9067e9bda77fcb6244bbda80a0fc45b4e9ab614a4c183b725f65ddced\" -C \"node_modules/scratch-gui/node_modules/path-dirname\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/path-dirname\"",
       "tar -xzf \"flatpak-node/npm/path-dirname-00bccd3e9c8dabd02a5cc0637b29888c50c0900147d3a987247fdc4811c0814d2ce2f7e9067e9bda77fcb6244bbda80a0fc45b4e9ab614a4c183b725f65ddced\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/path-dirname\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/path-exists\"",
-      "tar -xzf \"flatpak-node/npm/path-exists-6a4f50cb943b8d86f65b071ecb9169be0d8aa0073f64884b48b392066466ca03ec1b091556dd1f65ad2aaed333fa6ead2530077d943c167981e0c1b82d6cbbff\" -C \"node_modules/path-exists\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/path-exists\"",
-      "tar -xzf \"flatpak-node/npm/path-exists-6a4f50cb943b8d86f65b071ecb9169be0d8aa0073f64884b48b392066466ca03ec1b091556dd1f65ad2aaed333fa6ead2530077d943c167981e0c1b82d6cbbff\" -C \"node_modules/scratch-gui/node_modules/path-exists\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/path-is-absolute\"",
       "tar -xzf \"flatpak-node/npm/path-is-absolute-0156f0dd42767bd6eaeb8bd2692f409b47e37b53daf296c6a934ec9977da2223299ebe4394385f24eb8b8fd49ff7964f5430147ab0df124f3c30f98f7bb50242\" -C \"node_modules/path-is-absolute\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/path-is-absolute\"",
       "tar -xzf \"flatpak-node/npm/path-is-absolute-0156f0dd42767bd6eaeb8bd2692f409b47e37b53daf296c6a934ec9977da2223299ebe4394385f24eb8b8fd49ff7964f5430147ab0df124f3c30f98f7bb50242\" -C \"node_modules/scratch-gui/node_modules/path-is-absolute\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/path-is-absolute\"",
       "tar -xzf \"flatpak-node/npm/path-is-absolute-0156f0dd42767bd6eaeb8bd2692f409b47e37b53daf296c6a934ec9977da2223299ebe4394385f24eb8b8fd49ff7964f5430147ab0df124f3c30f98f7bb50242\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/path-is-absolute\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/path-key\"",
-      "tar -xzf \"flatpak-node/npm/path-key-a2399e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9\" -C \"node_modules/path-key\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/path-parse\"",
       "tar -xzf \"flatpak-node/npm/path-parse-2c32733d510410f47ecb8f33f7703411dd325dbf29001c865a8fe4e5861d620a58dbfd84b0eb24b09aeaee5387c6bcab54e9f57a31baa00a7c6a1bce2100fcb3\" -C \"node_modules/path-parse\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/path-parse\"",
       "tar -xzf \"flatpak-node/npm/path-parse-2c32733d510410f47ecb8f33f7703411dd325dbf29001c865a8fe4e5861d620a58dbfd84b0eb24b09aeaee5387c6bcab54e9f57a31baa00a7c6a1bce2100fcb3\" -C \"node_modules/scratch-gui/node_modules/path-parse\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/path-scurry\"",
       "tar -xzf \"flatpak-node/npm/path-scurry-5dae0dc35ec54bd02940527dba62e2252e28ac68e6ed9cf052bc1a99c190b874b30f2b61f5ba0a0dac9c61d0dc643baa6004d7c381c55e06aa59372d5bfbf51c\" -C \"node_modules/path-scurry\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/path-scurry/node_modules/lru-cache\"",
-      "tar -xzf \"flatpak-node/npm/lru-cache-24d03365c5eb0ade365462ee633d337c0cc37c0bc9596e807d8943050c835790c2948da6e6c0262be3883bbb39f577ec46c587a74da3009ad169d3d1193b7a49\" -C \"node_modules/path-scurry/node_modules/lru-cache\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/path-type\"",
       "tar -xzf \"flatpak-node/npm/path-type-80329bf1a64c0de0ffb595acf4febeab427d33091d97ac4c57c4e39c63f7a89549d3a6dd32091b0652d4f0875f3ac22c173d815b5acd553dd7b8d125f333c0bf\" -C \"node_modules/path-type\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/path-type\"",
       "tar -xzf \"flatpak-node/npm/path-type-80329bf1a64c0de0ffb595acf4febeab427d33091d97ac4c57c4e39c63f7a89549d3a6dd32091b0652d4f0875f3ac22c173d815b5acd553dd7b8d125f333c0bf\" -C \"node_modules/scratch-gui/node_modules/path-type\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/pbkdf2\"",
-      "tar -xzf \"flatpak-node/npm/pbkdf2-8ae87b2fa8c0ec9106bb65b10f0b503f575d3a9689342e0a9431057dd41a8d21a018f362e0ec8373647b4276d8d9b47d4230551b082f4dd34966813b45ac5430\" -C \"node_modules/pbkdf2\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/pbkdf2\"",
-      "tar -xzf \"flatpak-node/npm/pbkdf2-8ae87b2fa8c0ec9106bb65b10f0b503f575d3a9689342e0a9431057dd41a8d21a018f362e0ec8373647b4276d8d9b47d4230551b082f4dd34966813b45ac5430\" -C \"node_modules/scratch-gui/node_modules/pbkdf2\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/pbkdf2\"",
-      "tar -xzf \"flatpak-node/npm/pbkdf2-8ae87b2fa8c0ec9106bb65b10f0b503f575d3a9689342e0a9431057dd41a8d21a018f362e0ec8373647b4276d8d9b47d4230551b082f4dd34966813b45ac5430\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/pbkdf2\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/pbkdf2-c1f44b059d1f796461088928301e9eb5eedccc9727367a91a5ca164012ea6ada975e67a5491a9f7432b8177bbd4f6b367176acfe140972bc88ff89402fe5d394\" -C \"node_modules/pbkdf2\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/pbkdf2/node_modules/create-hash\"",
+      "tar -xzf \"flatpak-node/npm/create-hash-b27469721fe4c1085c7659d92986a7345d66d110e5ac2752290687f3bc3514214f54f34243f225f5024a017da354165d75175a1c1302fb35daf46c3db6690d50\" -C \"node_modules/pbkdf2/node_modules/create-hash\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/pbkdf2/node_modules/hash-base\"",
+      "tar -xzf \"flatpak-node/npm/hash-base-d1344e810d7f4b113a2a6c564af5c7bd18fdd3f5e8d49bd94a1a1f9d817e7fa66c1ad4787844bb59fad0ccf6a59b26a07ca6425e95678ad89179b66e956b1b8b\" -C \"node_modules/pbkdf2/node_modules/hash-base\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/pbkdf2/node_modules/ripemd160\"",
+      "tar -xzf \"flatpak-node/npm/ripemd160-27b7f8c2eb4df2675b574f0c2675e26d8a4238f1d1fb2cf2fa243f02c8ccbf68fc70b6af43c5466a00c5530c1301d17c16644a55e3696d34c4c0d1c25b583de3\" -C \"node_modules/pbkdf2/node_modules/ripemd160\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/pe-library\"",
       "tar -xzf \"flatpak-node/npm/pe-library-791581e4b073ecfa43bb83d49704f43e19d07d34099430dd3dadf9bab5783acae6d2dd00a901469fe508914de4959bf027c28f3b755b045b17aae03aa7a92a67\" -C \"node_modules/pe-library\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/pend\"",
@@ -13792,10 +14566,6 @@
       "tar -xzf \"flatpak-node/npm/performance-now-ec40079722c7239e9510874ae7bbb01dd1ca21a0066e75cf8b0d3259b6ab41938a68aa6f508816d2359154b89ab6733e5d7952c2c6a72011ff87318c26e94ca3\" -C \"node_modules/performance-now\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/performance-now\"",
       "tar -xzf \"flatpak-node/npm/performance-now-ec40079722c7239e9510874ae7bbb01dd1ca21a0066e75cf8b0d3259b6ab41938a68aa6f508816d2359154b89ab6733e5d7952c2c6a72011ff87318c26e94ca3\" -C \"node_modules/scratch-gui/node_modules/performance-now\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/picocolors\"",
-      "tar -xzf \"flatpak-node/npm/picocolors-c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454\" -C \"node_modules/picocolors\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/picocolors\"",
-      "tar -xzf \"flatpak-node/npm/picocolors-c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454\" -C \"node_modules/scratch-gui/node_modules/picocolors\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/picomatch\"",
       "tar -xzf \"flatpak-node/npm/picomatch-254ded7874cd8e6136542185cee63c117cc20d5c04a81d9af1fb08bf0692b4784058911e55dd68d500fcd0253af997445d748b6d2b2e2f0263902056a9141454\" -C \"node_modules/picomatch\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/picomatch\"",
@@ -13830,8 +14600,10 @@
       "tar -xzf \"flatpak-node/npm/posix-character-classes-c5381805cddfba8ed8b7b25b8ae171498193a0ca33f1f2e813a4c2f56c753ffbbe2df79384c380aa6bb21029e505a6896febb59bd847897504b705b83b37d426\" -C \"node_modules/scratch-gui/node_modules/posix-character-classes\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/posix-character-classes\"",
       "tar -xzf \"flatpak-node/npm/posix-character-classes-c5381805cddfba8ed8b7b25b8ae171498193a0ca33f1f2e813a4c2f56c753ffbbe2df79384c380aa6bb21029e505a6896febb59bd847897504b705b83b37d426\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/posix-character-classes\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/possible-typed-array-names\"",
+      "tar -xzf \"flatpak-node/npm/possible-typed-array-names-ffee55153721243a158f76e1a2a8ba51eca6703d340c0c1bd672706a6ccfbc712ccc9e05a45e9234d6d46ce4bcc88e7aa87cdd57c78ad2a11f3928a87644ddc6\" -C \"node_modules/possible-typed-array-names\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/postcss\"",
-      "tar -xzf \"flatpak-node/npm/postcss-77f8ed9beadd353f2da57b8763930cb5c6c91419215c4eb9f775d547d5281821fc8d2146722ee31af3061f94587793c1256fb4d0d650b7a81fec26da8090ab86\" -C \"node_modules/postcss\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/postcss-dd86e2d6d02ec003fdb34af5510d89e27e58d06d396c99295083b4fdb23d321c260fbd12e5a4d66d7181c311eb7a54fe5ccd64e9d334a64f92c0d9294d137b3e\" -C \"node_modules/postcss\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/postcss-import\"",
       "tar -xzf \"flatpak-node/npm/postcss-import-7e5c08f95826e1212539b1553e94c84fb494ed1dea9362fb3f276e31ca2489a54ab96bfd77f53e1a6fd001df0d0cbbb291359391cae339e0f63e9d6b31e0531b\" -C \"node_modules/postcss-import\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/postcss-load-config\"",
@@ -13894,10 +14666,6 @@
       "tar -xzf \"flatpak-node/npm/postcss-value-parser-d4d342b3abaeadf9156de5c6e12f09153f6dd7d9b8e480a789ff3358b779a0f499e74427c0c7caf87de3bf8d3c7788f0ffb06db6fe5ac52e48887a0b69534779\" -C \"node_modules/postcss-value-parser\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/postcss-value-parser\"",
       "tar -xzf \"flatpak-node/npm/postcss-value-parser-d4d342b3abaeadf9156de5c6e12f09153f6dd7d9b8e480a789ff3358b779a0f499e74427c0c7caf87de3bf8d3c7788f0ffb06db6fe5ac52e48887a0b69534779\" -C \"node_modules/scratch-gui/node_modules/postcss-value-parser\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/postject\"",
-      "tar -xzf \"flatpak-node/npm/postject-6fd11bf21d9e56a344f1e76f29dc2a92b63a3bb900c2623c91c9c1bf535272895825ba39f57505d27a05abe9716c2d72376d1b982d160446c30b91ffec049bd0\" -C \"node_modules/postject\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/postject/node_modules/commander\"",
-      "tar -xzf \"flatpak-node/npm/commander-291b3b5950ca83ce8f5a2b80aa10eb0109d35d92ab69570273abc574bd78aab67f0dc5b0b91a3b5688985da9573bb4b918aa6a622544c026e01437f134728905\" -C \"node_modules/postject/node_modules/commander\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/prelude-ls\"",
       "tar -xzf \"flatpak-node/npm/prelude-ls-112176dd5e12286ea55521998183696ec89a02475a6fa6603b17b9da9efe2a27775b7bb76f147855f77fa36d5d98dee34add08c20678bf9314776e8512d5c4f7\" -C \"node_modules/prelude-ls\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/escodegen/node_modules/prelude-ls\"",
@@ -13907,7 +14675,7 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/prepend-http\"",
       "tar -xzf \"flatpak-node/npm/prepend-http-adabc4ea6f40b70f59fe38edb51519f9c9485e881d821c9902e589dea1338d3fa323f74bd627c0aa165e0b9547cd0a75312b75fa3c4a90535e9a3fe23bbb5550\" -C \"node_modules/scratch-gui/node_modules/prepend-http\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/proc-log\"",
-      "tar -xzf \"flatpak-node/npm/proc-log-29c9a8d8585f0d35dd71b7c31fbe8deee0581c837173ff065bb50056e54ff48f956b7b8749eaeb9ca57a74ba2881afe087b1a5833b820abfdea257672f59ae1b\" -C \"node_modules/proc-log\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/proc-log-033c33be5f741da174682cf526b0dd5d0ca415a91248d3da3e8899f5f9b9a8920c1e2a036448bb380751c129baad2a0fb58dd0bad9e6dcbee882683775cfb06d\" -C \"node_modules/proc-log\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/process\"",
       "tar -xzf \"flatpak-node/npm/process-71d19e7ff76b585a32743d49b0ccee15ff35d349d997e193fb269c7366c471e7797fd463938cfe5ad1544c1bbd3e13a2f63fe37e604fbb498c118e3021d005f0\" -C \"node_modules/process\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/process\"",
@@ -13957,19 +14725,9 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/public-encrypt\"",
       "tar -xzf \"flatpak-node/npm/public-encrypt-cd5a5af282994b3e5b4cc4c50a57357d03a7cb2133a65e68ce98b507961cbc1adda213231f6adfb01b725dcb8dbb08ec0c85e6058945d8de45949621476f6df1\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/public-encrypt\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/pump\"",
-      "tar -xzf \"flatpak-node/npm/pump-b543d7b7394633c144dcfd192fa0d5b3fdcfe7c93d9e4f3f8d97900aead327295003ca856331c57e104992eab21341627ceb10d2e2967a4899e60f30b6bdbc73\" -C \"node_modules/pump\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/pump\"",
-      "tar -xzf \"flatpak-node/npm/pump-b543d7b7394633c144dcfd192fa0d5b3fdcfe7c93d9e4f3f8d97900aead327295003ca856331c57e104992eab21341627ceb10d2e2967a4899e60f30b6bdbc73\" -C \"node_modules/scratch-gui/node_modules/pump\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/punycode\"",
-      "tar -xzf \"flatpak-node/npm/punycode-bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16\" -C \"node_modules/punycode\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/psl/node_modules/punycode\"",
-      "tar -xzf \"flatpak-node/npm/punycode-bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16\" -C \"node_modules/scratch-gui/node_modules/psl/node_modules/punycode\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/punycode\"",
-      "tar -xzf \"flatpak-node/npm/punycode-bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/punycode\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/tough-cookie/node_modules/punycode\"",
-      "tar -xzf \"flatpak-node/npm/punycode-bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16\" -C \"node_modules/scratch-gui/node_modules/tough-cookie/node_modules/punycode\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/uri-js/node_modules/punycode\"",
-      "tar -xzf \"flatpak-node/npm/punycode-bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16\" -C \"node_modules/scratch-gui/node_modules/uri-js/node_modules/punycode\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/pump-b68770c4b318eff85e49c2a69edc101bc09756459439d63122f636b34556000321fe777c4a862245a2a396befe882b3df387f63fccefadf59c0c36156fbdcd7c\" -C \"node_modules/pump\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/qs\"",
+      "tar -xzf \"flatpak-node/npm/qs-fb7f2a23d48eafcb5f67842624da65314c6a8db7bb2cabef66059d13104e99df9e8194ed8cb07aec6bb41d15f7bbf5ceabb514d8dc7a9ec8ef4b5e99f6ec1fa6\" -C \"node_modules/qs\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/query-string\"",
       "tar -xzf \"flatpak-node/npm/query-string-82358eb26d92a069602c47401adedaeac9553a4f661a25e63c532aac484b43af2b850b819e97ecdfe12696fa8acb19c2a3dfcf3e517ef4cb58d364b568583e27\" -C \"node_modules/query-string\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/query-string\"",
@@ -14108,8 +14866,6 @@
       "tar -xzf \"flatpak-node/npm/readable-stream-f6efec9e20ab6370f959db04447cc71381b66025eaa06e454c7522082e1221bafa5dc2d9058d39c9af442a361e93d3b9c4e0308c6abed497460404bb43d49ca0\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/readable-stream\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/readable-stream\"",
       "tar -xzf \"flatpak-node/npm/readable-stream-f6efec9e20ab6370f959db04447cc71381b66025eaa06e454c7522082e1221bafa5dc2d9058d39c9af442a361e93d3b9c4e0308c6abed497460404bb43d49ca0\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/readable-stream\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/readdirp\"",
-      "tar -xzf \"flatpak-node/npm/readdirp-18387090b7f2c162f6b3abc48f286b8be79799f1fa8f52fb244dbb5a1a8b798ce887f0370c16981848f61ff1c56429ff90c7e29bbdc55f11094f0d3a5adc50c2\" -C \"node_modules/readdirp\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/rechoir\"",
       "tar -xzf \"flatpak-node/npm/rechoir-fe78e667cb35c15791ea98d367ed270a7bfc4a964d44c4f60f544b3894044a56050c1bf0a5303829626967eb01278faf86320b45c2bb24815d182771100022b6\" -C \"node_modules/rechoir\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/redux\"",
@@ -14190,8 +14946,6 @@
       "tar -xzf \"flatpak-node/npm/resolve-cwd-3ab65a5f631bfab242a47ffa0a94aab7dc4556937efb1d355e737689ef60e8fe7fdf17a52c0917595003a5dcf52070ff2857c45f213a574534d4e43750edab12\" -C \"node_modules/resolve-cwd\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/resolve-cwd/node_modules/resolve-from\"",
       "tar -xzf \"flatpak-node/npm/resolve-from-a9883d28fdb8743e6a91af49e3b774695932d0df9be1f4d4f3d2cdf620e78c1e706a4b220b8f6bbcc0743eb509406a13987e745cf8aa3af0230df6a28c6c5867\" -C \"node_modules/resolve-cwd/node_modules/resolve-from\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/resolve-from\"",
-      "tar -xzf \"flatpak-node/npm/resolve-from-a5bfcc6265ecb40932b11171f2988d235b4614d408140def904dc6ab812e035745ea01e9ffebe066ab021896a9bf2f0ddd0fb8a3b170beab8f25c9d9ed1632e2\" -C \"node_modules/resolve-from\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/resolve-url\"",
       "tar -xzf \"flatpak-node/npm/resolve-url-66e179e6155441a69cce0388c2a5b390470489d9a50ffc65e38c755199e1397718b853764bafab731a46f82d4ddd2a34c2f348dc39892025057eed92c61066be\" -C \"node_modules/resolve-url\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/resolve-url\"",
@@ -14254,16 +15008,46 @@
       "tar -xzf \"flatpak-node/npm/source-map-8231a7c4d3742befcfaf8322e1fb3fa4eb5d6b5d1d281e969fd42f8ceac7eafe535ac23b8211ee2541e8220c8ce839142f992bd86b4f1467ab7abccaa4c0567c\" -C \"node_modules/scratch-gui/node_modules/exports-loader/node_modules/source-map\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/source-map\"",
       "tar -xzf \"flatpak-node/npm/source-map-8231a7c4d3742befcfaf8322e1fb3fa4eb5d6b5d1d281e969fd42f8ceac7eafe535ac23b8211ee2541e8220c8ce839142f992bd86b4f1467ab7abccaa4c0567c\" -C \"node_modules/source-map\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/@npmcli/fs/node_modules/semver\"",
-      "tar -xzf \"flatpak-node/npm/semver-445d05c3eacee4031ff4c0326915c8e005745258f994c1ea571c5d4a08956e2c52097a049a65ff8e4d02b89c38fb74aaae860ef55a1487e1dcb898afbed25e98\" -C \"node_modules/scratch-gui/node_modules/@npmcli/fs/node_modules/semver\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/semver\"",
-      "tar -xzf \"flatpak-node/npm/semver-445d05c3eacee4031ff4c0326915c8e005745258f994c1ea571c5d4a08956e2c52097a049a65ff8e4d02b89c38fb74aaae860ef55a1487e1dcb898afbed25e98\" -C \"node_modules/semver\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@ampproject/remapping\"",
+      "tar -xzf \"flatpak-node/npm/remapping-df4899b403e0cfe2d3218a1e8afa98a3ce777f4da305849de6e1a71a9905574337c4eb7d68def77ab920600999538df1e157ea7272f15bd2a98374792c2e1863\" -C \"node_modules/scratch-gui/node_modules/@ampproject/remapping\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/cli\"",
+      "tar -xzf \"flatpak-node/npm/cli-71f77b0e71a5847e8e232b8f4928f7bdc7c87676d7ba4840c8a63c35a66b15a742ee95f22fd98e2f95a08dca6d88424b8b99378fc698bcb2150b37b3ad64da88\" -C \"node_modules/scratch-gui/node_modules/@babel/cli\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/compat-data\"",
+      "tar -xzf \"flatpak-node/npm/compat-data-2a2440a7f56825a5a492d7bce13bd477daa375b640762ab2bccc6b1a5d4deafcc5a202a668b8283372f5920b4b89ca761cfe5f0494bc26b64a2d521919524056\" -C \"node_modules/scratch-gui/node_modules/@babel/compat-data\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/core\"",
+      "tar -xzf \"flatpak-node/npm/core-6d7631ad716e6de61dbc1d0d843fcd041dd08ba699795db418e595238eedd9d91e7021289de47834f55c6fb69ba570c4bde8e0ad47c5b46eaf1bfcf100a9a0fa\" -C \"node_modules/scratch-gui/node_modules/@babel/core\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/generator\"",
+      "tar -xzf \"flatpak-node/npm/generator-646840dfb9747bf836b350a7cdd8b1d0edda2d89bae9e17c6ae7e256d78e827c3182744ff06a32323ed55ac8169d06d5297ca07bb86aac58762b64d033ab751f\" -C \"node_modules/scratch-gui/node_modules/@babel/generator\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/helper-module-transforms\"",
+      "tar -xzf \"flatpak-node/npm/helper-module-transforms-7523af630bf22ec58178847239e1d7a79bcf8f9975234d75af9d85335fabd6308446ff9a157624e3086041c7181066312b61f7640200f27b8f910d07694a37aa\" -C \"node_modules/scratch-gui/node_modules/@babel/helper-module-transforms\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/helpers\"",
+      "tar -xzf \"flatpak-node/npm/helpers-9ae13c4edf0cdb6eb7f07537d40dc281f494722c33d5f8404dfa156a2d3968f5c6a2bfff09d58309b9e5635caf04fa34ee78ee54e08d1824a9fc64edd76948ba\" -C \"node_modules/scratch-gui/node_modules/@babel/helpers\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/parser\"",
+      "tar -xzf \"flatpak-node/npm/parser-3ac41dd7be52c569069736e7cbc2772bc4e79c30f437796b214b41f76c70c91a7369e9c6661c43bf137f260534d14dc20d9363f6d3ee0c9e47d164b836ddef2a\" -C \"node_modules/scratch-gui/node_modules/@babel/parser\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/traverse\"",
+      "tar -xzf \"flatpak-node/npm/traverse-a0d72ed906c7aadb3d06d396268b0e5496a95a30434b1182a45be290d4794c60d80d07f7270a48a0ccc82abbdfa2d8bdddc2df3c9106e2d1fd48f55ec821a074\" -C \"node_modules/scratch-gui/node_modules/@babel/traverse\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@babel/types\"",
+      "tar -xzf \"flatpak-node/npm/types-113c87124d951c7be5f5bf6364fe481cf6af1d8939ec485a9e5451b9a7bd5c2a5bfe3e5b0c26cf3cc3817c25a19e5ffb103273d2310c0a2fd185c70213caf5f9\" -C \"node_modules/scratch-gui/node_modules/@babel/types\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@jridgewell/gen-mapping\"",
+      "tar -xzf \"flatpak-node/npm/gen-mapping-8a601b04691bf9e6d0cb12a0cefe47bb69e644ec680ce5c787cd1ebf17685cd3abbc09d5c7bce29b37353a8e61f5195f578bcf5da13688ce693856ef3820a558\" -C \"node_modules/scratch-gui/node_modules/@jridgewell/gen-mapping\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@jridgewell/set-array\"",
+      "tar -xzf \"flatpak-node/npm/set-array-47c80b45365eca9d37ca6ccfffa2e297fdbcb46786133871d6ada4ef4dca19644023555dbcf217746ef4549736a40330dcd03a24a2f986116ed6c257d0c9e7fc\" -C \"node_modules/scratch-gui/node_modules/@jridgewell/set-array\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@jridgewell/source-map\"",
+      "tar -xzf \"flatpak-node/npm/source-map-d5925365e6e0aa594eefdb9ed9b9b7ac81ae77f6ce7b4a4fe418d2442471c58904652f124d5ef337ce1405b898bbb8f2f9e08a4a7548520a16584fedb7eb2131\" -C \"node_modules/scratch-gui/node_modules/@jridgewell/source-map\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@jridgewell/sourcemap-codec\"",
+      "tar -xzf \"flatpak-node/npm/sourcemap-codec-82fdd945a2125377e33c080db2b88146a19640beaab85c74e1830f5bfcc3f1730bb14df69a10826df6cee8a6452e3bd8a4267ccf20c482ab207fe3f03da33b19\" -C \"node_modules/scratch-gui/node_modules/@jridgewell/sourcemap-codec\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@jridgewell/trace-mapping\"",
+      "tar -xzf \"flatpak-node/npm/trace-mapping-bcd93a684c326c6b5ac169b2fcfcf09c60ce8c290b5920f6c2abe3186020380c02196c926177d8a31b74d082644c5fbc2dbe7b0f039bdc06b4a3d080a5ea6261\" -C \"node_modules/scratch-gui/node_modules/@jridgewell/trace-mapping\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@transifex/api/node_modules/core-js\"",
+      "tar -xzf \"flatpak-node/npm/core-js-37ac046d34d9498398dab6009fce42baf5969022ba43078c9fbff836bdf0fa00c1781864ff1e0425e63a14fa384330e8259c554eff14ec232f81693aa4e1c7a8\" -C \"node_modules/scratch-gui/node_modules/@transifex/api/node_modules/core-js\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/@types/babel__traverse\"",
+      "tar -xzf \"flatpak-node/npm/babel__traverse-7643b97e14bbfbfa28b387225b1c84ca359ee3cce61bac1b0a17a8fc6d999c7c787ecdc453a602e9433cae4e7a8008cd27d3f73131f68e8e636fddbf2bac1b9e\" -C \"node_modules/scratch-gui/node_modules/@types/babel__traverse\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/@types/node\"",
       "tar -xzf \"flatpak-node/npm/node-317e198a8877f5c84794325b2a6120c9d2434b7b6ca4c3ff967402ebb1b7496b139dbf4d7985563a3931a4e4b2e2831f3ece12b5c587c01aef51be326df9ee6b\" -C \"node_modules/scratch-gui/node_modules/@types/node\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/acorn\"",
-      "tar -xzf \"flatpak-node/npm/acorn-359c896ab05f2fb9d6c08abe1432fa669ff21c485e3cc3679c9d32dea7e2782ae636f61cb7cbafb62578d54be549ee9aa407e4d1f63515b5b1f8dc1f9a9bed4e\" -C \"node_modules/scratch-gui/node_modules/acorn\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/terser/node_modules/acorn\"",
-      "tar -xzf \"flatpak-node/npm/acorn-359c896ab05f2fb9d6c08abe1432fa669ff21c485e3cc3679c9d32dea7e2782ae636f61cb7cbafb62578d54be549ee9aa407e4d1f63515b5b1f8dc1f9a9bed4e\" -C \"node_modules/terser/node_modules/acorn\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/browserslist\"",
+      "tar -xzf \"flatpak-node/npm/browserslist-3c9f2060a792e5eff0847061f31af060af9d02f123ec95edcfab93b9c9cc441f0e8864ec29c7057a4a11ae36a33c11d5f28398fb6b48e2ec5e71e4a298ac0c14\" -C \"node_modules/scratch-gui/node_modules/browserslist\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/caniuse-lite\"",
+      "tar -xzf \"flatpak-node/npm/caniuse-lite-0c240704166d88ae89564006c3b76bbc030ad10d0f383ff166f1260e9e9b6a230c3fa4175e4f47a43ea63580595a138f1ba2ef2036fcd884eab568e10dc90708\" -C \"node_modules/scratch-gui/node_modules/caniuse-lite\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/cookie\"",
       "tar -xzf \"flatpak-node/npm/cookie-619dc65329ffa3c81f289967957ee0ef1ab88323ba392ba118f29a686b2c181daa803512d203e0b53be8c992d3b7d01be9d0b885f73d755e5aae4bdcfce0a6af\" -C \"node_modules/scratch-gui/node_modules/cookie\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/cookie\"",
@@ -14274,18 +15058,30 @@
       "tar -xzf \"flatpak-node/npm/core-util-is-65006f8b50dca49e060ea6a78ee719d878f7c043b9a590d2f3d0566e472bbddc64b09a2bc140c365a997f65745929f5ac369660432e090e6c40380d6349f4561\" -C \"node_modules/scratch-gui/node_modules/scratch-parser/node_modules/core-util-is\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/scratch-parser/node_modules/core-util-is\"",
       "tar -xzf \"flatpak-node/npm/core-util-is-65006f8b50dca49e060ea6a78ee719d878f7c043b9a590d2f3d0566e472bbddc64b09a2bc140c365a997f65745929f5ac369660432e090e6c40380d6349f4561\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/scratch-parser/node_modules/core-util-is\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/electron-to-chromium\"",
+      "tar -xzf \"flatpak-node/npm/electron-to-chromium-2f1711be760ee5ecf66cc385a5bbae56e008e5035e6359dc572b44fca5da2fa64d7f35f5c8f9403b49d23b2207c767d502e529acca8fb3f4dd561505672ed221\" -C \"node_modules/scratch-gui/node_modules/electron-to-chromium\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/end-of-stream\"",
+      "tar -xzf \"flatpak-node/npm/end-of-stream-faec358a720754f428695b87cd1c97776d6270cf9c9ede02cc3e6b5be342d708ce5124ceb3e4deec53afec084deef4bdc7fa08ca12cfe4f4751fea614001eee5\" -C \"node_modules/scratch-gui/node_modules/end-of-stream\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/end-of-stream\"",
+      "tar -xzf \"flatpak-node/npm/end-of-stream-faec358a720754f428695b87cd1c97776d6270cf9c9ede02cc3e6b5be342d708ce5124ceb3e4deec53afec084deef4bdc7fa08ca12cfe4f4751fea614001eee5\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/end-of-stream\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/escodegen/node_modules/type-check\"",
       "tar -xzf \"flatpak-node/npm/type-check-64298e25dbce583058265cc0a05902f90d3e6d4c84392d65b60a75306534ddfa871be75b8bdb41154d9177d40a883645018ae13e1d8951feeb65122e1d12ad3a\" -C \"node_modules/scratch-gui/node_modules/escodegen/node_modules/type-check\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/type-check\"",
       "tar -xzf \"flatpak-node/npm/type-check-64298e25dbce583058265cc0a05902f90d3e6d4c84392d65b60a75306534ddfa871be75b8bdb41154d9177d40a883645018ae13e1d8951feeb65122e1d12ad3a\" -C \"node_modules/type-check\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/globals\"",
+      "tar -xzf \"flatpak-node/npm/globals-58e069fc410652222c252a7bc1cbffcba30efa557d5289dc5aac6e15f9bc781c3358d8327c177a1b3f8878a43d8c29b28681fdf60d793374fe41a5471638b354\" -C \"node_modules/scratch-gui/node_modules/globals\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/globby/node_modules/slash\"",
       "tar -xzf \"flatpak-node/npm/slash-83d43585a79bcb7e8e492b706f89ed08618668ab1a5528d0ebc7c1c6841cbad9797d2d6fb98d7c1f7c12b778c5c85b6b931f8acf45751bce40e0cc80743322d9\" -C \"node_modules/scratch-gui/node_modules/globby/node_modules/slash\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/slash\"",
       "tar -xzf \"flatpak-node/npm/slash-83d43585a79bcb7e8e492b706f89ed08618668ab1a5528d0ebc7c1c6841cbad9797d2d6fb98d7c1f7c12b778c5c85b6b931f8acf45751bce40e0cc80743322d9\" -C \"node_modules/slash\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/mime-db\"",
-      "tar -xzf \"flatpak-node/npm/mime-db-694e4426e20dd960de982700a76bc505fa7f9b810085626750d492c348b1b3bfe45db77a3e0eb8126c0990d745841f1a5add6c1f60935eb2f1a3f880195de83d\" -C \"node_modules/scratch-gui/node_modules/mime-db\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/mkdirp\"",
       "tar -xzf \"flatpak-node/npm/mkdirp-eae08fe10734b16b2030bcb510eaaa4bfdeb8c31ce127b12b55affe2fb4020ad98e62da403b94515e8d8ae923288df70d2961fe1c91e0984fd7f5af53fd297e6\" -C \"node_modules/scratch-gui/node_modules/mkdirp\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/nan\"",
+      "tar -xzf \"flatpak-node/npm/nan-0c03608711644b5a650dd46c5f45fda66d19e9224d37a80176d5df6a7c2867c868a02e60a2c1854811916075153f3d5ab0a03f90c46a0d1747ae5b99eb54a905\" -C \"node_modules/scratch-gui/node_modules/nan\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/pbkdf2\"",
+      "tar -xzf \"flatpak-node/npm/pbkdf2-8ae87b2fa8c0ec9106bb65b10f0b503f575d3a9689342e0a9431057dd41a8d21a018f362e0ec8373647b4276d8d9b47d4230551b082f4dd34966813b45ac5430\" -C \"node_modules/scratch-gui/node_modules/pbkdf2\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/pbkdf2\"",
+      "tar -xzf \"flatpak-node/npm/pbkdf2-8ae87b2fa8c0ec9106bb65b10f0b503f575d3a9689342e0a9431057dd41a8d21a018f362e0ec8373647b4276d8d9b47d4230551b082f4dd34966813b45ac5430\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/pbkdf2\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/postcss-import\"",
       "tar -xzf \"flatpak-node/npm/postcss-import-dc6b62df77660a3c8a0608a6a86c4bdef715f30f7e6ec1f03b952b05ac29efdebe8dd6ab75b70597844fe70ffbe81c0d2fb686ce92acb487c5f48fa4744f294f\" -C \"node_modules/scratch-gui/node_modules/postcss-import\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/postcss-import\"",
@@ -14314,6 +15110,8 @@
       "tar -xzf \"flatpak-node/npm/postcss-simple-vars-c5622e7f106820d26fe8988b6fb8e5e68125829fbaa6e270bd3e73647962512c9da0bcf80c00d10773430ec6207ca570a239f84c32e2b1ea02eb932e4bca061a\" -C \"node_modules/scratch-gui/node_modules/postcss-simple-vars\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/postcss-simple-vars\"",
       "tar -xzf \"flatpak-node/npm/postcss-simple-vars-c5622e7f106820d26fe8988b6fb8e5e68125829fbaa6e270bd3e73647962512c9da0bcf80c00d10773430ec6207ca570a239f84c32e2b1ea02eb932e4bca061a\" -C \"node_modules/scratch-gui/node_modules/postcss-simple-vars\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/pump\"",
+      "tar -xzf \"flatpak-node/npm/pump-b543d7b7394633c144dcfd192fa0d5b3fdcfe7c93d9e4f3f8d97900aead327295003ca856331c57e104992eab21341627ceb10d2e2967a4899e60f30b6bdbc73\" -C \"node_modules/scratch-gui/node_modules/pump\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-paint/node_modules/@turbowarp/paper\"",
       "tar -xzf \"flatpak-node/npm/paper-071a0a7e0863a1b11e413f694e18b953544430196e263781990b2f2b14827037d2eaf08317dc9effc7d89acade71e65c3717626be84a6193ebdb5b3dd78946d7\" -C \"node_modules/scratch-gui/node_modules/scratch-paint/node_modules/@turbowarp/paper\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-paint/node_modules/classnames\"",
@@ -14418,12 +15216,6 @@
       "tar -xzf \"flatpak-node/npm/webpack-b5dedf63080b4ab932ddf23512e539727794e3ea5b1fa1a039fb8a352d6d34f71f7468a71842c0aac6ff04fe279ef6722921b68bfc45194efe9f63ef640f0725\" -C \"node_modules/scratch-gui/node_modules/webpack\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/webpack\"",
       "tar -xzf \"flatpak-node/npm/webpack-b5dedf63080b4ab932ddf23512e539727794e3ea5b1fa1a039fb8a352d6d34f71f7468a71842c0aac6ff04fe279ef6722921b68bfc45194efe9f63ef640f0725\" -C \"node_modules/webpack\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-render/node_modules/word-wrap\"",
-      "tar -xzf \"flatpak-node/npm/word-wrap-04ddb607979a30c23d50cb63ac677983978260fa423c3532d052576d8b1a4f9cd8c6314e7244b9dd2403137a56915a16a475d56f706b61c10de13c1ae7907970\" -C \"node_modules/scratch-gui/node_modules/scratch-render/node_modules/word-wrap\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/word-wrap\"",
-      "tar -xzf \"flatpak-node/npm/word-wrap-04ddb607979a30c23d50cb63ac677983978260fa423c3532d052576d8b1a4f9cd8c6314e7244b9dd2403137a56915a16a475d56f706b61c10de13c1ae7907970\" -C \"node_modules/scratch-gui/node_modules/word-wrap\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/word-wrap\"",
-      "tar -xzf \"flatpak-node/npm/word-wrap-04ddb607979a30c23d50cb63ac677983978260fa423c3532d052576d8b1a4f9cd8c6314e7244b9dd2403137a56915a16a475d56f706b61c10de13c1ae7907970\" -C \"node_modules/word-wrap\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-sb1-converter\"",
       "tar -xzf \"flatpak-node/npm/scratch-sb1-converter-305d4dce644b6e00a2abbc22493ba4d82f6b402f2e3395a3ed2698b27d5210c58d2bdaed2b4b9cdcb4a6f059c4b75e104bfd48731d9880cb143ca4741da3c375\" -C \"node_modules/scratch-gui/node_modules/scratch-sb1-converter\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/scratch-sb1-converter\"",
@@ -14462,6 +15254,8 @@
       "tar -xzf \"flatpak-node/npm/binary-extensions-8c372d27f21541b6682729287876e15e93a5341a8635cc1724a268838d84e470cf53041349d8c21dd8a18e3d0396785e43b6e56d3e9d1ce69f340892f28a1028\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/binary-extensions\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/bluebird\"",
       "tar -xzf \"flatpak-node/npm/bluebird-5e9363e860d0cdd7d6fabd969e7ef189201ded33378f39311970464ed58ab925efd71515f9acf1026f2375664dd3a413424fb63765c1f6344392f6e6426711b6\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/bluebird\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/brace-expansion\"",
+      "tar -xzf \"flatpak-node/npm/brace-expansion-882b8f1c3160ac75fb1f6bc423fe71a73d3bcd21c1d344e9ba0aa1998b5598c3bae75f260ae44ca0e60595d101974835f3bb9fa3375a1e058a71815beb5a8688\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/brace-expansion\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/browserify-rsa\"",
       "tar -xzf \"flatpak-node/npm/browserify-rsa-01d1044741e4b29827a36691f7b4807fabe2d32d24f0db8ea469d51f73bdf6b700e50eac87c43172782d1ee27ab97c277c05cd3381a7d466fbfcc575f9899ba2\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/browserify-rsa\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/browserify-sign\"",
@@ -14606,8 +15400,6 @@
       "tar -xzf \"flatpak-node/npm/sha.js-40c129e41edc7ed13b00f3a393963ac60adb5aef9690b550c24f0936367c9ca45c899681c845ba32e6e2780893a12efe770beb8c6847f23457cf7315774018a9\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/sha.js\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/sha.js\"",
       "tar -xzf \"flatpak-node/npm/sha.js-40c129e41edc7ed13b00f3a393963ac60adb5aef9690b550c24f0936367c9ca45c899681c845ba32e6e2780893a12efe770beb8c6847f23457cf7315774018a9\" -C \"node_modules/scratch-gui/node_modules/sha.js\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/sha.js\"",
-      "tar -xzf \"flatpak-node/npm/sha.js-40c129e41edc7ed13b00f3a393963ac60adb5aef9690b550c24f0936367c9ca45c899681c845ba32e6e2780893a12efe770beb8c6847f23457cf7315774018a9\" -C \"node_modules/sha.js\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/snapdragon\"",
       "tar -xzf \"flatpak-node/npm/snapdragon-16dc8e9d637fc021d355738cc2f4afdba77e928e6f5a52030face8509ecb5bcbe1f99042f107658ef7913fe72b36bb41c22a04516cbfe1d32d6c18c0e22a0d96\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/snapdragon\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/snapdragon\"",
@@ -14814,12 +15606,6 @@
       "tar -xzf \"flatpak-node/npm/upath-699c06a5a9853bad60dce95f4fb390087aa11a75b8de2787f5665e3fb43137f1bf8d2e237ea524671a2bcaf26054f11cae5e4d2ff8201ec4a62cc1ee1fae0b86\" -C \"node_modules/scratch-gui/node_modules/upath\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/upath\"",
       "tar -xzf \"flatpak-node/npm/upath-699c06a5a9853bad60dce95f4fb390087aa11a75b8de2787f5665e3fb43137f1bf8d2e237ea524671a2bcaf26054f11cae5e4d2ff8201ec4a62cc1ee1fae0b86\" -C \"node_modules/upath\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/uri-js\"",
-      "tar -xzf \"flatpak-node/npm/uri-js-eeb294cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/uri-js\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/uri-js\"",
-      "tar -xzf \"flatpak-node/npm/uri-js-eeb294cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06\" -C \"node_modules/scratch-gui/node_modules/uri-js\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/uri-js\"",
-      "tar -xzf \"flatpak-node/npm/uri-js-eeb294cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06\" -C \"node_modules/uri-js\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/urix\"",
       "tar -xzf \"flatpak-node/npm/urix-026d68bac02148b05e07d706ffb93baf6474ce3e74b834656473c66dace2779b3dae517517f40a60e6c429222e9d28c83a4259ab04512e9bdec2312433ba52aa\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/urix\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/urix\"",
@@ -14950,12 +15736,6 @@
       "tar -xzf \"flatpak-node/npm/schema-utils-bff8b053ac2fc062bc1db53dca2dff9e11b33f4c864ae8503332fac9289e735152ad96439219b89e83925b3acd168fe311cf92258ea3453c2ec1b49724f0d49d\" -C \"node_modules/scratch-vm/node_modules/schema-utils\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/worker-loader/node_modules/schema-utils\"",
       "tar -xzf \"flatpak-node/npm/schema-utils-bff8b053ac2fc062bc1db53dca2dff9e11b33f4c864ae8503332fac9289e735152ad96439219b89e83925b3acd168fe311cf92258ea3453c2ec1b49724f0d49d\" -C \"node_modules/worker-loader/node_modules/schema-utils\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/wrappy\"",
-      "tar -xzf \"flatpak-node/npm/wrappy-9784a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/wrappy\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/wrappy\"",
-      "tar -xzf \"flatpak-node/npm/wrappy-9784a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71\" -C \"node_modules/scratch-gui/node_modules/wrappy\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/wrappy\"",
-      "tar -xzf \"flatpak-node/npm/wrappy-9784a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71\" -C \"node_modules/wrappy\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/xtend\"",
       "tar -xzf \"flatpak-node/npm/xtend-2ca614d620172575200179fd5118e2bbe3168725171ecbdfa7b99cb989bd75250a2b4fc28edad4c050310fcdbf98259bb4bb068c521a774c08b28778ceb4c011\" -C \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/xtend\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/xtend\"",
@@ -15032,8 +15812,6 @@
       "tar -xzf \"flatpak-node/npm/spdx-expression-parse-71ba87ba7b105a724d13a2a155232c31e1f91ff2fd129ca66f3a93437b8bc0d08b675438f35a166a87ea1fb9cee95d3bc655f063a3e141d43621e756c7f64ae1\" -C \"node_modules/spdx-expression-parse\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/spdx-license-ids\"",
       "tar -xzf \"flatpak-node/npm/spdx-license-ids-06f83ff05e577a98677522b725f7da46a753fa0ca17ea20fc031e95fcd2d26b17c410458328f2c34c79a6760e9e7e8e1c0a9d49883b214541f1d1923266e675e\" -C \"node_modules/scratch-gui/node_modules/spdx-license-ids\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/spdx-license-ids\"",
-      "tar -xzf \"flatpak-node/npm/spdx-license-ids-06f83ff05e577a98677522b725f7da46a753fa0ca17ea20fc031e95fcd2d26b17c410458328f2c34c79a6760e9e7e8e1c0a9d49883b214541f1d1923266e675e\" -C \"node_modules/spdx-license-ids\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/sshpk\"",
       "tar -xzf \"flatpak-node/npm/sshpk-da9d8a2594d2a90fc8dfe1d7e3612960e6b69777fc12bbfc3162accb623db9fe3003bc852245d17df61db31f3acbacf8bc7b55f2eee0fa93e5afcff8a2e031b1\" -C \"node_modules/scratch-gui/node_modules/sshpk\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/sshpk\"",
@@ -15104,8 +15882,6 @@
       "tar -xzf \"flatpak-node/npm/terser-webpack-plugin-8d3817878d119ef3ab2d0360224c042a743cae61e31cae2efba501122f96f853e6bdbfaea3e7212579ed29eeffde55b998dcac812583eb42b27ac9e15bc0fa31\" -C \"node_modules/terser-webpack-plugin\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/terser-webpack-plugin/node_modules/terser\"",
       "tar -xzf \"flatpak-node/npm/terser-5180af53d6105b67ff57097e3f419f8712716d418bc1dfb942bac680b6a3cd602d0bfdb7017d2f722b1edf69243fb12ed16bbd565cf31c05e42ce6e08d07c595\" -C \"node_modules/scratch-gui/node_modules/terser-webpack-plugin/node_modules/terser\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/terser\"",
-      "tar -xzf \"flatpak-node/npm/terser-5180af53d6105b67ff57097e3f419f8712716d418bc1dfb942bac680b6a3cd602d0bfdb7017d2f722b1edf69243fb12ed16bbd565cf31c05e42ce6e08d07c595\" -C \"node_modules/terser\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/through\"",
       "tar -xzf \"flatpak-node/npm/through-c3cf6a83b3c8f3001dbd7eb46cc0cff9b1680f90ef866f682e1785a793b86b6405d1c4811ac057e2a66669d3ccbd5aa52c9041722f96a8618e00fbdc0de35256\" -C \"node_modules/scratch-gui/node_modules/through\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/through\"",
@@ -15120,8 +15896,6 @@
       "tar -xzf \"flatpak-node/npm/tiny-inflate-a646357e3d5c2876f6b1e583cb4075e87796c9cce5240f7f596deeddce33fcd8960ec3b70ce5390fb9e14cb13d085d325effd064563bb042668f6e1d2be46bab\" -C \"node_modules/tiny-inflate\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/to-buffer\"",
       "tar -xzf \"flatpak-node/npm/to-buffer-971f41e62bfb9acb85604dddcad4fe284e6d6a9fab358c3e2b88d591bf51fdab006fea5b052335ee3b6e9c7a658417ba45125d671dcf9f6269876e0edf698e56\" -C \"node_modules/scratch-gui/node_modules/to-buffer\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/to-buffer\"",
-      "tar -xzf \"flatpak-node/npm/to-buffer-971f41e62bfb9acb85604dddcad4fe284e6d6a9fab358c3e2b88d591bf51fdab006fea5b052335ee3b6e9c7a658417ba45125d671dcf9f6269876e0edf698e56\" -C \"node_modules/to-buffer\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/to-style\"",
       "tar -xzf \"flatpak-node/npm/to-style-f4af0a61e82bf61add9bcc8fa6ee62663269e6de913c0a788050d4e610fdcd1f21c2a805e1fb284a2b4cb6444a406daa90fe63fee1b7c1a8db815d3dae3988aa\" -C \"node_modules/scratch-gui/node_modules/to-style\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/to-style\"",
@@ -15184,8 +15958,6 @@
       "tar -xzf \"flatpak-node/npm/url-to-options-d2440b2331b87dd93f1b934e364bbae2b487ff1df634e037f4b550aa52bc2deea5bd317a186449a6a690146814f822f0c9222a05231dc18334b18716f5fe8fe0\" -C \"node_modules/scratch-gui/node_modules/url-to-options\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/url-to-options\"",
       "tar -xzf \"flatpak-node/npm/url-to-options-d2440b2331b87dd93f1b934e364bbae2b487ff1df634e037f4b550aa52bc2deea5bd317a186449a6a690146814f822f0c9222a05231dc18334b18716f5fe8fe0\" -C \"node_modules/url-to-options\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/url/node_modules/qs\"",
-      "tar -xzf \"flatpak-node/npm/qs-6165938e000148a72fb3f9d6062f4fc9c63f2623c9a8e0f8240ea8f527a3d80b6f4866ab5f1282dce412938a406ab6dd4252808790f814242424d916f86027df\" -C \"node_modules/scratch-gui/node_modules/url/node_modules/qs\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/scratch-gui/node_modules/validate-npm-package-license\"",
       "tar -xzf \"flatpak-node/npm/validate-npm-package-license-0e92a6d948bfc4deff1d0282b69671a11581859f59d24aadca01bc5c280d43c6650e7c6e4265a18f9eba8fc7cde02bb7fc999b86c0e8edf70026ae2cf61dbb13\" -C \"node_modules/scratch-gui/node_modules/validate-npm-package-license\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/validate-npm-package-license\"",
@@ -15222,20 +15994,16 @@
       "tar -xzf \"flatpak-node/npm/yauzl-a786bd23a5fa9eee888681a606a01c6c9cb59a50b88f6eef10f657f45e0be3fbd94f72f2ab5564147c3f57f3d4701f41ba8f831b7887913d31dd0c9ae7ccdcde\" -C \"node_modules/scratch-gui/node_modules/yauzl\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/yauzl\"",
       "tar -xzf \"flatpak-node/npm/yauzl-a786bd23a5fa9eee888681a606a01c6c9cb59a50b88f6eef10f657f45e0be3fbd94f72f2ab5564147c3f57f3d4701f41ba8f831b7887913d31dd0c9ae7ccdcde\" -C \"node_modules/yauzl\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/scratch-gui/node_modules/yocto-queue\"",
-      "tar -xzf \"flatpak-node/npm/yocto-queue-ad592cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9\" -C \"node_modules/scratch-gui/node_modules/yocto-queue\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/yocto-queue\"",
-      "tar -xzf \"flatpak-node/npm/yocto-queue-ad592cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9\" -C \"node_modules/yocto-queue\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/semver\"",
+      "tar -xzf \"flatpak-node/npm/semver-49db0a32b23d4dd823770794491f4cc1e1c0e0427c6311e7f0315a0e2b2f85595439ee01175b4b0fb1808f4948a96565f9d3dbfeb131af406d6f2e65a109b6d1\" -C \"node_modules/semver\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/semver-compare\"",
       "tar -xzf \"flatpak-node/npm/semver-compare-60cdff213876309e4cb7368ce36f5a9e1fb1da388b563a882c5e26e28c90075f16ec681e6bb05fa9d1ffc0630aedd0e232086fffa586ef39d6330503cc9897a3\" -C \"node_modules/semver-compare\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/serialize-error\"",
       "tar -xzf \"flatpak-node/npm/serialize-error-f08f138d6e4a30e2ac6504efa318ee4886bb7e80303d618eb6cfbaa3bb208f3e35fea303f55407103c62e8f06f2b6974317526a99c8da542be4f6b5069a125bf\" -C \"node_modules/serialize-error\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/sha.js\"",
+      "tar -xzf \"flatpak-node/npm/sha.js-f0bcc2e7e6ef238e418e97d753c5797dd53699f78a8907b50f5808327ed752517739352ba5d2693cf1f810c0271740ec1c775266a09d4acb39a829892ae88edf\" -C \"node_modules/sha.js\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/shallow-clone\"",
       "tar -xzf \"flatpak-node/npm/shallow-clone-ffa2aa5fe19551da8fb8f3ddd8bc430f1cd7e8201b8c97a100038a94da6aa94a40a8f33a1de2fc7fea376be26cc868e7da5bf4598f14b1381426353d3a4e7934\" -C \"node_modules/shallow-clone\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/shebang-command\"",
-      "tar -xzf \"flatpak-node/npm/shebang-command-907c6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c\" -C \"node_modules/shebang-command\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/shebang-regex\"",
-      "tar -xzf \"flatpak-node/npm/shebang-regex-efef9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4\" -C \"node_modules/shebang-regex\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/signal-exit\"",
       "tar -xzf \"flatpak-node/npm/signal-exit-c270f6644fa5f923c2feea12d2f5de13d2f5fb4c2e68ca8a95fcfd00c528dfc26cc8b48159215c1d1d51ae2eb62d9735daf2ebd606f78e5ee2c10860c2901b19\" -C \"node_modules/signal-exit\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/simple-update-notifier\"",
@@ -15245,11 +16013,13 @@
       "mkdir -p \"node_modules/smart-buffer\"",
       "tar -xzf \"flatpak-node/npm/smart-buffer-f7884ad0787cacfa90976c577371ec681a0e5ca576d0c4e83e4717bf06c84962c4b3eeb8b01ab9905827da42431dbd4faf2f72acfd1dc6b088f5145c8bb4572a\" -C \"node_modules/smart-buffer\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/socks\"",
-      "tar -xzf \"flatpak-node/npm/socks-885fad3434256b6da0789753c89075c0cfeaad7f43311c16adc8843f058b3d158050433cb108b2c607242f1593d5fefef5569b252d234c61abe10801baf8ba5b\" -C \"node_modules/socks\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/socks-1cba6dfae2f2fe9c41f9bba6ffd0f302088a4bc097d44bdb5b1238ce59a01821312262dd89a776882c174f967873d73712af2b3f6df5f263d6d9cf906ed8caf0\" -C \"node_modules/socks\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/socks-proxy-agent\"",
-      "tar -xzf \"flatpak-node/npm/socks-proxy-agent-16097460f67dd36c04b00ca243e89d19dd40eeb485c7f6b20b509054cc393fe110c765744a0a46b5fe8e2858558cf7e53d497d60c9843a799f8c274c52cca0c3\" -C \"node_modules/socks-proxy-agent\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/socks-proxy-agent-1de84212ca2d16a6cf5bdb09f1655807a51b98832fee4514391205d8d9dcab8550bc17cd04b89b5bd619479765602494870703eb6f29465966ee7f84f984f327\" -C \"node_modules/socks-proxy-agent\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/source-map-js\"",
       "tar -xzf \"flatpak-node/npm/source-map-js-51758c2a12cec1529bef6f0852d40f5f17d853ebac7726ed52b2bff2e184f0240cbeb84ea70bf30c1c23d108522fb31073bbc8b084811bc550f3e203431a5f40\" -C \"node_modules/source-map-js\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/spdx-license-ids\"",
+      "tar -xzf \"flatpak-node/npm/spdx-license-ids-e0f453e2787510898f6edda301238a1d7ecf07b23e7b821634bbe42850f13612657e36d8965798421dbce59ff798f4c74802bf02f74c9b0e4134db981fc4a181\" -C \"node_modules/spdx-license-ids\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/sprintf-js\"",
       "tar -xzf \"flatpak-node/npm/sprintf-js-3a8fb4444155e7dfebcf781f24d2908819707c7692112975a5c1b200142c9e721f58e16de89363e600a883653a30b67ffc81980fe9c0f2723e9934a144445e68\" -C \"node_modules/sprintf-js\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/stat-mode\"",
@@ -15270,18 +16040,28 @@
       "tar -xzf \"flatpak-node/npm/temp-file-0b9b63942fc70ad5543a2dca595a24778bc755588e9868ed2f0221e0cbb33e8fe73184d5fe9d6eaeddd19cccf62165c374a106247de4e7e28fc6da91b14606b6\" -C \"node_modules/temp-file\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/temp/node_modules/rimraf\"",
       "tar -xzf \"flatpak-node/npm/rimraf-9b0a9e5b95ec036a807a31b8ea061d10d6b15e3c7da2744d09f9fb2f476eb8fe210ae4c88bf40eecf0cad3b2897e9d5dfa2cd63ebcc4243712a816b439942b88\" -C \"node_modules/temp/node_modules/rimraf\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/terser\"",
+      "tar -xzf \"flatpak-node/npm/terser-fba7ab2db066d3e2d1397dac3d7954631feec793f213d2bf6bdd96aedea803e5830281537691c4e6d098088e4f373ab6cbc75fe2b03e4201cb26e4788cdca6b2\" -C \"node_modules/terser\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/tiny-async-pool\"",
       "tar -xzf \"flatpak-node/npm/tiny-async-pool-d35100c39103adc56b760c822e0a123efab39c2d2c5710d255e88ecf4f455298e1ef51bbf550aa9de3abfb1beded3d6befa085e9965f3e31e8acddbe77ede6a8\" -C \"node_modules/tiny-async-pool\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/tinyglobby\"",
+      "tar -xzf \"flatpak-node/npm/tinyglobby-8f666ae0dc90606e573124f871bb34d8093c88951dc513345c8e50cb15ee64ecca3883665aeae9dec997bb7cb9c03709ae9b70a528e05c7cc8431474a265e58d\" -C \"node_modules/tinyglobby\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/tinyglobby/node_modules/fdir\"",
+      "tar -xzf \"flatpak-node/npm/fdir-b486d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e\" -C \"node_modules/tinyglobby/node_modules/fdir\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/tinyglobby/node_modules/picomatch\"",
+      "tar -xzf \"flatpak-node/npm/picomatch-e604e680463fb2a2ba8055cb22c40d1f5f6559be1e6cf0cb03849d2cfeddb169085c75a51baea83ee56f5d21853e9a58673f190d9ab475862b6c77c109551bd5\" -C \"node_modules/tinyglobby/node_modules/picomatch\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/tmp\"",
-      "tar -xzf \"flatpak-node/npm/tmp-9d90fb9bd8823c2e60d2962671ac688182a08127cbb1dc65f287f743fa086ea0aa2cb20ef48005d065a35f5cfd3594473e25eff167b1e320c2699b20130d18f3\" -C \"node_modules/tmp\" --warning=no-unknown-keyword --strip-components=1",
+      "tar -xzf \"flatpak-node/npm/tmp-be8cb3e8c0296b5ad0194c53dc4f812bbfd139ef22b44c7bbc3f3f1c4bede31c17b9cbd0e46e687848879261d926e04edb546939ff98626f4c3a2be3ef4f63a3\" -C \"node_modules/tmp\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/tmp-promise\"",
       "tar -xzf \"flatpak-node/npm/tmp-promise-47033b3283e88cfc6c381627c9dda1cb46f1b48955ae284db3da63e5252f63c673d6c41c406dad1b5852afc3c3c5f80407c44d28386a6c896ba086ab48d0cdb1\" -C \"node_modules/tmp-promise\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/to-buffer\"",
+      "tar -xzf \"flatpak-node/npm/to-buffer-b41f362e90085a384b61baa3c775f8cc478737a33c0a2b8e132d8963c48441575845edc20873856aaac15b57682c3adfa5686995c5bb04bf9b3b7ffa4b7a5c0d\" -C \"node_modules/to-buffer\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/truncate-utf8-bytes\"",
       "tar -xzf \"flatpak-node/npm/truncate-utf8-bytes-f793eed505d0bebb86121bfad9708c3b7326f741ac70e08296fac853008cd0f60e5cade4685de5dec207c71ef54e125f71b3363b902ee923b701609211f5b899\" -C \"node_modules/truncate-utf8-bytes\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/type-fest\"",
       "tar -xzf \"flatpak-node/npm/type-fest-df847b1d39c6d172097014a7e5784377b9cd14f45c5d8459ac10763b68dd2aa60e0e5752cc102acec5a865862f76e932ef7b68612fc44aac4fbe40dffc5d1732\" -C \"node_modules/type-fest\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/typescript\"",
-      "tar -xzf \"flatpak-node/npm/typescript-a757625ba4ea2fd2f4ee7371bd130cee130cc387395cea3fd626cbe1a0081a6480b7db254c4d57830e4a5aea1fdae4cebc283d058ed9462f86685fbbb1f80f79\" -C \"node_modules/typescript\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/typed-array-buffer\"",
+      "tar -xzf \"flatpak-node/npm/typed-array-buffer-9c0618c1f637aa7cd7df422403a01066355bb4ae9db86a27b5c426d56486d4c0fde182ea2b4e75e46340a57928c4a39632eb15b2c00758b87d49e6a879f6051b\" -C \"node_modules/typed-array-buffer\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/undici-types\"",
       "tar -xzf \"flatpak-node/npm/undici-types-8b00d9aa0d10006ae0f516afe47e27d0ceb87379a4479f5c27ac10a7eec2e2723482c984c5a79d6982cd3b8e1e4f802d041c236d38863cc96dd8c7744fd1fd25\" -C \"node_modules/undici-types\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/unicode-canonical-property-names-ecmascript\"",
@@ -15308,8 +16088,8 @@
       "tar -xzf \"flatpak-node/npm/commander-42b59707e6504953e6216221b443bd1fe8301da3066221790a1be827e2bd6461c6fec56c6baca27ac003d460bfc78eac113d345e5c28d6ee3d455555cef71293\" -C \"node_modules/webpack-cli/node_modules/commander\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/webpack-merge\"",
       "tar -xzf \"flatpak-node/npm/webpack-merge-fb8cd729dc7b5273bed6368de25da51d50fe985be795940fffa96368955be12662c0829e527ad3e65d20913f33fa7e212a90be8e93afe8ef51fa02ed6a0ee948\" -C \"node_modules/webpack-merge\" --warning=no-unknown-keyword --strip-components=1",
-      "mkdir -p \"node_modules/which\"",
-      "tar -xzf \"flatpak-node/npm/which-04b2374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c\" -C \"node_modules/which\" --warning=no-unknown-keyword --strip-components=1",
+      "mkdir -p \"node_modules/which-typed-array\"",
+      "tar -xzf \"flatpak-node/npm/which-typed-array-ac4bebf7405c938599b7d1c7142e0324cb23beeef1fabe9b226cf4fc1adb59bec0d9d8c9f219d932b5a71e8f45f2cb2fd0e304adab0385fb6b7d1393caa483af\" -C \"node_modules/which-typed-array\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/wildcard\"",
       "tar -xzf \"flatpak-node/npm/wildcard-082d5b38bf3b3c85920610dc4eb75e2e8e9e193ee6085b6b834b8826da89505c8af9e267ce5f00d67887e7abaeeca31ae5716bb6257e010b873b79fb0ec1e72d\" -C \"node_modules/wildcard\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/wrap-ansi\"",
@@ -15327,19 +16107,19 @@
       "mkdir -p \"node_modules/yargs-parser\"",
       "tar -xzf \"flatpak-node/npm/yargs-parser-b55a6c256ec376379c0221696c80757b7ab1210b04e8da0f739fde4ddadb6c80b88742d5b16867a1ade0fa6d87725048ba31f3b31678549540f8652e736fcb07\" -C \"node_modules/yargs-parser\" --warning=no-unknown-keyword --strip-components=1",
       "mkdir -p \"node_modules/@turbowarp/extensions/node_modules/@turbowarp/types\"",
-      "cp -a \"flatpak-node/git/types-tw-0cf07a4b9b5fe05bc1766db216d726c5bf373ec7\"/* \"node_modules/@turbowarp/extensions/node_modules/@turbowarp/types\"",
+      "cp -a \"flatpak-node/git/types-tw-dfefbd12587ac30be1963d414648e44b14e223d4\"/* \"node_modules/@turbowarp/extensions/node_modules/@turbowarp/types\"",
+      "mkdir -p \"node_modules/@turbowarp/extensions\"",
+      "cp -a \"flatpak-node/git/extensions-847e6d0f0f0ecb9721878c7e2c3e94cd039ab809\"/* \"node_modules/@turbowarp/extensions\"",
       "mkdir -p \"node_modules/@turbowarp/types\"",
       "cp -a \"flatpak-node/git/types-tw-0cf07a4b9b5fe05bc1766db216d726c5bf373ec7\"/* \"node_modules/@turbowarp/types\"",
-      "mkdir -p \"node_modules/@turbowarp/extensions\"",
-      "cp -a \"flatpak-node/git/extensions-b7b3a4881b546b482400c33443e188a945dfa9e5\"/* \"node_modules/@turbowarp/extensions\"",
       "mkdir -p \"node_modules/scratch-audio\"",
       "cp -a \"flatpak-node/git/scratch-audio-aba00cd02e36d95407effafa03f3678e4c669b30\"/* \"node_modules/scratch-audio\"",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-audio\"",
       "cp -a \"flatpak-node/git/scratch-audio-aba00cd02e36d95407effafa03f3678e4c669b30\"/* \"node_modules/scratch-gui/node_modules/scratch-audio\"",
       "mkdir -p \"node_modules/scratch-blocks\"",
-      "cp -a \"flatpak-node/git/scratch-blocks-67121bfdb8ae5448abdd90de37c2d56921f261a5\"/* \"node_modules/scratch-blocks\"",
+      "cp -a \"flatpak-node/git/scratch-blocks-6a7e7e5561f25dce86d4ffe664703a110f5945e7\"/* \"node_modules/scratch-blocks\"",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-blocks\"",
-      "cp -a \"flatpak-node/git/scratch-blocks-67121bfdb8ae5448abdd90de37c2d56921f261a5\"/* \"node_modules/scratch-gui/node_modules/scratch-blocks\"",
+      "cp -a \"flatpak-node/git/scratch-blocks-6a7e7e5561f25dce86d4ffe664703a110f5945e7\"/* \"node_modules/scratch-gui/node_modules/scratch-blocks\"",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-paint\"",
       "cp -a \"flatpak-node/git/scratch-paint-8093bf77b27ad1128cc9e2862b7b5b39e736e178\"/* \"node_modules/scratch-gui/node_modules/scratch-paint\"",
       "mkdir -p \"node_modules/scratch-paint\"",
@@ -15351,9 +16131,9 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-render/node_modules/scratch-render-fonts\"",
       "cp -a \"flatpak-node/git/scratch-render-fonts-b49a8f5b0455fcf7bba3a064a6578c11eee4e42d\"/* \"node_modules/scratch-gui/node_modules/scratch-render/node_modules/scratch-render-fonts\"",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-render\"",
-      "cp -a \"flatpak-node/git/scratch-render-49f714ec63edfb84a6e450ce2c2daf30e0b53632\"/* \"node_modules/scratch-gui/node_modules/scratch-render\"",
+      "cp -a \"flatpak-node/git/scratch-render-dd5d399eace4b5bae11906e2237fe67ee6b79d84\"/* \"node_modules/scratch-gui/node_modules/scratch-render\"",
       "mkdir -p \"node_modules/scratch-render\"",
-      "cp -a \"flatpak-node/git/scratch-render-49f714ec63edfb84a6e450ce2c2daf30e0b53632\"/* \"node_modules/scratch-render\"",
+      "cp -a \"flatpak-node/git/scratch-render-dd5d399eace4b5bae11906e2237fe67ee6b79d84\"/* \"node_modules/scratch-render\"",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-render-fonts\"",
       "cp -a \"flatpak-node/git/scratch-render-fonts-7b6768fc6dfef6b343a06f992587b74807043961\"/* \"node_modules/scratch-gui/node_modules/scratch-render-fonts\"",
       "mkdir -p \"node_modules/scratch-render-fonts\"",
@@ -15363,11 +16143,11 @@
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/scratch-render-fonts\"",
       "cp -a \"flatpak-node/git/scratch-render-fonts-6be162025085d738317b40a01644cf8dcbcee023\"/* \"node_modules/scratch-gui/node_modules/scratch-vm/node_modules/scratch-render-fonts\"",
       "mkdir -p \"node_modules/scratch-gui/node_modules/scratch-vm\"",
-      "cp -a \"flatpak-node/git/scratch-vm-6222be2a3c1e1fe22add331685a4f5b746eec969\"/* \"node_modules/scratch-gui/node_modules/scratch-vm\"",
+      "cp -a \"flatpak-node/git/scratch-vm-55674f82eef8d901affdb2e6061d5127020be489\"/* \"node_modules/scratch-gui/node_modules/scratch-vm\"",
       "mkdir -p \"node_modules/scratch-vm\"",
-      "cp -a \"flatpak-node/git/scratch-vm-6222be2a3c1e1fe22add331685a4f5b746eec969\"/* \"node_modules/scratch-vm\"",
+      "cp -a \"flatpak-node/git/scratch-vm-55674f82eef8d901affdb2e6061d5127020be489\"/* \"node_modules/scratch-vm\"",
       "mkdir -p \"node_modules/scratch-gui\"",
-      "cp -a \"flatpak-node/git/scratch-gui-063c399a77f99c4bc60e7b633da7a0990170fab1\"/* \"node_modules/scratch-gui\""
+      "cp -a \"flatpak-node/git/scratch-gui-63a507a3ee7f12662408dfb20c7ad393c6ff1dd0\"/* \"node_modules/scratch-gui\""
     ],
     "dest": "flatpak-node",
     "dest-filename": "finish.sh"

--- a/org.turbowarp.TurboWarp.yaml
+++ b/org.turbowarp.TurboWarp.yaml
@@ -43,6 +43,7 @@ modules:
       - library-sources.json
       - packager-sources.json
       - microbit-sources.json
+      - extensions-sources.json
     build-commands:
       # Finish setting up Node.js dependencies.
       - ./flatpak-node/finish.sh

--- a/org.turbowarp.TurboWarp.yaml
+++ b/org.turbowarp.TurboWarp.yaml
@@ -13,7 +13,8 @@ build-options:
 finish-args:
   - --share=ipc
   - --share=network
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --socket=pulseaudio
   # For webcam and microphone access.
   - --device=all

--- a/org.turbowarp.TurboWarp.yaml
+++ b/org.turbowarp.TurboWarp.yaml
@@ -35,7 +35,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/TurboWarp/desktop.git
-        commit: 1a48ca111ae2d90a0bd7539814436603291a3783
+        commit: 5ac50569e4577fbbccd193c4ddb8ceb9aae57308
       - type: file
         dest-filename: turbowarp-desktop.sh
         path: turbowarp-desktop.sh

--- a/org.turbowarp.TurboWarp.yaml
+++ b/org.turbowarp.TurboWarp.yaml
@@ -62,7 +62,7 @@ modules:
         mkdir -pv ../node_modules/scratch-gui/src/generated
         echo "module.exports = require('./../../static/microbit.hex');" | tee ../node_modules/scratch-gui/src/generated/microbit-hex-url.cjs
       # Build extensions
-      - node scripts/prepare-extensions.js
+      - node scripts/prepare-extensions.mjs
       # Build editor
       - NODE_ENV=production node node_modules/webpack/bin/webpack.js
       # Package Electron

--- a/packager-sources.json
+++ b/packager-sources.json
@@ -1,8 +1,8 @@
 [
   {
     "type": "file",
-    "url": "https://github.com/TurboWarp/packager/releases/download/v3.6.0/turbowarp-packager-standalone-3.6.0.html",
-    "sha256": "90dbfd2245e126cc0b3a3968b46c85f184f5ce1460b18da4e7d73ad84932426d",
+    "url": "https://github.com/TurboWarp/packager/releases/download/v3.9.0/turbowarp-packager-standalone-3.9.0.html",
+    "sha256": "49f1ad37426397e44b1947d22c6a8e6700ca92598e36e99aef6363d8ec9b2dae",
     "dest": "src-renderer/packager",
     "dest-filename": "standalone.html"
   }

--- a/turbowarp-desktop.sh
+++ b/turbowarp-desktop.sh
@@ -1,15 +1,5 @@
 #!/bin/bash
 
-# Enable Wayland if it is available
-# From https://github.com/flathub/com.slack.Slack/blob/62e3c2d2236f2e8375c2bdd9c4a89158a004774a/slack.sh
-FLAGS=""
-WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
-if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET}" || -e "${WAYLAND_DISPLAY}" ]]
-then
-    echo "org.turbowarp.TurboWarp: enabling wayland"
-    FLAGS="--ozone-platform-hint=auto"
-fi
-
 # Disable the in-app update checker as updates are managed by flatpak.
 export TW_DISABLE_UPDATE_CHECKER=1
 


### PR DESCRIPTION
Changes that matter to the flatpak aside from just bumping the version and regenerating sources:

- Electron 38 uses Wayland by default, so switched to --socket=wayland --socket=fallback-x11
- Extended source generation script to also support the new extension dependencies
- Extension prep script is now mjs